### PR TITLE
test_harness_system_bd: Fix axi_cpu_interconnect bug for MI >= 16

### DIFF
--- a/common/test_harness/test_harness_system_bd.tcl
+++ b/common/test_harness/test_harness_system_bd.tcl
@@ -153,8 +153,21 @@ ad_cpu_interconnect 0x41200000 axi_intc
 ad_mem_hp0_interconnect sys_mem_clk ddr_axi_vip/S_AXI
 
 # connect mng_vip to ddr_vip
-set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect]
-ad_connect axi_cpu_interconnect/M01_AXI /axi_mem_interconnect/S00_AXI
+ad_ip_instance smartconnect interconnect [list \
+  NUM_MI 2 \
+  NUM_SI 1 \
+  NUM_CLKS 2 \
+]
+
+delete_bd_objs [get_bd_intf_nets mng_axi_vip_M_AXI]
+
+ad_connect sys_cpu_clk interconnect/aclk
+ad_connect sys_mem_clk interconnect/aclk1
+ad_connect sys_cpu_resetn interconnect/aresetn
+
+ad_connect mng_axi_vip/M_AXI interconnect/S00_AXI
+ad_connect interconnect/M00_AXI axi_cpu_interconnect/S00_AXI
+ad_connect interconnect/M01_AXI axi_mem_interconnect/S00_AXI
 
 global sys_mem_clk_index
 incr sys_mem_clk_index


### PR DESCRIPTION
In **test_harness** block design, **axi_mem_interconnect** is connected to **axi_cpu_interconnect** but in case **axi_cpu_interconnect** has more than 16 interfaces connected, a smartconnect error will occur: _"ERROR: [xilinx.com:ip:smartconnect:1.0-1] test_harness_axi_cpu_interconnect_0: For SmartConnect test_harness_axi_cpu_interconnect_0, the use of >16 MI is reserved for low-bandwidth pathways only. Either the SI must be AXI4LITE or all MI must be 32-bit-wide AXI4LITE. Otherwise, you may cascade multiple instances with <=16 MI"_.
So in order to solve this another smartconnect is used to separate the **axi_mem_interconnect** from the **axi_cpu_interconnect**!
This was tested only for the adrv9009 Testbench!