### PR TITLE
adrv9001/fmmcoms2: Fix up_adc_common minor version in sanity test

### DIFF
--- a/adrv9001/tests/test_program.sv
+++ b/adrv9001/tests/test_program.sv
@@ -220,9 +220,9 @@ program test_program;
 
     //check ADC VERSION
     axi_read_v (RX1_COMMON + GetAddrs(REG_VERSION),
-                    `SET_REG_VERSION_VERSION('h000a0162));
+                    `SET_REG_VERSION_VERSION('h000a0262));
     axi_read_v (RX2_COMMON + GetAddrs(REG_VERSION),
-                    `SET_REG_VERSION_VERSION('h000a0162));
+                    `SET_REG_VERSION_VERSION('h000a0262));
     //check DAC VERSION
     axi_read_v (TX1_COMMON + GetAddrs(REG_VERSION),
                     `SET_REG_VERSION_VERSION('h00090162));

--- a/fmcomms2/tests/test_program.sv
+++ b/fmcomms2/tests/test_program.sv
@@ -154,7 +154,7 @@ program test_program;
   begin
     //check ADC VERSION
     axi_read_v (RX1_COMMON + GetAddrs(REG_VERSION),
-               `SET_REG_VERSION_VERSION('h000a0162));
+               `SET_REG_VERSION_VERSION('h000a0262));
     //check DAC VERSION
     axi_read_v (TX1_COMMON + GetAddrs(REG_VERSION),
                `SET_REG_VERSION_VERSION('h00090162));


### PR DESCRIPTION
Version 1:

- Updated minor version to the current one (32'h000a0262 -  in hdl master [branch](https://github.com/analogdevicesinc/hdl/blob/master/library/common/up_adc_common.v) - [commit](https://github.com/analogdevicesinc/hdl/commit/045327c8dbf14ad166b275389252e0756d8ba8b6);