### PR TITLE
common: hotfix add use_smartconnect

### DIFF
--- a/common/test_harness/test_harness_system_bd.tcl
+++ b/common/test_harness/test_harness_system_bd.tcl
@@ -1,6 +1,10 @@
 
 #global mng_axi_cfg
 global use_smartconnect
+if {[expr {![info exists use_smartconnect]}]} {
+  set use_smartconnect 1
+}
+
 # axi lite management port
 set mng_axi_cfg [ list \
    ADDR_WIDTH {32} \


### PR DESCRIPTION
Sets default value to use_smartconnenct.
Previously I thought it would take from somewhere else for every tb, but that preconception is false since #54 is failing rebased to main.