### PR TITLE
DMA testbench related updates

### DIFF
--- a/common/sv/adi_regmap_dmac_pkg.sv
+++ b/common/sv/adi_regmap_dmac_pkg.sv
@@ -33,7 +33,7 @@
 // ***************************************************************************
 // ***************************************************************************
 /* Auto generated Register Map */
-/* Mon Feb  7 12:05:09 2022 */
+/* Tue May  3 15:36:59 2022 */
 
 package adi_regmap_dmac_pkg;
   import adi_regmap_pkg::*;
@@ -72,8 +72,7 @@ package adi_regmap_dmac_pkg;
     "DMA_TYPE_DEST": '{ 5, 4, R, 0 },
     "BYTES_PER_BEAT_SRC_LOG2": '{ 11, 8, R, 0 },
     "DMA_TYPE_SRC": '{ 13, 12, R, 0 },
-    "BYTES_PER_BURST_WIDTH": '{ 19, 16, R, 0 },
-    "DMA_2D_TRANSFER": '{ 20, 20, R, 0 }}};
+    "BYTES_PER_BURST_WIDTH": '{ 19, 16, R, 0 }}};
   `define SET_DMAC_INTERFACE_DESCRIPTION_BYTES_PER_BEAT_DEST_LOG2(x) SetField(DMAC_INTERFACE_DESCRIPTION,"BYTES_PER_BEAT_DEST_LOG2",x)
   `define GET_DMAC_INTERFACE_DESCRIPTION_BYTES_PER_BEAT_DEST_LOG2(x) GetField(DMAC_INTERFACE_DESCRIPTION,"BYTES_PER_BEAT_DEST_LOG2",x)
   `define SET_DMAC_INTERFACE_DESCRIPTION_DMA_TYPE_DEST(x) SetField(DMAC_INTERFACE_DESCRIPTION,"DMA_TYPE_DEST",x)
@@ -84,8 +83,6 @@ package adi_regmap_dmac_pkg;
   `define GET_DMAC_INTERFACE_DESCRIPTION_DMA_TYPE_SRC(x) GetField(DMAC_INTERFACE_DESCRIPTION,"DMA_TYPE_SRC",x)
   `define SET_DMAC_INTERFACE_DESCRIPTION_BYTES_PER_BURST_WIDTH(x) SetField(DMAC_INTERFACE_DESCRIPTION,"BYTES_PER_BURST_WIDTH",x)
   `define GET_DMAC_INTERFACE_DESCRIPTION_BYTES_PER_BURST_WIDTH(x) GetField(DMAC_INTERFACE_DESCRIPTION,"BYTES_PER_BURST_WIDTH",x)
-  `define SET_DMAC_INTERFACE_DESCRIPTION_DMA_2D_TRANSFER(x) SetField(DMAC_INTERFACE_DESCRIPTION,"DMA_2D_TRANSFER",x)
-  `define GET_DMAC_INTERFACE_DESCRIPTION_DMA_2D_TRANSFER(x) GetField(DMAC_INTERFACE_DESCRIPTION,"DMA_2D_TRANSFER",x)
 
   const reg_t DMAC_IRQ_MASK = '{ 'h0080, "IRQ_MASK" , '{
     "TRANSFER_COMPLETED": '{ 1, 1, RW, 'h1 },

--- a/common/sv/axi_dmac_pkg.sv
+++ b/common/sv/axi_dmac_pkg.sv
@@ -39,24 +39,10 @@ typedef struct {
   int ID;
   int DMA_DATA_WIDTH_SRC;
   int DMA_DATA_WIDTH_DEST;
-//  int DMA_LENGTH_WIDTH;
   int DMA_2D_TRANSFER;
-//  int ASYNC_CLK_REQ_SRC;
-//  int ASYNC_CLK_SRC_DEST;
-//  int ASYNC_CLK_DEST_REQ;
-//  int AXI_SLICE_DEST;
-//  int AXI_SLICE_SRC;
-//  int SYNC_TRANSFER_START;
-//  int CYCLIC;
-//  int DMA_AXI_PROTOCOL_SRC;
-//  int DMA_AXI_PROTOCOL_DEST;
   int DMA_TYPE_SRC;
   int DMA_TYPE_DEST;
-//  int DMA_AXI_ADDR_WIDTH;
   int MAX_BYTES_PER_BURST;
-//  int FIFO_SIZE;
-//  int DISABLE_DEBUG_REGISTERS;
-//  int ENABLE_DIAGNOSTICS_IF;
 } axi_dmac_params_t;
 
 endpackage

--- a/common/sv/dmac_api.sv
+++ b/common/sv/dmac_api.sv
@@ -75,7 +75,15 @@ package dmac_api_pkg;
       p.DMA_TYPE_SRC = `GET_DMAC_INTERFACE_DESCRIPTION_DMA_TYPE_SRC(val);
       bpb_width_log2 = `GET_DMAC_INTERFACE_DESCRIPTION_BYTES_PER_BURST_WIDTH(val);            
       p.MAX_BYTES_PER_BURST = 2**bpb_width_log2;
-      p.DMA_2D_TRANSFER = `GET_DMAC_INTERFACE_DESCRIPTION_DMA_2D_TRANSFER(val);               
+      this.bus.RegWrite32(this.base_address + GetAddrs(DMAC_Y_LENGTH),
+                                SetField(DMAC_Y_LENGTH, "Y_LENGTH", 32'hFFFFFFFF));
+      this.bus.RegRead32(this.base_address + GetAddrs(DMAC_Y_LENGTH), val);
+      if (val==0) begin
+        p.DMA_2D_TRANSFER = 0;
+      end else begin 
+        p.DMA_2D_TRANSFER = 1;
+        this.bus.RegWrite32(this.base_address + GetAddrs(DMAC_Y_LENGTH), 32'h0);
+      end
     endtask : discover_params
 
     // -----------------

--- a/dma_loopback/tests/test_program.sv
+++ b/dma_loopback/tests/test_program.sv
@@ -48,7 +48,7 @@ import dma_trans_pkg::*;
 
 `define RX_DMA      32'h7c42_0000
 `define TX_DMA      32'h7c43_0000
-`define DDR_BASE    32'h8000_0000
+`define DDR_BASE    32'h44A0_0000
 
 program test_program;
 


### PR DESCRIPTION
1. Removed the DMA_2D_TRANSFER functions; used a write-read procedure to determine its value instead
2. Updated the DDR_BASE for the dma_loopback test