### PR TITLE
Default running all tbs in all cfgs

### DIFF
--- a/pulsar_adc_pmdz/Makefile
+++ b/pulsar_adc_pmdz/Makefile
@@ -37,17 +37,17 @@ LIB_DEPS += spi_engine/spi_engine_interconnect
 LIB_DEPS += spi_engine/spi_engine_offload
 LIB_DEPS += sysid_rom
 
-# default test program
-TP := test_program
+# default test programs
+# Format is: <test name>
+TP := $(notdir $(basename $(wildcard tests/*.sv)))
 
 # config files should have the following format
 #  cfg_<param1>_<param2>.tcl
 CFG_FILES := $(notdir $(wildcard cfgs/cfg*.tcl))
-#$(warning $(CFG_FILES))
 
 # List of tests and configuration combinations that has to be run
 # Format is:  <configuration>:<test name>
-TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(cfg):$(TP))
+TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(addprefix $(cfg):, $(TP)))
 
 include ../scripts/project-sim.mk
 


### PR DESCRIPTION
I think the current default approach of having a single test program to run at every configuration is counter-intuitive.
I updated the pulsar_adc Makefile to take an array of programs, and then **for each test program** and **for each cfg**, run the testbench.
For the pulsar_adc that means ``make`` runs both test_program and  test_sleep_delay run in cfg1.

Of course, we could do it manually:
```
TESTS += cfg1:test_program 
TESTS += cfg1:test_sleep_delay
```
but the whole point of this pr and discussion is to default running all tbs in all cfgs.

If this idea is well received, I would update all tbs to use ``addprefix``, except the ones that define ``TESTS`` manually.