### PR TITLE
adrv9009 testbench

### DIFF
--- a/adrv9009/Makefile
+++ b/adrv9009/Makefile
@@ -1,0 +1,77 @@
+####################################################################################
+####################################################################################
+## Copyright 2018(c) Analog Devices, Inc.
+####################################################################################
+####################################################################################
+
+# All test-bench dependencies except test programs
+SV_DEPS += ../common/sv/utils.svh
+SV_DEPS += ../common/sv/logger_pkg.sv
+SV_DEPS += ../common/sv/reg_accessor.sv
+SV_DEPS += ../common/sv/m_axis_sequencer.sv
+SV_DEPS += ../common/sv/s_axis_sequencer.sv
+SV_DEPS += ../common/sv/m_axi_sequencer.sv
+SV_DEPS += ../common/sv/s_axi_sequencer.sv
+SV_DEPS += ../common/sv/dmac_api.sv
+SV_DEPS += ../common/sv/adi_regmap_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_dac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_common_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_adc_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_jesd_tx_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_jesd_rx_pkg.sv
+SV_DEPS += ../common/sv/dma_trans.sv
+SV_DEPS += ../common/sv/axi_dmac_pkg.sv
+SV_DEPS += ../common/sv/test_harness_env.sv
+SV_DEPS += system_tb.sv
+
+ENV_DEPS += system_project.tcl
+ENV_DEPS += system_bd.tcl
+ENV_DEPS +=../scripts/adi_sim.tcl
+ENV_DEPS +=../scripts/run_sim.tcl
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_dac
+LIB_DEPS += jesd204/axi_jesd204_tx
+LIB_DEPS += jesd204/jesd204_tx
+LIB_DEPS += jesd204/ad_ip_jesd204_tpl_adc
+LIB_DEPS += jesd204/axi_jesd204_rx
+LIB_DEPS += jesd204/jesd204_rx
+LIB_DEPS += sysid_rom
+LIB_DEPS += util_dacfifo
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+LIB_DEPS += xilinx/axi_adxcvr
+LIB_DEPS += xilinx/util_adxcvr
+
+
+# default test program
+TP := test_program
+
+# config files should have the following format
+#  cfg_<param1>_<param2>.tcl
+CFG_FILES := $(notdir $(wildcard cfgs/cfg*.tcl))
+#$(warning $(CFG_FILES))
+
+# List of tests and configuration combinations that has to be run
+# Format is:  <configuration>:<test name>
+TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(cfg):$(TP))
+#TESTS += cfg1_mm2mm_default:directed_test
+#TESTS += cfg1:test_program
+#TESTS += cfg2_fsync:test_program
+#TESTS += cfg2_fsync:test_frame_delay
+
+include ../scripts/project-sim.mk
+
+# usage :
+#
+# run specific test on a specific configuration in gui mode
+# 	make CFG=cfg2_fsync TST=test_frame_delay MODE=gui
+#
+# run all test from a configuration
+# 	make cfg1_mm2mm_default
+
+####################################################################################
+####################################################################################

--- a/adrv9009/README.md
+++ b/adrv9009/README.md
@@ -1,0 +1,27 @@
+Usage :
+
+Run all tests in batch mode:
+
+	make
+
+
+Run all tests in GUI mode:
+
+	make MODE=gui
+
+
+Run specific test on a specific configuration in gui mode:
+
+	make CFG=<name of cfg> TST=<name of test> MODE=gui
+
+
+Run all test from a configuration:
+
+	make <name of cfg>
+
+
+Where:
+
+ * <name of cfg> is a file from the cfgs directory without the tcl extension of format cfg\*
+ * <name of test> is a file from the tests directory without the tcl extension
+

--- a/adrv9009/cfgs/cfg1.tcl
+++ b/adrv9009/cfgs/cfg1.tcl
@@ -3,6 +3,7 @@ global ad_project_params
 set ad_project_params(JESD_MODE) 8B10B
 
 set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
 
 set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
 

--- a/adrv9009/cfgs/cfg1.tcl
+++ b/adrv9009/cfgs/cfg1.tcl
@@ -1,32 +1,29 @@
 global ad_project_params
 
-set ad_project_params(JESD_MODE) 8B10B
+set ad_project_params(LINK_MODE) 1
 
 set ad_project_params(REF_CLK_RATE) 500
 set ad_project_params(LANE_RATE) 10
 
 set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
 
-# set ad_project_params(RX_LANE_RATE) 10
-# set ad_project_params(TX_LANE_RATE) 10
-
-set ad_project_params(TX_JESD_M) 4
-set ad_project_params(TX_JESD_L) 4
+set ad_project_params(TX_JESD_M) 1
+set ad_project_params(TX_JESD_L) 1
 set ad_project_params(TX_JESD_S) 1
 set ad_project_params(TX_JESD_NP) 16
 set ad_project_params(TX_JESD_F) 2
 set ad_project_params(TX_JESD_K) 32
 
-set ad_project_params(RX_JESD_M) 4
-set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_M) 1
+set ad_project_params(RX_JESD_L) 1
 set ad_project_params(RX_JESD_S) 1
 set ad_project_params(RX_JESD_NP) 16
-set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_F) 2
 set ad_project_params(RX_JESD_K) 32
 
-set ad_project_params(RX_OS_JESD_M) 2
-set ad_project_params(RX_OS_JESD_L) 2
-set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_M) 1
+set ad_project_params(RX_OS_JESD_L) 1
+set ad_project_params(RX_OS_JESD_S) 2
 set ad_project_params(RX_OS_JESD_NP) 16
-set ad_project_params(RX_OS_JESD_F) 2
+set ad_project_params(RX_OS_JESD_F) 4
 set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg1.tcl
+++ b/adrv9009/cfgs/cfg1.tcl
@@ -14,7 +14,7 @@ set ad_project_params(TX_JESD_M) 4
 set ad_project_params(TX_JESD_L) 4
 set ad_project_params(TX_JESD_S) 1
 set ad_project_params(TX_JESD_NP) 16
-set ad_project_params(TX_JESD_F) 4
+set ad_project_params(TX_JESD_F) 2
 set ad_project_params(TX_JESD_K) 32
 
 set ad_project_params(RX_JESD_M) 4
@@ -28,5 +28,5 @@ set ad_project_params(RX_OS_JESD_M) 2
 set ad_project_params(RX_OS_JESD_L) 2
 set ad_project_params(RX_OS_JESD_S) 1
 set ad_project_params(RX_OS_JESD_NP) 16
-set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_F) 2
 set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg1.tcl
+++ b/adrv9009/cfgs/cfg1.tcl
@@ -1,0 +1,31 @@
+global ad_project_params
+
+set ad_project_params(JESD_MODE) 8B10B
+
+set ad_project_params(REF_CLK_RATE) 500
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+# set ad_project_params(RX_LANE_RATE) 10
+# set ad_project_params(TX_LANE_RATE) 10
+
+set ad_project_params(TX_JESD_M) 4
+set ad_project_params(TX_JESD_L) 4
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 4
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 4
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 2
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg2.tcl
+++ b/adrv9009/cfgs/cfg2.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 1
+set ad_project_params(TX_JESD_L) 2
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 1
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 1
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 1
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 1
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 2
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 2
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg3.tcl
+++ b/adrv9009/cfgs/cfg3.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 1
+set ad_project_params(TX_JESD_L) 2
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 1
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 1
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 4
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 1
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 4
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg4.tcl
+++ b/adrv9009/cfgs/cfg4.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 2
+set ad_project_params(TX_JESD_L) 1
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 4
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 2
+set ad_project_params(RX_JESD_L) 1
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 2
+set ad_project_params(RX_OS_JESD_L) 1
+set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg5.tcl
+++ b/adrv9009/cfgs/cfg5.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 2
+set ad_project_params(TX_JESD_L) 2
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 2
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 2
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 2
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 2
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 2
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg6.tcl
+++ b/adrv9009/cfgs/cfg6.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 2
+set ad_project_params(TX_JESD_L) 4
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 1
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 2
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 2
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 2
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 2
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg7.tcl
+++ b/adrv9009/cfgs/cfg7.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 4
+set ad_project_params(TX_JESD_L) 2
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 4
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 4
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 4
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/cfgs/cfg8.tcl
+++ b/adrv9009/cfgs/cfg8.tcl
@@ -1,0 +1,29 @@
+global ad_project_params
+
+set ad_project_params(LINK_MODE) 1
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+
+set ad_project_params(DAC_FIFO_ADDRESS_WIDTH) 16
+
+set ad_project_params(TX_JESD_M) 4
+set ad_project_params(TX_JESD_L) 4
+set ad_project_params(TX_JESD_S) 1
+set ad_project_params(TX_JESD_NP) 16
+set ad_project_params(TX_JESD_F) 2
+set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(RX_JESD_M) 4
+set ad_project_params(RX_JESD_L) 2
+set ad_project_params(RX_JESD_S) 1
+set ad_project_params(RX_JESD_NP) 16
+set ad_project_params(RX_JESD_F) 4
+set ad_project_params(RX_JESD_K) 32
+
+set ad_project_params(RX_OS_JESD_M) 4
+set ad_project_params(RX_OS_JESD_L) 2
+set ad_project_params(RX_OS_JESD_S) 1
+set ad_project_params(RX_OS_JESD_NP) 16
+set ad_project_params(RX_OS_JESD_F) 4
+set ad_project_params(RX_OS_JESD_K) 32

--- a/adrv9009/environment.sv
+++ b/adrv9009/environment.sv
@@ -1,0 +1,100 @@
+`include "utils.svh"
+`include "m_axi_sequencer.sv"
+
+`ifndef __ENVIRONMENT_SV__
+`define __ENVIRONMENT_SV__
+
+import axi_vip_pkg::*;
+import axi4stream_vip_pkg::*;
+import `PKGIFY(`TH, `MNG_AXI)::*;
+
+class environment;
+
+  // Agents
+  `AGENT(`TH, `MNG_AXI, mst_t) mng_agent;
+  // Sequencers
+  m_axi_sequencer #(`AGENT(`TH, `MNG_AXI, mst_t)) mng;
+
+  // Register accessors
+  bit done = 0;
+
+
+  //============================================================================
+  // Constructor
+  //============================================================================
+  function new(
+    virtual interface axi_vip_if #(`AXI_VIP_IF_PARAMS(`TH, `MNG_AXI)) mng_vip_if
+  );
+
+    // Creating the agents
+    mng_agent = new("AXI Manager agent", mng_vip_if);
+
+    // Creating the sequencers
+    mng = new(mng_agent);
+
+  endfunction
+
+  //============================================================================
+  // Start environment
+  //   - Connect all the agents to the scoreboard
+  //   - Start the agents
+  //============================================================================
+  task start();
+    mng_agent.start_master();
+
+  endtask
+
+  //============================================================================
+  // Start the test
+  //   - start the scoreboard
+  //   - start the sequencers
+  //============================================================================
+  task test();
+    fork
+
+    join_none
+  endtask
+
+  //============================================================================
+  // Post test subroutine
+  //============================================================================
+  task post_test();
+    // wait until done
+    wait_done();
+  endtask
+
+  //============================================================================
+  // Run subroutine
+  //============================================================================
+  task run;
+    test();
+    post_test();
+  endtask
+
+  //============================================================================
+  // Stop subroutine
+  //============================================================================
+  task stop;
+    mng_agent.stop_master();
+  endtask
+
+  //============================================================================
+  // Wait until all component are done
+  //============================================================================
+  task wait_done;
+    wait (done == 1);
+    //`INFO(("Shutting down"));
+  endtask
+
+  //============================================================================
+  // Test controller routine
+  //============================================================================
+  task test_c_run();
+    done = 1;
+  endtask
+
+
+
+endclass
+
+`endif

--- a/adrv9009/system_bd.tcl
+++ b/adrv9009/system_bd.tcl
@@ -1,0 +1,216 @@
+# ***************************************************************************
+# ***************************************************************************
+# Copyright 2018 (c) Analog Devices, Inc. All rights reserved.
+#
+# In this HDL repository, there are many different and unique modules, consisting
+# of various HDL (Verilog or VHDL) components. The individual modules are
+# developed independently, and may be accompanied by separate and unique license
+# terms.
+#
+# The user should read each of these license terms, and understand the
+# freedoms and responsibilities that he or she has by using this source/core.
+#
+# This core is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.
+#
+# Redistribution and use of source or resulting binaries, with or without modification
+# of this file, are permitted under one of the following two license terms:
+#
+#   1. The GNU General Public License version 2 as published by the
+#      Free Software Foundation, which can be found in the top level directory
+#      of this repository (LICENSE_GPL2), and also online at:
+#      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+#
+# OR
+#
+#   2. An ADI specific BSD license, which can be found in the top level directory
+#      of this repository (LICENSE_ADIBSD), and also on-line at:
+#      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+#      This will allow to generate bit files and not release the source code,
+#      as long as it attaches to an ADI device.
+#
+# ***************************************************************************
+# ***************************************************************************
+
+source ../../library/scripts/adi_env.tcl
+source $ad_hdl_dir/library/jesd204/scripts/jesd204.tcl
+
+global ad_project_params
+
+source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
+source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
+
+set dac_fifo_address_width $ad_project_params(DAC_FIFO_ADDRESS_WIDTH)
+set ENCODER_SEL 2
+set LANE_RATE 24.75
+
+set TX_NUM_OF_LANES $ad_project_params(TX_JESD_L)
+set TX_NUM_OF_CONVERTERS $ad_project_params(TX_JESD_M)
+set TX_SAMPLES_PER_FRAME $ad_project_params(TX_JESD_S)
+set TX_SAMPLE_WIDTH $ad_project_params(TX_JESD_NP)
+
+set RX_NUM_OF_LANES $ad_project_params(RX_JESD_L)
+set RX_NUM_OF_CONVERTERS $ad_project_params(RX_JESD_M)
+set RX_SAMPLES_PER_FRAME $ad_project_params(RX_JESD_S)
+set RX_SAMPLE_WIDTH $ad_project_params(RX_JESD_NP)
+
+set RX_OS_NUM_OF_LANES $ad_project_params(RX_OS_JESD_L)
+set RX_OS_NUM_OF_CONVERTERS $ad_project_params(RX_OS_JESD_M)
+set RX_OS_SAMPLES_PER_FRAME $ad_project_params(RX_OS_JESD_S)
+set RX_OS_SAMPLE_WIDTH $ad_project_params(RX_OS_JESD_NP)
+
+set TX_MAX_LANES 4
+set RX_MAX_LANES 2
+
+# Ref clk
+ad_ip_instance clk_vip ref_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 250000000 \
+]
+adi_sim_add_define "REF_CLK=ref_clk_vip"
+create_bd_port -dir O ref_clk_out
+ad_connect ref_clk_out ref_clk_vip/clk_out
+
+# Tx Device clk
+ad_ip_instance clk_vip tx_device_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 250000000 \
+]
+adi_sim_add_define "TX_DEVICE_CLK=tx_device_clk_vip"
+create_bd_port -dir O tx_device_clk_out
+ad_connect tx_device_clk_out tx_device_clk_vip/clk_out
+
+# Rx Device clk
+ad_ip_instance clk_vip rx_device_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 250000000 \
+]
+adi_sim_add_define "RX_DEVICE_CLK=rx_device_clk_vip"
+create_bd_port -dir O rx_device_clk_out
+ad_connect rx_device_clk_out rx_device_clk_vip/clk_out
+
+# Rx Observation Device clk
+ad_ip_instance clk_vip rx_os_device_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 250000000 \
+]
+adi_sim_add_define "RX_OS_DEVICE_CLK=rx_os_device_clk_vip"
+create_bd_port -dir O rx_os_device_clk_out
+ad_connect rx_os_device_clk_out rx_os_device_clk_vip/clk_out
+
+# SYSREF clk
+ad_ip_instance clk_vip sysref_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 5000000 \
+]
+adi_sim_add_define "SYSREF_CLK=sysref_clk_vip"
+create_bd_port -dir O sysref_clk_out
+ad_connect sysref_clk_out sysref_clk_vip/clk_out
+
+#
+#  Block design under test
+#
+
+create_bd_port -dir I -type clk ref_clk 
+create_bd_port -dir I -type clk tx_device_clk
+create_bd_port -dir I -type clk rx_device_clk
+create_bd_port -dir I -type clk rx_os_device_clk
+create_bd_port -dir I -type clk sysref
+
+set_property CONFIG.FREQ_HZ 250000000 [get_bd_ports tx_device_clk]
+set_property CONFIG.FREQ_HZ 250000000 [get_bd_ports rx_device_clk]
+set_property CONFIG.FREQ_HZ 250000000 [get_bd_ports rx_os_device_clk]
+
+for {set i 0} {$i < $TX_MAX_LANES} {incr i} {
+create_bd_port -dir O tx_data1_${i}_n
+create_bd_port -dir O tx_data1_${i}_p
+}
+
+for {set i 0} {$i < $RX_MAX_LANES} {incr i} {
+create_bd_port -dir I rx_data1_${i}_n
+create_bd_port -dir I rx_data1_${i}_p
+create_bd_port -dir I rx_os_data1_${i}_n
+create_bd_port -dir I rx_os_data1_${i}_p
+}
+
+# Tx reset generator
+ad_ip_instance proc_sys_reset tx_device_clk_rstgen
+ad_connect  tx_device_clk tx_device_clk_rstgen/slowest_sync_clk
+ad_connect  $sys_cpu_resetn tx_device_clk_rstgen/ext_reset_in
+
+# Rx reset generator
+ad_ip_instance proc_sys_reset rx_device_clk_rstgen
+ad_connect  rx_device_clk rx_device_clk_rstgen/slowest_sync_clk
+ad_connect  $sys_cpu_resetn rx_device_clk_rstgen/ext_reset_in
+
+# Rx Observation reset generator
+ad_ip_instance proc_sys_reset rx_os_device_clk_rstgen
+ad_connect  rx_os_device_clk rx_os_device_clk_rstgen/slowest_sync_clk
+ad_connect  $sys_cpu_resetn rx_os_device_clk_rstgen/ext_reset_in
+
+source $ad_hdl_dir/projects/adrv9009/common/adrv9009_bd.tcl
+
+source ../common/test_harness/jesd_exerciser.tcl
+
+create_jesd_exerciser tx_jesd_exerciser 1 $ENCODER_SEL $LANE_RATE $TX_NUM_OF_CONVERTERS $TX_NUM_OF_LANES $TX_SAMPLES_PER_FRAME $TX_SAMPLE_WIDTH
+create_bd_cell -type container -reference tx_jesd_exerciser i_tx_jesd_exerciser
+
+create_jesd_exerciser rx_jesd_exerciser 0 $ENCODER_SEL $LANE_RATE $RX_NUM_OF_CONVERTERS $RX_NUM_OF_LANES $RX_SAMPLES_PER_FRAME $RX_SAMPLE_WIDTH
+create_bd_cell -type container -reference rx_jesd_exerciser i_rx_jesd_exerciser
+
+create_jesd_exerciser rx_os_jesd_exerciser 0 $ENCODER_SEL $LANE_RATE $RX_OS_NUM_OF_CONVERTERS $RX_OS_NUM_OF_LANES $RX_OS_SAMPLES_PER_FRAME $RX_OS_SAMPLE_WIDTH
+create_bd_cell -type container -reference rx_os_jesd_exerciser i_rx_os_jesd_exerciser
+
+# Tx exerciser
+for {set i 0} {$i < $TX_NUM_OF_LANES} {incr i} {
+  ad_connect tx_data1_${i}_n i_tx_jesd_exerciser/tx_data_${i}_n
+  ad_connect tx_data1_${i}_p i_tx_jesd_exerciser/tx_data_${i}_p
+}
+ad_connect sysref i_tx_jesd_exerciser/tx_sysref_0
+
+ad_connect $sys_cpu_clk i_tx_jesd_exerciser/sys_cpu_clk
+ad_connect $sys_cpu_resetn i_tx_jesd_exerciser/sys_cpu_resetn
+
+ad_connect tx_device_clk i_tx_jesd_exerciser/device_clk
+
+ad_connect ref_clk i_tx_jesd_exerciser/ref_clk
+
+set_property -dict [list CONFIG.NUM_MI {17}] [get_bd_cells axi_cpu_interconnect]
+ad_connect i_tx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M16_AXI
+
+# Rx exerciser
+for {set i 0} {$i < $RX_NUM_OF_LANES} {incr i} {
+  ad_connect rx_data1_${i}_n i_rx_jesd_exerciser/rx_data_${i}_n
+  ad_connect rx_data1_${i}_p i_rx_jesd_exerciser/rx_data_${i}_p
+}
+ad_connect sysref i_rx_jesd_exerciser/rx_sysref_0
+
+ad_connect $sys_cpu_clk i_rx_jesd_exerciser/sys_cpu_clk
+ad_connect $sys_cpu_resetn i_rx_jesd_exerciser/sys_cpu_resetn
+
+ad_connect rx_device_clk i_rx_jesd_exerciser/device_clk
+
+ad_connect ref_clk i_rx_jesd_exerciser/ref_clk
+
+set_property -dict [list CONFIG.NUM_MI {18}] [get_bd_cells axi_cpu_interconnect]
+ad_connect i_rx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M17_AXI
+
+# Rx Observation exerciser
+for {set i 0} {$i < $RX_OS_NUM_OF_LANES} {incr i} {
+  ad_connect rx_os_data1_${i}_n i_rx_os_jesd_exerciser/rx_data_${i}_n
+  ad_connect rx_os_data1_${i}_p i_rx_os_jesd_exerciser/rx_data_${i}_p
+}
+ad_connect sysref i_rx_os_jesd_exerciser/rx_sysref_0
+
+ad_connect $sys_cpu_clk i_rx_os_jesd_exerciser/sys_cpu_clk
+ad_connect $sys_cpu_resetn i_rx_os_jesd_exerciser/sys_cpu_resetn
+
+ad_connect rx_os_device_clk i_rx_os_jesd_exerciser/device_clk
+
+ad_connect ref_clk i_rx_os_jesd_exerciser/ref_clk
+
+set_property -dict [list CONFIG.NUM_MI {19}] [get_bd_cells axi_cpu_interconnect]
+ad_connect i_rx_os_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M18_AXI
+
+assign_bd_address

--- a/adrv9009/system_bd.tcl
+++ b/adrv9009/system_bd.tcl
@@ -42,8 +42,8 @@ source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
 set dac_fifo_address_width $ad_project_params(DAC_FIFO_ADDRESS_WIDTH)
-set ENCODER_SEL 2
-set LANE_RATE 24.75
+set ENCODER_SEL 1
+set LANE_RATE $ad_project_params(LANE_RATE)
 
 set TX_NUM_OF_LANES $ad_project_params(TX_JESD_L)
 set TX_NUM_OF_CONVERTERS $ad_project_params(TX_JESD_M)

--- a/adrv9009/system_project.tcl
+++ b/adrv9009/system_project.tcl
@@ -1,0 +1,54 @@
+source ../scripts/adi_sim.tcl
+source ../../library/scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+if {$argc < 1} {
+  puts "Expecting at least one argument that specifies the test configuration"
+  exit 1
+} else {
+  set cfg_file [lindex $argv 0]
+}
+
+# Read config file
+source "cfgs/${cfg_file}"
+
+# Set the project name
+set project_name [file rootname $cfg_file]
+
+# Create the project
+#adi_sim_project_xilinx $project_name "xcvm1802-vfvc1760-3HP-e-S"
+adi_sim_project_xilinx $project_name "xcvu9p-flga2104-2L-e"
+#adi_sim_project_xilinx $project_name "xczu9eg-ffvb1156-2-e"; # GTH4
+
+# Add test files to the project
+adi_sim_project_files [list \
+ "../common/sv/utils.svh" \
+ "../common/sv/logger_pkg.sv" \
+ "../common/sv/reg_accessor.sv" \
+ "../common/sv/m_axis_sequencer.sv" \
+ "../common/sv/s_axis_sequencer.sv" \
+ "../common/sv/m_axi_sequencer.sv" \
+ "../common/sv/s_axi_sequencer.sv" \
+ "../common/sv/dmac_api.sv" \
+ "../common/sv/adi_regmap_pkg.sv" \
+ "../common/sv/adi_regmap_dmac_pkg.sv" \
+ "../common/sv/adi_regmap_dac_pkg.sv" \
+ "../common/sv/adi_regmap_common_pkg.sv" \
+ "../common/sv/adi_regmap_adc_pkg.sv" \
+ "../common/sv/adi_regmap_jesd_tx_pkg.sv" \
+ "../common/sv/adi_regmap_jesd_rx_pkg.sv" \
+ "../common/sv/dma_trans.sv" \
+ "../common/sv/axi_dmac_pkg.sv" \
+ "../common/sv/test_harness_env.sv" \
+ "../common/sv/adi_regmap_xcvr_pkg.sv" \
+ "../common/sv/adi_peripheral_pkg.sv" \
+ "../common/sv/adi_jesd204_pkg.sv" \
+ "../common/sv/adi_xcvr_pkg.sv" \
+ "tests/test_program.sv" \
+ "system_tb.sv" \
+ ]
+
+#set a default test program
+adi_sim_add_define "TEST_PROGRAM=test_program"
+
+adi_sim_generate $project_name

--- a/adrv9009/system_tb.sv
+++ b/adrv9009/system_tb.sv
@@ -109,12 +109,12 @@ module system_tb();
        
     .tx_data_0_n(dut2ex_serial_lane_n[0]),
     .tx_data_0_p(dut2ex_serial_lane_p[0]),
-    .tx_data_1_n(dut2ex_serial_lane_n[1]),
-    .tx_data_1_p(dut2ex_serial_lane_p[1]),
+    .tx_data_1_n(dut2ex_serial_lane_n[3]),
+    .tx_data_1_p(dut2ex_serial_lane_p[3]),
     .tx_data_2_n(dut2ex_serial_lane_n[2]),
     .tx_data_2_p(dut2ex_serial_lane_p[2]),
-    .tx_data_3_n(dut2ex_serial_lane_n[3]),
-    .tx_data_3_p(dut2ex_serial_lane_p[3])
+    .tx_data_3_n(dut2ex_serial_lane_n[1]),
+    .tx_data_3_p(dut2ex_serial_lane_p[1])
   );
 
 endmodule

--- a/adrv9009/system_tb.sv
+++ b/adrv9009/system_tb.sv
@@ -38,7 +38,11 @@
 `include "utils.svh"
 
 module system_tb();
-
+ 
+  wire rx_sync;
+  wire tx_sync;
+  wire tx_os_sync;
+  
   wire [3:0] ex2dut_serial_lane_n;
   wire [3:0] ex2dut_serial_lane_p;
 
@@ -48,57 +52,70 @@ module system_tb();
   `TEST_PROGRAM test();
 
   test_harness `TH (
-    .ref_clk_out    (ref_clk),
-    .tx_device_clk_out (tx_device_clk),
+    .tx_ref_clk_0 (ref_clk),
+    .rx_ref_clk_0 (ref_clk),
+    .rx_ref_clk_2 (ref_clk),
+    .ref_clk_out  (ref_clk),
     .rx_device_clk_out (rx_device_clk),
-    .rx_os_device_clk_out (rx_os_device_clk),
+    .tx_device_clk_out (tx_device_clk),
+    .tx_os_device_clk_out (tx_os_device_clk),
     .sysref_clk_out (sysref),
 
-    .tx_device_clk(tx_device_clk),
     .rx_device_clk(rx_device_clk),
-    .rx_os_device_clk(rx_os_device_clk),
+    .tx_device_clk(tx_device_clk),
+    .tx_os_device_clk(tx_os_device_clk),
     .ref_clk(ref_clk),
     .sysref(sysref),
+    .tx_sysref_0(sysref),
+    .rx_sysref_0(sysref),
+    .rx_sysref_2(sysref),
 
-    // .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_p(ref_clk),
-    // .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_n(~ref_clk),
+    .tx_sync_0(rx_sync),
+    .ex_rx_sync(rx_sync),
+
+    .rx_sync_0(tx_sync),
+    .ex_tx_sync(tx_sync),
+
+    .rx_sync_2(tx_os_sync),
+    .ex_tx_os_sync(tx_os_sync),
+
+    .rx_data1_0_n(dut2ex_serial_lane_n[0]),
+    .rx_data1_0_p(dut2ex_serial_lane_p[0]),
+    .rx_data1_1_n(dut2ex_serial_lane_n[1]),
+    .rx_data1_1_p(dut2ex_serial_lane_p[1]),
+    .rx_data1_2_n(dut2ex_serial_lane_n[2]),
+    .rx_data1_2_p(dut2ex_serial_lane_p[2]),
+    .rx_data1_3_n(dut2ex_serial_lane_n[3]),
+    .rx_data1_3_p(dut2ex_serial_lane_p[3]),
     
-    .rx_data1_0_p(ex2dut_serial_lane_p[0]),
-    .rx_data1_0_n(ex2dut_serial_lane_n[0]),
-    .rx_data1_1_p(ex2dut_serial_lane_p[1]),
-    .rx_data1_1_n(ex2dut_serial_lane_n[1]),
+    .tx_data1_0_n(ex2dut_serial_lane_n[0]),
+    .tx_data1_0_p(ex2dut_serial_lane_p[0]),
+    .tx_data1_1_n(ex2dut_serial_lane_n[1]),
+    .tx_data1_1_p(ex2dut_serial_lane_p[1]),
 
-    .rx_os_data1_0_p(ex2dut_serial_lane_p[2]),
-    .rx_os_data1_0_n(ex2dut_serial_lane_n[2]),
-    .rx_os_data1_1_p(ex2dut_serial_lane_p[3]),
-    .rx_os_data1_1_n(ex2dut_serial_lane_n[3]),
+    .tx_os_data1_0_n(ex2dut_serial_lane_n[2]),
+    .tx_os_data1_0_p(ex2dut_serial_lane_p[2]),
+    .tx_os_data1_1_n(ex2dut_serial_lane_n[3]),
+    .tx_os_data1_1_p(ex2dut_serial_lane_p[3]),
 
-    .tx_data1_0_p(dut2ex_serial_lane_p[0]),
-    .tx_data1_0_n(dut2ex_serial_lane_n[0]),
-    .tx_data1_1_p(dut2ex_serial_lane_p[1]),
-    .tx_data1_1_n(dut2ex_serial_lane_n[1]),
-    .tx_data1_2_p(dut2ex_serial_lane_p[2]),
-    .tx_data1_2_n(dut2ex_serial_lane_n[2]),
-    .tx_data1_3_p(dut2ex_serial_lane_p[3]),
-    .tx_data1_3_n(dut2ex_serial_lane_n[3]),
-
-    .rx_data_0_p(dut2ex_serial_lane_p[0]),
-    .rx_data_0_n(dut2ex_serial_lane_n[0]),
-    .rx_data_1_p(dut2ex_serial_lane_p[1]),
-    .rx_data_1_n(dut2ex_serial_lane_n[1]),
-    .rx_data_2_p(dut2ex_serial_lane_p[2]),
-    .rx_data_2_n(dut2ex_serial_lane_n[2]),
-    .rx_data_3_p(dut2ex_serial_lane_p[3]),
-    .rx_data_3_n(dut2ex_serial_lane_n[3]),
-
-    .tx_data_0_p(ex2dut_serial_lane_p[0]),
-    .tx_data_0_n(ex2dut_serial_lane_n[0]),
-    .tx_data_1_p(ex2dut_serial_lane_p[1]),
-    .tx_data_1_n(ex2dut_serial_lane_n[1]),
-    .tx_data_2_p(ex2dut_serial_lane_p[2]),
-    .tx_data_2_n(ex2dut_serial_lane_n[2]),
-    .tx_data_3_p(ex2dut_serial_lane_p[3]),
-    .tx_data_3_n(ex2dut_serial_lane_n[3])
+    .rx_data_0_n(ex2dut_serial_lane_n[0]),
+    .rx_data_0_p(ex2dut_serial_lane_p[0]),
+    .rx_data_1_n(ex2dut_serial_lane_n[1]),
+    .rx_data_1_p(ex2dut_serial_lane_p[1]),
+    .rx_data_2_n(ex2dut_serial_lane_n[2]),
+    .rx_data_2_p(ex2dut_serial_lane_p[2]),
+    .rx_data_3_n(ex2dut_serial_lane_n[3]),
+    .rx_data_3_p(ex2dut_serial_lane_p[3]),
+       
+    .tx_data_0_n(dut2ex_serial_lane_n[0]),
+    .tx_data_0_p(dut2ex_serial_lane_p[0]),
+    .tx_data_1_n(dut2ex_serial_lane_n[1]),
+    .tx_data_1_p(dut2ex_serial_lane_p[1]),
+    .tx_data_2_n(dut2ex_serial_lane_n[2]),
+    .tx_data_2_p(dut2ex_serial_lane_p[2]),
+    .tx_data_3_n(dut2ex_serial_lane_n[3]),
+    .tx_data_3_p(dut2ex_serial_lane_p[3])
   );
 
 endmodule
+

--- a/adrv9009/system_tb.sv
+++ b/adrv9009/system_tb.sv
@@ -1,0 +1,104 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2018 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/1ps
+
+`include "utils.svh"
+
+module system_tb();
+
+  wire [3:0] ex2dut_serial_lane_n;
+  wire [3:0] ex2dut_serial_lane_p;
+
+  wire [3:0] dut2ex_serial_lane_n;
+  wire [3:0] dut2ex_serial_lane_p;
+
+  `TEST_PROGRAM test();
+
+  test_harness `TH (
+    .ref_clk_out    (ref_clk),
+    .tx_device_clk_out (tx_device_clk),
+    .rx_device_clk_out (rx_device_clk),
+    .rx_os_device_clk_out (rx_os_device_clk),
+    .sysref_clk_out (sysref),
+
+    .tx_device_clk(tx_device_clk),
+    .rx_device_clk(rx_device_clk),
+    .rx_os_device_clk(rx_os_device_clk),
+    .ref_clk(ref_clk),
+    .sysref(sysref),
+
+    // .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_p(ref_clk),
+    // .gt_bridge_ip_0_diff_gt_ref_clock_0_clk_n(~ref_clk),
+    
+    .rx_data1_0_p(ex2dut_serial_lane_p[0]),
+    .rx_data1_0_n(ex2dut_serial_lane_n[0]),
+    .rx_data1_1_p(ex2dut_serial_lane_p[1]),
+    .rx_data1_1_n(ex2dut_serial_lane_n[1]),
+
+    .rx_os_data1_0_p(ex2dut_serial_lane_p[2]),
+    .rx_os_data1_0_n(ex2dut_serial_lane_n[2]),
+    .rx_os_data1_1_p(ex2dut_serial_lane_p[3]),
+    .rx_os_data1_1_n(ex2dut_serial_lane_n[3]),
+
+    .tx_data1_0_p(dut2ex_serial_lane_p[0]),
+    .tx_data1_0_n(dut2ex_serial_lane_n[0]),
+    .tx_data1_1_p(dut2ex_serial_lane_p[1]),
+    .tx_data1_1_n(dut2ex_serial_lane_n[1]),
+    .tx_data1_2_p(dut2ex_serial_lane_p[2]),
+    .tx_data1_2_n(dut2ex_serial_lane_n[2]),
+    .tx_data1_3_p(dut2ex_serial_lane_p[3]),
+    .tx_data1_3_n(dut2ex_serial_lane_n[3]),
+
+    .rx_data_0_p(dut2ex_serial_lane_p[0]),
+    .rx_data_0_n(dut2ex_serial_lane_n[0]),
+    .rx_data_1_p(dut2ex_serial_lane_p[1]),
+    .rx_data_1_n(dut2ex_serial_lane_n[1]),
+    .rx_data_2_p(dut2ex_serial_lane_p[2]),
+    .rx_data_2_n(dut2ex_serial_lane_n[2]),
+    .rx_data_3_p(dut2ex_serial_lane_p[3]),
+    .rx_data_3_n(dut2ex_serial_lane_n[3]),
+
+    .tx_data_0_p(ex2dut_serial_lane_p[0]),
+    .tx_data_0_n(ex2dut_serial_lane_n[0]),
+    .tx_data_1_p(ex2dut_serial_lane_p[1]),
+    .tx_data_1_n(ex2dut_serial_lane_n[1]),
+    .tx_data_2_p(ex2dut_serial_lane_p[2]),
+    .tx_data_2_n(ex2dut_serial_lane_n[2]),
+    .tx_data_3_p(ex2dut_serial_lane_p[3]),
+    .tx_data_3_n(ex2dut_serial_lane_n[3])
+  );
+
+endmodule

--- a/adrv9009/system_tb.sv
+++ b/adrv9009/system_tb.sv
@@ -39,6 +39,15 @@
 
 module system_tb();
  
+  localparam RX_SAMPLES_PER_CHANNEL = (`RX_JESD_L*`LL_OUT_BYTES*8) / `RX_JESD_M / `RX_JESD_NP;
+  localparam RX_DMA_NP = `RX_JESD_NP == 12 ? 16 : `RX_JESD_NP;
+
+  localparam RX_OS_SAMPLES_PER_CHANNEL = (`RX_OS_JESD_L*`LL_OUT_BYTES1*8) / `RX_OS_JESD_M / `RX_OS_JESD_NP;
+  localparam RX_OS_DMA_NP = `RX_OS_JESD_NP == 12 ? 16 : `RX_OS_JESD_NP;
+  
+  reg [`RX_JESD_M*RX_SAMPLES_PER_CHANNEL*RX_DMA_NP-1:0] tx_ex_dac_data = 'h0;
+  reg [`RX_OS_JESD_M*RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP-1:0] tx_os_ex_dac_data = 'h0;
+
   wire rx_sync;
   wire tx_sync;
   wire tx_os_sync;
@@ -52,19 +61,20 @@ module system_tb();
   `TEST_PROGRAM test();
 
   test_harness `TH (
-    .tx_ref_clk_0 (ref_clk),
-    .rx_ref_clk_0 (ref_clk),
-    .rx_ref_clk_2 (ref_clk),
-    .ref_clk_out  (ref_clk),
-    .rx_device_clk_out (rx_device_clk),
-    .tx_device_clk_out (tx_device_clk),
-    .tx_os_device_clk_out (tx_os_device_clk),
-    .sysref_clk_out (sysref),
+    .tx_ref_clk_0(ref_clk_ex),
+    .rx_ref_clk_0(ref_clk_ex),
+    .rx_ref_clk_2(ref_clk_ex),
+    .ref_clk_out(ref_clk_ex),
+    .rx_device_clk_out(rx_device_clk),
+    .tx_device_clk_out(tx_device_clk),
+    .tx_os_device_clk_out(tx_os_device_clk),
+    .sysref_clk_out(sysref),
 
     .rx_device_clk(rx_device_clk),
     .tx_device_clk(tx_device_clk),
     .tx_os_device_clk(tx_os_device_clk),
-    .ref_clk(ref_clk),
+    .ref_clk(tx_device_clk),
+    .ref_clk_ex(ref_clk_ex),
     .sysref(sysref),
     .tx_sysref_0(sysref),
     .rx_sysref_0(sysref),
@@ -114,8 +124,60 @@ module system_tb();
     .tx_data_2_n(dut2ex_serial_lane_n[2]),
     .tx_data_2_p(dut2ex_serial_lane_p[2]),
     .tx_data_3_n(dut2ex_serial_lane_n[1]),
-    .tx_data_3_p(dut2ex_serial_lane_p[1])
+    .tx_data_3_p(dut2ex_serial_lane_p[1]),
+    
+    .dac_data_0(tx_ex_dac_data[RX_SAMPLES_PER_CHANNEL*RX_DMA_NP*0 +: RX_SAMPLES_PER_CHANNEL*RX_DMA_NP]),
+    .dac_data_1(tx_ex_dac_data[RX_SAMPLES_PER_CHANNEL*RX_DMA_NP*1 +: RX_SAMPLES_PER_CHANNEL*RX_DMA_NP]),
+    .dac_data_2(tx_ex_dac_data[RX_SAMPLES_PER_CHANNEL*RX_DMA_NP*2 +: RX_SAMPLES_PER_CHANNEL*RX_DMA_NP]),
+    .dac_data_3(tx_ex_dac_data[RX_SAMPLES_PER_CHANNEL*RX_DMA_NP*3 +: RX_SAMPLES_PER_CHANNEL*RX_DMA_NP]),
+
+    .dac_os_data_0(tx_os_ex_dac_data[RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP*0 +: RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP]),
+    .dac_os_data_1(tx_os_ex_dac_data[RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP*1 +: RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP]),
+    .dac_os_data_2(tx_os_ex_dac_data[RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP*2 +: RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP]),
+    .dac_os_data_3(tx_os_ex_dac_data[RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP*3 +: RX_OS_SAMPLES_PER_CHANNEL*RX_OS_DMA_NP]),
+    
+    .dac_fir_filter_active (1'b0),
+    .adc_fir_filter_active (1'b0),
+    .dac_fifo_bypass (1'b0)
   );
+
+  reg [RX_DMA_NP-1:0] sample = 'h0;
+  integer sample_counter = 0;
+  always @(posedge tx_device_clk) begin
+    for (int i = 0; i < `RX_JESD_M; i++) begin
+      for (int j = 0; j < RX_SAMPLES_PER_CHANNEL; j++) begin
+        // First 256 sample is channel count on each nibble
+        // Next 256 sample is channel count on MS nibble and incr pattern
+        if (sample_counter[9] | 1) begin
+          sample[RX_DMA_NP-1 -: 4] = i;
+          sample[7:0] = sample_counter+j;
+        end else begin
+          sample = {4{i[3:0]}};
+        end
+        tx_ex_dac_data[RX_DMA_NP*(RX_SAMPLES_PER_CHANNEL*i+j) +:RX_DMA_NP] = sample;
+      end
+    end
+    sample_counter = sample_counter + RX_SAMPLES_PER_CHANNEL;
+  end
+
+  reg [RX_OS_DMA_NP-1:0] sample1 = 'h0;
+  integer sample_counter1 = 0;
+  always @(posedge tx_os_device_clk) begin
+    for (int i = 0; i < `RX_OS_JESD_M; i++) begin
+      for (int j = 0; j < RX_OS_SAMPLES_PER_CHANNEL; j++) begin
+        // First 256 sample is channel count on each nibble
+        // Next 256 sample is channel count on MS nibble and incr pattern
+        if (sample_counter1[9] | 1) begin
+          sample1[RX_OS_DMA_NP-1 -: 4] = i;
+          sample1[7:0] = sample_counter1+j;
+        end else begin
+          sample1 = {4{i[3:0]}};
+        end
+        tx_os_ex_dac_data[RX_OS_DMA_NP*(RX_OS_SAMPLES_PER_CHANNEL*i+j) +:RX_OS_DMA_NP] = sample1;
+      end
+    end
+    sample_counter1 = sample_counter1 + RX_OS_SAMPLES_PER_CHANNEL;
+  end
 
 endmodule
 

--- a/adrv9009/tests/test_program.sv
+++ b/adrv9009/tests/test_program.sv
@@ -60,6 +60,8 @@ import adi_xcvr_pkg::*;
 `define ADC_OS_TPL  32'h44a0_8000
 `define DAC_TPL     32'h44a0_4000
 
+`define EX_ADC_TPL  32'h0006_0000
+
 `define DUT_AXI_XCVR_RX_OS 32'h44a5_0000
 `define DUT_AXI_XCVR_RX    32'h44a6_0000
 `define DUT_AXI_XCVR_TX    32'h44a8_0000
@@ -91,20 +93,25 @@ program test_program;
   bit [31:0] lane_rate_khz = `LANE_RATE*1000000;
   longint lane_rate = lane_rate_khz*1000;
 
-  int use_dds = 0;
-  real tx_sysref_clk, rx_sysref_clk, common_sysref_clk;
+  int use_dds = 1;
+  real rx_sysref_clk, tx_sysref_clk, tx_os_sysref_clk, common_sysref_clk;
 
   jesd_link tx_link;
   jesd_link rx_link;
+  jesd_link rx_os_link;
 
   rx_link_layer ex_rx_ll;
   tx_link_layer ex_tx_ll;
+  tx_link_layer ex_tx_os_ll;
   xcvr ex_rx_xcvr;
   xcvr ex_tx_xcvr;
+  xcvr ex_tx_os_xcvr;
 
   rx_link_layer dut_rx_ll;
+  rx_link_layer dut_rx_os_ll;
   tx_link_layer dut_tx_ll;
   xcvr dut_rx_xcvr;
+  xcvr dut_rx_os_xcvr;
   xcvr dut_tx_xcvr;
 
   initial begin
@@ -142,11 +149,25 @@ program test_program;
     rx_link.set_encoding(enc8b10b);
     rx_link.set_lane_rate(lane_rate);
 
+    rx_os_link = new;
+    rx_os_link.set_L(`RX_OS_JESD_L);
+    rx_os_link.set_M(`RX_OS_JESD_M);
+    rx_os_link.set_F(2);
+    rx_os_link.set_S(`RX_OS_JESD_S);
+    rx_os_link.set_K(32);
+    rx_os_link.set_N(`RX_OS_JESD_NP);
+    rx_os_link.set_NP(`RX_OS_JESD_NP);
+    rx_os_link.set_encoding(enc8b10b);
+    rx_os_link.set_lane_rate(lane_rate);
+
     ex_rx_ll = new("EX RX_LINK_LAYER", env.mng, `EX_AXI_JESD_RX, tx_link);
     ex_rx_ll.probe();
 
     ex_tx_ll = new("EX TX_LINK_LAYER", env.mng, `EX_AXI_JESD_TX, rx_link);
     ex_tx_ll.probe();
+
+    ex_tx_os_ll = new("EX TX_OS_LINK_LAYER", env.mng, `EX_AXI_JESD_TX_OS, rx_os_link);
+    ex_tx_os_ll.probe();
 
     ex_rx_xcvr = new("EX RX_XCVR", env.mng, `EX_AXI_XCVR_RX);
     ex_rx_xcvr.probe();
@@ -154,8 +175,14 @@ program test_program;
     ex_tx_xcvr = new("EX TX_XCVR", env.mng, `EX_AXI_XCVR_TX);
     ex_tx_xcvr.probe();
 
+    ex_tx_os_xcvr = new("EX TX_OS_XCVR", env.mng, `EX_AXI_XCVR_TX_OS);
+    ex_tx_os_xcvr.probe();
+
     dut_rx_xcvr = new("DUT RX_XCVR", env.mng, `DUT_AXI_XCVR_RX);
     dut_rx_xcvr.probe();
+
+    dut_rx_os_xcvr = new("DUT RX_OS_XCVR", env.mng, `DUT_AXI_XCVR_RX_OS);
+    dut_rx_os_xcvr.probe();
 
     dut_tx_xcvr = new("DUT TX_XCVR", env.mng, `DUT_AXI_XCVR_TX);
     dut_tx_xcvr.probe();
@@ -163,16 +190,22 @@ program test_program;
     dut_rx_ll = new("DUT RX_LINK_LAYER", env.mng, `AXI_JESD_RX, rx_link);
     dut_rx_ll.probe();
 
+    dut_rx_os_ll = new("DUT RX_OS_LINK_LAYER", env.mng, `AXI_JESD_RX_OS, rx_os_link);
+    dut_rx_os_ll.probe();
+
     dut_tx_ll = new("DUT TX_LINK_LAYER", env.mng, `AXI_JESD_TX, tx_link);
     dut_tx_ll.probe();
 
     `TH.`REF_CLK.inst.IF.set_clk_frq(.user_frequency(`REF_CLK_RATE*1000000));
     `TH.`RX_DEVICE_CLK.inst.IF.set_clk_frq(.user_frequency(ex_rx_ll.calc_device_clk()));
     `TH.`TX_DEVICE_CLK.inst.IF.set_clk_frq(.user_frequency(ex_tx_ll.calc_device_clk()));
+    `TH.`TX_OS_DEVICE_CLK.inst.IF.set_clk_frq(.user_frequency(ex_tx_os_ll.calc_device_clk()));
 
-    tx_sysref_clk = ex_tx_ll.calc_sysref_clk();
     rx_sysref_clk = ex_rx_ll.calc_sysref_clk();
-
+    tx_sysref_clk = ex_tx_ll.calc_sysref_clk();
+    tx_os_sysref_clk = ex_tx_os_ll.calc_sysref_clk();
+    
+    // Add tx_os_sysref_clk logic!
     if (tx_sysref_clk > rx_sysref_clk && `fmod(tx_sysref_clk, rx_sysref_clk) == 0)
       common_sysref_clk = rx_sysref_clk;
     else if (tx_sysref_clk < rx_sysref_clk && `fmod(rx_sysref_clk, tx_sysref_clk) == 0) begin
@@ -185,12 +218,16 @@ program test_program;
     `TH.`REF_CLK.inst.IF.start_clock;
     `TH.`RX_DEVICE_CLK.inst.IF.start_clock;
     `TH.`TX_DEVICE_CLK.inst.IF.start_clock;
+    `TH.`TX_OS_DEVICE_CLK.inst.IF.start_clock;
     `TH.`SYSREF_CLK.inst.IF.start_clock;
 
     ex_rx_xcvr.setup_clocks(lane_rate,
                             `REF_CLK_RATE*1000000);
 
     ex_tx_xcvr.setup_clocks(lane_rate,
+                            `REF_CLK_RATE*1000000);
+
+    ex_tx_os_xcvr.setup_clocks(lane_rate,
                             `REF_CLK_RATE*1000000);
     
     dut_tx_xcvr.setup_clocks(lane_rate,
@@ -199,8 +236,9 @@ program test_program;
     dut_rx_xcvr.setup_clocks(lane_rate,
                             `REF_CLK_RATE*1000000, '{CPLL});
 
-    // ex_tx_xcvr.setup_clocks(lane_rate,
-    //                        `REF_CLK_RATE*1000000);
+    dut_rx_os_xcvr.setup_clocks(lane_rate,
+                            `REF_CLK_RATE*1000000, '{CPLL});
+
 
     for (int i = 0; i < `TX_JESD_M; i++) begin
       if (use_dds) begin
@@ -221,14 +259,14 @@ program test_program;
     end
 
     for (int i = 0; i < `TX_JESD_M; i++) begin
-      env.mng.RegWrite32(`ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+      env.mng.RegWrite32(`EX_ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
 
     env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`EX_ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
 
@@ -240,15 +278,15 @@ program test_program;
     // -----------------------
     // bringup DUT TX path
     // -----------------------
-  //  env.mng.RegWrite32(`AXI_CLKGEN_TX + 'h40, 3);
-  //  dut_tx_xcvr.up();
-  //  dut_tx_ll.link_up();
+    env.mng.RegWrite32(`AXI_CLKGEN_TX + 'h40, 3);
+    dut_tx_xcvr.up();
+    dut_tx_ll.link_up();
 
-  //  ex_rx_xcvr.up();
-  //  ex_rx_ll.link_up();
+    ex_rx_xcvr.up();
+    ex_rx_ll.link_up();
 
-  //  dut_tx_ll.wait_link_up();
-  //  ex_rx_ll.wait_link_up();
+    dut_tx_ll.wait_link_up();
+    ex_rx_ll.wait_link_up();
 
 
     // -----------------------
@@ -265,12 +303,29 @@ program test_program;
     dut_rx_ll.wait_link_up();
 
 
+    // -----------------------
+    // bringup DUT RX Observation path
+    // -----------------------
+    env.mng.RegWrite32(`AXI_CLKGEN_RX_OS + 'h40, 3);
+    ex_tx_os_xcvr.up();
+    ex_tx_os_ll.link_up();
+
+    dut_rx_os_xcvr.up();
+    dut_rx_os_ll.link_up();
+
+    ex_tx_os_ll.wait_link_up();
+    dut_rx_os_ll.wait_link_up();
+
+
     // Move data around
     #10us;
+    ex_tx_os_xcvr.down();
+    dut_rx_os_xcvr.down();
     ex_rx_xcvr.down();
     dut_rx_xcvr.down();
     ex_tx_xcvr.down();
     dut_tx_xcvr.down();
+
 
     `INFO(("======================="));
     `INFO(("  JESD LINK TEST DONE  "));

--- a/adrv9009/tests/test_program.sv
+++ b/adrv9009/tests/test_program.sv
@@ -1,0 +1,219 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2018 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+//
+//
+//
+`include "utils.svh"
+
+import test_harness_env_pkg::*;
+import adi_regmap_pkg::*;
+import axi_vip_pkg::*;
+import axi4stream_vip_pkg::*;
+import logger_pkg::*;
+import adi_regmap_dmac_pkg::*;
+import adi_regmap_jesd_tx_pkg::*;
+import adi_regmap_jesd_rx_pkg::*;
+import adi_regmap_common_pkg::*;
+import adi_regmap_dac_pkg::*;
+import adi_regmap_adc_pkg::*;
+import adi_jesd204_pkg::*;
+import adi_xcvr_pkg::*;
+
+
+`define JESD_PHY    32'h44a6_0000
+`define AXI_JESD_RX 32'h44a9_0000
+`define AXI_JESD_TX 32'h44b9_0000
+`define ADC_TPL     32'h44a1_0000
+`define DAC_TPL     32'h44b1_0000
+
+`define EX_AXI_XCVR_RX 32'h44a2_0000
+`define EX_AXI_XCVR_TX 32'h44a5_0000
+`define EX_AXI_JESD_RX 32'h44A0_0000
+`define EX_AXI_JESD_TX 32'h44A4_0000
+
+`define LINK_MODE 2
+`define MODE_8B10B 1
+`define MODE_64B66B 2
+
+program test_program;
+
+  test_harness_env env;
+  // bit [31:0] val;
+
+  // bit [31:0] lane_rate_khz = `LANE_RATE*1000000;
+  // longint lane_rate = lane_rate_khz*1000;
+
+  // int use_dds = 0;
+
+  // jesd_link link;
+  // rx_link_layer ex_rx_ll;
+  // tx_link_layer ex_tx_ll;
+  // xcvr ex_rx_xcvr;
+  // xcvr ex_tx_xcvr;
+
+  // rx_link_layer dut_rx_ll;
+  // tx_link_layer dut_tx_ll;
+
+
+  initial begin
+    //creating environment
+    env = new(`TH.`SYS_CLK.inst.IF,
+              `TH.`DMA_CLK.inst.IF,
+              `TH.`DDR_CLK.inst.IF,
+              `TH.`MNG_AXI.inst.IF,
+              `TH.`DDR_AXI.inst.IF);
+
+    #2ps;
+
+    setLoggerVerbosity(6);
+    env.start();
+
+    // link = new;
+    // link.set_L(`JESD_L);
+    // link.set_M(`JESD_M);
+    // link.set_F(`JESD_F);
+    // link.set_S(`JESD_S);
+    // link.set_K(`JESD_K);
+    // link.set_N(`JESD_NP);
+    // link.set_NP(`JESD_NP);
+    // link.set_encoding(`LINK_MODE == `MODE_8B10B ? enc8b10b : enc64b66b);
+    // link.set_lane_rate(lane_rate);
+
+    // ex_rx_ll = new("RX_LINK_LAYER", env.mng, `EX_AXI_JESD_RX, link);
+    // ex_rx_ll.probe();
+
+    // ex_tx_ll = new("TX_LINK_LAYER", env.mng, `EX_AXI_JESD_TX, link);
+    // ex_tx_ll.probe();
+
+    // ex_rx_xcvr = new("RX_XCVR", env.mng, `EX_AXI_XCVR_RX);
+    // ex_rx_xcvr.probe();
+
+    // ex_tx_xcvr = new("TX_XCVR", env.mng, `EX_AXI_XCVR_TX);
+    // ex_tx_xcvr.probe();
+
+
+    // dut_rx_ll = new("DUT RX_LINK_LAYER", env.mng, `AXI_JESD_RX, link);
+    // dut_rx_ll.probe();
+
+    // dut_tx_ll = new("DUT TX_LINK_LAYER", env.mng, `AXI_JESD_TX, link);
+    // dut_tx_ll.probe();
+
+    // `TH.`REF_CLK.inst.IF.set_clk_frq(.user_frequency(`REF_CLK_RATE*1000000));
+    // `TH.`DEVICE_CLK.inst.IF.set_clk_frq(.user_frequency(ex_rx_ll.calc_device_clk()));
+    // `TH.`SYSREF_CLK.inst.IF.set_clk_frq(.user_frequency(ex_rx_ll.calc_sysref_clk()));
+
+    // `TH.`REF_CLK.inst.IF.start_clock;
+    // `TH.`DEVICE_CLK.inst.IF.start_clock;
+    // `TH.`SYSREF_CLK.inst.IF.start_clock;
+
+    // ex_rx_xcvr.setup_clocks(lane_rate,
+    //                         `REF_CLK_RATE*1000000);
+
+    // ex_tx_xcvr.setup_clocks(lane_rate,
+    //                        `REF_CLK_RATE*1000000);
+
+    // for (int i = 0; i < `JESD_M; i++) begin
+    //   if (use_dds) begin
+    //     // Select DDS as source
+    //     env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+    //                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
+    //     // Configure tone amplitude and frequency
+    //     env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+    //                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
+    //     env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+    //                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
+
+    //   end else begin
+    //     // Set DMA as source for DAC TPL
+    //     env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+    //                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    //   end
+    // end
+
+    // for (int i = 0; i < `JESD_M; i++) begin
+    //   env.mng.RegWrite32(`ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+    //                      `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
+    // end
+
+
+    // env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    //                    `SET_DAC_COMMON_REG_RSTN_RSTN(1));
+    // env.mng.RegWrite32(`ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    //                    `SET_ADC_COMMON_REG_RSTN_RSTN(1));
+
+
+    // // Sync DDS cores
+    // env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    //                    `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
+
+
+    // // -----------------------
+    // // bringup DUT TX path
+    // // -----------------------
+    // dut_tx_ll.link_up();
+
+    // ex_rx_xcvr.up();
+    // ex_rx_ll.link_up();
+
+    // dut_tx_ll.wait_link_up();
+    // ex_rx_ll.wait_link_up();
+
+
+    // // -----------------------
+    // // bringup DUT RX path
+    // // -----------------------
+    // ex_tx_xcvr.up();
+    // ex_tx_ll.link_up();
+
+    // dut_rx_ll.link_up();
+
+    // ex_tx_ll.wait_link_up();
+    // dut_rx_ll.wait_link_up();
+
+
+    // // Move data around
+    // #10us;
+
+    // ex_rx_xcvr.down();
+    // ex_tx_xcvr.down();
+
+    // `INFO(("======================="));
+    // `INFO(("  JESD LINK TEST DONE  "));
+    // `INFO(("======================="));
+
+
+  end
+
+endprogram

--- a/adrv9009/waves/cfg1.wcfg
+++ b/adrv9009/waves/cfg1.wcfg
@@ -7,7 +7,6 @@
          <top_modules>
             <top_module name="adi_jesd204_pkg" />
             <top_module name="adi_peripheral_pkg" />
-            <top_module name="adi_regmap_adc_pkg" />
             <top_module name="adi_regmap_dac_pkg" />
             <top_module name="adi_regmap_jesd_rx_pkg" />
             <top_module name="adi_regmap_jesd_tx_pkg" />
@@ -33,70 +32,82 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="10.174033350 us"></ZoomStartTime>
-      <ZoomEndTime time="117.529033351 us"></ZoomEndTime>
-      <Cursor1Time time="90.311430282 us"></Cursor1Time>
+      <ZoomStartTime time="13941448950fs"></ZoomStartTime>
+      <ZoomEndTime time="86486448951fs"></ZoomEndTime>
+      <Cursor1Time time="66496271172fs"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
       <NameColumnWidth column_width="177"></NameColumnWidth>
-      <ValueColumnWidth column_width="205"></ValueColumnWidth>
+      <ValueColumnWidth column_width="201"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="33" />
+   <WVObjectSize size="29" />
    <wvobject fp_name="divider170" type="divider">
       <obj_property name="label">DUT TX</obj_property>
       <obj_property name="DisplayName">label</obj_property>
    </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_data_tdata">
-      <obj_property name="ElementShortName">tx_data_tdata[383:0]</obj_property>
-      <obj_property name="ObjectShortName">tx_data_tdata[383:0]</obj_property>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_adrv9009_tx_jesd/sync">
+      <obj_property name="ElementShortName">sync[0:0]</obj_property>
+      <obj_property name="ObjectShortName">sync[0:0]</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_data_tready">
-      <obj_property name="ElementShortName">tx_data_tready</obj_property>
-      <obj_property name="ObjectShortName">tx_data_tready</obj_property>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_adrv9009_tx_jesd/sync_1">
+      <obj_property name="ElementShortName">sync_1[0:0]</obj_property>
+      <obj_property name="ObjectShortName">sync_1[0:0]</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/sysref">
-      <obj_property name="ElementShortName">sysref</obj_property>
-      <obj_property name="ObjectShortName">sysref</obj_property>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_phy0_rxdata">
+      <obj_property name="ElementShortName">rx_phy0_rxdata[31:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_phy0_rxdata[31:0]</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/device_clk">
-      <obj_property name="ElementShortName">device_clk</obj_property>
-      <obj_property name="ObjectShortName">device_clk</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/link_clk">
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/link_clk">
       <obj_property name="ElementShortName">link_clk</obj_property>
       <obj_property name="ObjectShortName">link_clk</obj_property>
    </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_phy0_txdata">
-      <obj_property name="ElementShortName">tx_phy0_txdata[63:0]</obj_property>
-      <obj_property name="ObjectShortName">tx_phy0_txdata[63:0]</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/device_clk">
+      <obj_property name="ElementShortName">device_clk</obj_property>
+      <obj_property name="ObjectShortName">device_clk</obj_property>
    </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_phy0_txheader">
-      <obj_property name="ElementShortName">tx_phy0_txheader[1:0]</obj_property>
-      <obj_property name="ObjectShortName">tx_phy0_txheader[1:0]</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/rx_device_clk">
+      <obj_property name="ElementShortName">rx_device_clk</obj_property>
+      <obj_property name="ObjectShortName">rx_device_clk</obj_property>
    </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/jesd204_phy/GT_Serial_gtx_p">
-      <obj_property name="ElementShortName">GT_Serial_gtx_p[3:0]</obj_property>
-      <obj_property name="ObjectShortName">GT_Serial_gtx_p[3:0]</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/rx_device_clk_out">
+      <obj_property name="ElementShortName">rx_device_clk_out</obj_property>
+      <obj_property name="ObjectShortName">rx_device_clk_out</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/tx_device_clk_out">
+      <obj_property name="ElementShortName">tx_device_clk_out</obj_property>
+      <obj_property name="ObjectShortName">tx_device_clk_out</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_axi_core_reset">
+      <obj_property name="ElementShortName">rx_axi_core_reset</obj_property>
+      <obj_property name="ObjectShortName">rx_axi_core_reset</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_axi_device_reset">
+      <obj_property name="ElementShortName">rx_axi_device_reset</obj_property>
+      <obj_property name="ObjectShortName">rx_axi_device_reset</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tdata">
+      <obj_property name="ElementShortName">rx_data_tdata[127:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tdata[127:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tvalid">
+      <obj_property name="ElementShortName">rx_data_tvalid</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tvalid</obj_property>
    </wvobject>
    <wvobject fp_name="divider170" type="divider">
       <obj_property name="label">Ex Rx</obj_property>
       <obj_property name="DisplayName">label</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /i_slip">
-      <obj_property name="ElementShortName">i_slip</obj_property>
-      <obj_property name="ObjectShortName">i_slip</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/rx_sysref_0">
+      <obj_property name="ElementShortName">rx_sysref_0</obj_property>
+      <obj_property name="ObjectShortName">rx_sysref_0</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /i_slip_done">
-      <obj_property name="ElementShortName">i_slip_done</obj_property>
-      <obj_property name="ObjectShortName">i_slip_done</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /valid_header">
-      <obj_property name="ElementShortName">valid_header</obj_property>
-      <obj_property name="ObjectShortName">valid_header</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/sysref_1">
+      <obj_property name="ElementShortName">sysref_1</obj_property>
+      <obj_property name="ObjectShortName">sysref_1</obj_property>
    </wvobject>
    <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/rx_data_0">
-      <obj_property name="ElementShortName">rx_data_0[63:0]</obj_property>
-      <obj_property name="ObjectShortName">rx_data_0[63:0]</obj_property>
+      <obj_property name="ElementShortName">rx_data_0[31:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_0[31:0]</obj_property>
    </wvobject>
    <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/rx_header_0">
       <obj_property name="ElementShortName">rx_header_0[1:0]</obj_property>
@@ -107,8 +118,8 @@
       <obj_property name="ObjectShortName">rx_block_sync_0</obj_property>
    </wvobject>
    <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tdata">
-      <obj_property name="ElementShortName">rx_data_tdata[383:0]</obj_property>
-      <obj_property name="ObjectShortName">rx_data_tdata[383:0]</obj_property>
+      <obj_property name="ElementShortName">rx_data_tdata[127:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tdata[127:0]</obj_property>
    </wvobject>
    <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tvalid">
       <obj_property name="ElementShortName">rx_data_tvalid</obj_property>
@@ -131,8 +142,8 @@
       <obj_property name="ObjectShortName">tx_data_tready</obj_property>
    </wvobject>
    <wvobject type="array" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/tx_phy0_txdata">
-      <obj_property name="ElementShortName">tx_phy0_txdata[63:0]</obj_property>
-      <obj_property name="ObjectShortName">tx_phy0_txdata[63:0]</obj_property>
+      <obj_property name="ElementShortName">tx_phy0_txdata[31:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_phy0_txdata[31:0]</obj_property>
    </wvobject>
    <wvobject type="array" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/tx_phy0_txheader">
       <obj_property name="ElementShortName">tx_phy0_txheader[1:0]</obj_property>
@@ -145,33 +156,5 @@
    <wvobject fp_name="divider170" type="divider">
       <obj_property name="label">DUT RX</obj_property>
       <obj_property name="DisplayName">label</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/rx_adapt_0/rxdata">
-      <obj_property name="ElementShortName">rxdata[127:0]</obj_property>
-      <obj_property name="ObjectShortName">rxdata[127:0]</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/rx_adapt_0/rxheader">
-      <obj_property name="ElementShortName">rxheader[5:0]</obj_property>
-      <obj_property name="ObjectShortName">rxheader[5:0]</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/rx_adapt_0/rxgearboxslip">
-      <obj_property name="ElementShortName">rxgearboxslip</obj_property>
-      <obj_property name="ObjectShortName">rxgearboxslip</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/device_clk">
-      <obj_property name="ElementShortName">device_clk</obj_property>
-      <obj_property name="ObjectShortName">device_clk</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/link_clk">
-      <obj_property name="ElementShortName">link_clk</obj_property>
-      <obj_property name="ObjectShortName">link_clk</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test_harness/adc_jesd204_link/rx_data_tdata">
-      <obj_property name="ElementShortName">rx_data_tdata[383:0]</obj_property>
-      <obj_property name="ObjectShortName">rx_data_tdata[383:0]</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/rx_data_tvalid">
-      <obj_property name="ElementShortName">rx_data_tvalid</obj_property>
-      <obj_property name="ObjectShortName">rx_data_tvalid</obj_property>
    </wvobject>
 </wave_config>

--- a/adrv9009/waves/cfg1.wcfg
+++ b/adrv9009/waves/cfg1.wcfg
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wave_config>
+   <wave_state>
+   </wave_state>
+   <db_ref_list>
+      <db_ref path="system_tb_behav.wdb" id="1">
+         <top_modules>
+            <top_module name="adi_jesd204_pkg" />
+            <top_module name="adi_peripheral_pkg" />
+            <top_module name="adi_regmap_adc_pkg" />
+            <top_module name="adi_regmap_dac_pkg" />
+            <top_module name="adi_regmap_jesd_rx_pkg" />
+            <top_module name="adi_regmap_jesd_tx_pkg" />
+            <top_module name="adi_regmap_pkg" />
+            <top_module name="adi_regmap_xcvr_pkg" />
+            <top_module name="adi_xcvr_pkg" />
+            <top_module name="axi4stream_vip_pkg" />
+            <top_module name="axi_vip_pkg" />
+            <top_module name="glbl" />
+            <top_module name="ipif_pkg" />
+            <top_module name="logger_pkg" />
+            <top_module name="m_axi_sequencer_pkg" />
+            <top_module name="reg_accessor_pkg" />
+            <top_module name="s_axi_sequencer_pkg" />
+            <top_module name="std" />
+            <top_module name="system_tb" />
+            <top_module name="test_harness_ddr_axi_vip_0_pkg" />
+            <top_module name="test_harness_env_pkg" />
+            <top_module name="test_harness_mng_axi_vip_0_pkg" />
+            <top_module name="vpkg" />
+            <top_module name="xil_common_vip_pkg" />
+         </top_modules>
+      </db_ref>
+   </db_ref_list>
+   <zoom_setting>
+      <ZoomStartTime time="10.174033350 us"></ZoomStartTime>
+      <ZoomEndTime time="117.529033351 us"></ZoomEndTime>
+      <Cursor1Time time="90.311430282 us"></Cursor1Time>
+   </zoom_setting>
+   <column_width_setting>
+      <NameColumnWidth column_width="177"></NameColumnWidth>
+      <ValueColumnWidth column_width="205"></ValueColumnWidth>
+   </column_width_setting>
+   <WVObjectSize size="33" />
+   <wvobject fp_name="divider170" type="divider">
+      <obj_property name="label">DUT TX</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_data_tdata">
+      <obj_property name="ElementShortName">tx_data_tdata[383:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_data_tdata[383:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_data_tready">
+      <obj_property name="ElementShortName">tx_data_tready</obj_property>
+      <obj_property name="ObjectShortName">tx_data_tready</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/sysref">
+      <obj_property name="ElementShortName">sysref</obj_property>
+      <obj_property name="ObjectShortName">sysref</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/device_clk">
+      <obj_property name="ElementShortName">device_clk</obj_property>
+      <obj_property name="ObjectShortName">device_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/dac_jesd204_link/link_clk">
+      <obj_property name="ElementShortName">link_clk</obj_property>
+      <obj_property name="ObjectShortName">link_clk</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_phy0_txdata">
+      <obj_property name="ElementShortName">tx_phy0_txdata[63:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_phy0_txdata[63:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/dac_jesd204_link/tx_phy0_txheader">
+      <obj_property name="ElementShortName">tx_phy0_txheader[1:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_phy0_txheader[1:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/jesd204_phy/GT_Serial_gtx_p">
+      <obj_property name="ElementShortName">GT_Serial_gtx_p[3:0]</obj_property>
+      <obj_property name="ObjectShortName">GT_Serial_gtx_p[3:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider170" type="divider">
+      <obj_property name="label">Ex Rx</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /i_slip">
+      <obj_property name="ElementShortName">i_slip</obj_property>
+      <obj_property name="ObjectShortName">i_slip</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /i_slip_done">
+      <obj_property name="ElementShortName">i_slip_done</obj_property>
+      <obj_property name="ObjectShortName">i_slip_done</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/inst/\genblk2.i_xch_0 /\genblk1.i_sync_header_align /valid_header">
+      <obj_property name="ElementShortName">valid_header</obj_property>
+      <obj_property name="ObjectShortName">valid_header</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/rx_data_0">
+      <obj_property name="ElementShortName">rx_data_0[63:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_0[63:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/rx_header_0">
+      <obj_property name="ElementShortName">rx_header_0[1:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_header_0[1:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/util_xcvr/rx_block_sync_0">
+      <obj_property name="ElementShortName">rx_block_sync_0</obj_property>
+      <obj_property name="ObjectShortName">rx_block_sync_0</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tdata">
+      <obj_property name="ElementShortName">rx_data_tdata[383:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tdata[383:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_rx_jesd_exerciser/axi_jesd/rx_data_tvalid">
+      <obj_property name="ElementShortName">rx_data_tvalid</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tvalid</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider170" type="divider">
+      <obj_property name="label">Ex Tx</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/device_clk">
+      <obj_property name="ElementShortName">device_clk</obj_property>
+      <obj_property name="ObjectShortName">device_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/link_clk">
+      <obj_property name="ElementShortName">link_clk</obj_property>
+      <obj_property name="ObjectShortName">link_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/tx_data_tready">
+      <obj_property name="ElementShortName">tx_data_tready</obj_property>
+      <obj_property name="ObjectShortName">tx_data_tready</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/tx_phy0_txdata">
+      <obj_property name="ElementShortName">tx_phy0_txdata[63:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_phy0_txdata[63:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/axi_jesd/tx_phy0_txheader">
+      <obj_property name="ElementShortName">tx_phy0_txheader[1:0]</obj_property>
+      <obj_property name="ObjectShortName">tx_phy0_txheader[1:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/i_tx_jesd_exerciser/util_xcvr/tx_0_p">
+      <obj_property name="ElementShortName">tx_0_p</obj_property>
+      <obj_property name="ObjectShortName">tx_0_p</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider170" type="divider">
+      <obj_property name="label">DUT RX</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/rx_adapt_0/rxdata">
+      <obj_property name="ElementShortName">rxdata[127:0]</obj_property>
+      <obj_property name="ObjectShortName">rxdata[127:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/rx_adapt_0/rxheader">
+      <obj_property name="ElementShortName">rxheader[5:0]</obj_property>
+      <obj_property name="ObjectShortName">rxheader[5:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/rx_adapt_0/rxgearboxslip">
+      <obj_property name="ElementShortName">rxgearboxslip</obj_property>
+      <obj_property name="ObjectShortName">rxgearboxslip</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/device_clk">
+      <obj_property name="ElementShortName">device_clk</obj_property>
+      <obj_property name="ObjectShortName">device_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/link_clk">
+      <obj_property name="ElementShortName">link_clk</obj_property>
+      <obj_property name="ObjectShortName">link_clk</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/adc_jesd204_link/rx_data_tdata">
+      <obj_property name="ElementShortName">rx_data_tdata[383:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tdata[383:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/adc_jesd204_link/rx_data_tvalid">
+      <obj_property name="ElementShortName">rx_data_tvalid</obj_property>
+      <obj_property name="ObjectShortName">rx_data_tvalid</obj_property>
+   </wvobject>
+</wave_config>

--- a/common/sv/adi_xcvr_pkg.sv
+++ b/common/sv/adi_xcvr_pkg.sv
@@ -524,20 +524,26 @@ package adi_xcvr_pkg;
     //    ref clock
     // -----------------
     task setup_clocks(longint unsigned lane_rate,
-                      int unsigned ref_clk);
+                      int unsigned ref_clk,
+                      pll_type_t plls_to_try[] = {});
 
       int pll_idx;
       pll_type_t pll_type;
+      pll_type_t invalid_plls[$];
       out_clk_sel_t out_clk_sel;
       int out_div;
       int pll_success = 0;
 
-      pll_type_t plls_to_try[];
-
       case (xcvr_type)
         GTXE2:
           begin
-            plls_to_try = '{QPLL0, CPLL};
+            if (plls_to_try.size() == 0)
+              plls_to_try = '{QPLL0, CPLL};
+
+            invalid_plls = plls_to_try.find(x) with (x == QPLL1);
+            if (invalid_plls.size() != 0)
+              `ERROR(("QPLL1 is not supported on GTXE2"));
+
             out_clk_sel = OUTCLKPMA;
           end
         GTHE3,
@@ -545,7 +551,8 @@ package adi_xcvr_pkg;
         GTYE3_NOT_SUPPORTED,
         GTYE4:
           begin
-            plls_to_try = '{QPLL0, QPLL1, CPLL};
+            if (plls_to_try.size() == 0)
+              plls_to_try = '{QPLL0, QPLL1, CPLL};
             out_clk_sel = PROGDIVCLK;
           end
         default:

--- a/common/test_harness/test_harness_system_bd.tcl
+++ b/common/test_harness/test_harness_system_bd.tcl
@@ -151,21 +151,21 @@ ad_cpu_interconnect 0x41200000 axi_intc
 ad_mem_hp0_interconnect sys_mem_clk ddr_axi_vip/S_AXI
 
 # connect mng_vip to ddr_vip
-set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect]
-ad_connect axi_cpu_interconnect/M01_AXI /axi_mem_interconnect/S00_AXI
+# set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect]
+#ad_connect axi_cpu_interconnect/M01_AXI /axi_mem_interconnect/S00_AXI
 
-global sys_mem_clk_index
-incr sys_mem_clk_index
-set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] [get_bd_cells axi_mem_interconnect]
-ad_connect sys_cpu_clk axi_mem_interconnect/ACLK$sys_mem_clk_index
+#global sys_mem_clk_index
+# incr sys_mem_clk_index
+# set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] [get_bd_cells axi_mem_interconnect]
+# ad_connect sys_cpu_clk axi_mem_interconnect/ACLK$sys_mem_clk_index
 
 #fake an ad_cpu_interconnect
-global sys_cpu_interconnect_index
-incr sys_cpu_interconnect_index
-#fake an ad_mem_hpx_interconnect
-global sys_mem_interconnect_index
-incr sys_mem_interconnect_index
+# global sys_cpu_interconnect_index
+# incr sys_cpu_interconnect_index
+# #fake an ad_mem_hpx_interconnect
+# global sys_mem_interconnect_index
+# incr sys_mem_interconnect_index
 
-# Set DDR VIP to a range of 2G 
-create_bd_addr_seg -range 0x80000000 -offset 0x80000000 [get_bd_addr_spaces /mng_axi_vip/Master_AXI] \
-  [get_bd_addr_segs ddr_axi_vip/S_AXI/Reg] SEG_mng_ddr_cntlr
+# # Set DDR VIP to a range of 2G 
+# create_bd_addr_seg -range 0x80000000 -offset 0x80000000 [get_bd_addr_spaces /mng_axi_vip/Master_AXI] \
+#   [get_bd_addr_segs ddr_axi_vip/S_AXI/Reg] SEG_mng_ddr_cntlr


### PR DESCRIPTION
- This testbench supports link layer loop back for every link(TX, RX. RX_OBSERVATION) implemented with jesd_exercisers
- Supports DMA/DDS tests for every link
- CFG files support JESD configurations only with NP=16 and F<8
- RX and RX_OBSERVATION links work with maximum of 2 lanes each
