### PR TITLE
jesd_exerciser.tcl: Bug fixes

### DIFF
--- a/common/test_harness/jesd_exerciser.tcl
+++ b/common/test_harness/jesd_exerciser.tcl
@@ -95,6 +95,10 @@ proc create_jesd_exerciser { \
                                                   $SAMPLE_WIDTH \
                                                   $TPL_DATAPATH_WIDTH \
                                                   $DMA_SAMPLE_WIDTH
+  
+  if {$TX_OR_RX_N == 0} {
+    ad_ip_parameter ${rxtx}_tpl_core/adc_tpl_core CONFIG.EN_FRAME_ALIGN {0}
+  }
 
   for {set i 0} {$i < $NUM_OF_LANES} {incr i} {
     ad_xcvrpll  ref_clk  util_xcvr/cpll_ref_clk_$i
@@ -113,6 +117,9 @@ proc create_jesd_exerciser { \
 
   if {$TX_OR_RX_N == 1} {
     ad_connect tx_tpl_core/link axi_jesd/tx_data
+    for {set i 0} {$i < $NUM_OF_CONVERTERS} {incr i} {
+      make_bd_pins_external [get_bd_pins tx_tpl_core/dac_data_$i]
+    }
   } else {
     ad_connect axi_jesd/rx_data_tdata  rx_tpl_core/link_data
     ad_connect axi_jesd/rx_data_tvalid rx_tpl_core/link_valid


### PR DESCRIPTION
- Made dac_data pins external for possible jesd_exerciser DMA tests
- Disable ADC_TPL_CORE frame aligner