### PR TITLE
common: add use_smartconnect option

### DIFF
--- a/common/test_harness/test_harness_system_bd.tcl
+++ b/common/test_harness/test_harness_system_bd.tcl
@@ -1,5 +1,6 @@
 
 #global mng_axi_cfg
+global use_smartconnect
 # axi lite management port
 set mng_axi_cfg [ list \
    ADDR_WIDTH {32} \
@@ -157,9 +158,16 @@ set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect]
 ad_connect axi_cpu_interconnect/M01_AXI /axi_mem_interconnect/S00_AXI
 
 global sys_mem_clk_index
-incr sys_mem_clk_index
-set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] [get_bd_cells axi_mem_interconnect]
-ad_connect sys_cpu_clk axi_mem_interconnect/ACLK$sys_mem_clk_index
+if { $use_smartconnect == 1} {
+  incr sys_mem_clk_index
+  set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] [get_bd_cells axi_mem_interconnect]
+  ad_connect sys_cpu_clk axi_mem_interconnect/ACLK$sys_mem_clk_index
+} else {
+  ad_connect sys_cpu_clk axi_cpu_interconnect/M01_ACLK
+  ad_connect sys_cpu_clk axi_mem_interconnect/S00_ACLK
+  ad_connect sys_cpu_resetn axi_cpu_interconnect/M01_ARESETN
+  ad_connect sys_cpu_resetn axi_mem_interconnect/S00_ARESETN
+}
 
 #fake an ad_cpu_interconnect
 global sys_cpu_interconnect_index

--- a/pulsar_adc_pmdz/system_project.tcl
+++ b/pulsar_adc_pmdz/system_project.tcl
@@ -15,6 +15,9 @@ source "cfgs/${cfg_file}"
 # Set the project name
 set project_name [file rootname $cfg_file]
 
+# Set to use SmartConnect or AXI Interconnect
+set use_smartconnect 1
+
 # Create the project
 adi_sim_project_xilinx $project_name "xcvu9p-flga2104-2L-e"
 

--- a/scripts/adi_sim.tcl
+++ b/scripts/adi_sim.tcl
@@ -10,6 +10,7 @@ proc adi_sim_add_define {value} {
 proc adi_sim_project_xilinx {project_name {part "xc7vx485tffg1157-1"}} {
   global design_name
   global ad_project_params
+  global use_smartconnect
 
   # Create project
   create_project ${project_name} ./runs/${project_name} -part $part -force


### PR DESCRIPTION
Use SmartConnect global variable sets to use SmartConnect or AXI Interconnect for both cpu and mem.
By default, it is set to 1.
Should be merged alongside analogdevicesinc/hdl#1054 .