### PR TITLE
ad7616: Update tb

### DIFF
--- a/ad7616/cfgs/cfg_pi.tcl
+++ b/ad7616/cfgs/cfg_pi.tcl
@@ -1,3 +1,3 @@
 global ad_project_params
 
-set ad_project_params(SI_OR_PI) 1
+set ad_project_params(SER_PAR_N) 0

--- a/ad7616/cfgs/cfg_si.tcl
+++ b/ad7616/cfgs/cfg_si.tcl
@@ -1,3 +1,3 @@
 global ad_project_params
 
-set ad_project_params(SI_OR_PI) 0
+set ad_project_params(SER_PAR_N) 1

--- a/ad7616/system_bd.tcl
+++ b/ad7616/system_bd.tcl
@@ -36,7 +36,7 @@
 source ../../scripts/adi_env.tcl
 
 # system level parameters
-set SI_OR_PI  $ad_project_params(SI_OR_PI)
+set SER_PAR_N  $ad_project_params(SER_PAR_N)
 
 global ad_project_params
 
@@ -50,7 +50,7 @@ adi_project_files [list \
 
 source ../../projects/ad7616_sdz/common/ad7616_bd.tcl
 
-if {$SI_OR_PI == 0} {
+if {$SER_PAR_N == 1} {
 
   create_bd_port -dir O spi_clk
   create_bd_port -dir O irq
@@ -58,12 +58,10 @@ if {$SI_OR_PI == 0} {
   ad_connect spi_clk sys_cpu_clk
   ad_connect irq spi_ad7616/irq
 
-} elseif {$SI_OR_PI == 1} {
+} else {
 
   create_bd_port -dir O sys_clk
-  create_bd_port -dir O irq
-
+  ad_disconnect  spi_clk ad7616_pwm_gen/ext_clk
+  ad_connect  sys_cpu_clk ad7616_pwm_gen/ext_clk
   ad_connect sys_clk sys_cpu_clk
-  ad_connect irq axi_ad7616/irq
-
 }

--- a/ad7616/system_project.tcl
+++ b/ad7616/system_project.tcl
@@ -15,6 +15,26 @@ source "cfgs/${cfg_file}"
 # Set the project name
 set project_name [file rootname $cfg_file]
 
+# Set project params
+global ad_project_params
+
+set SER_PAR_N $ad_project_params(SER_PAR_N)
+
+#set a default test program
+if {$SER_PAR_N == 1} {
+  adi_sim_add_define "TEST_PROGRAM=test_program_si"
+} elseif {$SER_PAR_N == 0} {
+  adi_sim_add_define "TEST_PROGRAM=test_program_pi"
+} else {
+  adi_sim_add_define "TEST_PROGRAM=test_program_si"
+}
+
+#global mng_axi_cfg
+global use_smartconnect
+if {[expr {![info exists use_smartconnect]}]} {
+  set use_smartconnect 1
+}
+
 # Create the project
 adi_sim_project_xilinx $project_name "xcvu9p-flga2104-2L-e"
 
@@ -36,8 +56,5 @@ adi_sim_project_files [list \
  "tests/test_program_si.sv" \
  "tests/test_program_pi.sv" \
  "system_tb.sv"]
-
-#set a default test program
-adi_sim_add_define "TEST_PROGRAM=test_program_si"
 
 adi_sim_generate $project_name

--- a/ad7616/system_tb.sv
+++ b/ad7616/system_tb.sv
@@ -39,7 +39,7 @@
 
 module system_tb();
     generate
-    if (`SI_OR_PI == 0) begin
+    if (`SER_PAR_N == 1) begin //serial interface
       wire       ad7616_spi_sclk;
       wire       ad7616_spi_sdo;
       wire [1:0] ad7616_spi_sdi;
@@ -48,27 +48,27 @@ module system_tb();
       wire       adc_cnvst;
       wire       spi_clk;
       wire       irq;
-  
+
     `TEST_PROGRAM test(
       .spi_clk (spi_clk),
       .irq (irq),
       .ad7616_spi_sdi(ad7616_spi_sdi),
       .ad7616_spi_cs (ad7616_spi_cs),
-      .ad7616_spi_sclk (ad7616_spi_sclk));   
-  
+      .ad7616_spi_sclk (ad7616_spi_sclk));
+
     test_harness `TH (
       .spi_clk (spi_clk),
       .irq (irq),
       .rx_busy (adc_busy),
       .rx_cnvst (adc_cnvst),
-      .ad7616_spi_sdo (ad7616_spi_sdo),  
-      .ad7616_spi_sdi (ad7616_spi_sdi),  
+      .ad7616_spi_sdo (ad7616_spi_sdo),
+      .ad7616_spi_sdi (ad7616_spi_sdi),
       .ad7616_spi_cs (ad7616_spi_cs),
       .ad7616_spi_sclk (ad7616_spi_sclk));
-      
+
       assign adc_busy = adc_cnvst;
     end
-    else
+    else //parallel interface
     begin
       wire        rx_cnvst;
       wire        rx_busy;
@@ -79,18 +79,17 @@ module system_tb();
       wire        rx_wr_n;
       wire        rx_cs_n;
       wire        sys_clk;
-  
+
     `TEST_PROGRAM test(
-      .rx_cnvst (rx_cnvst),
-      .rx_busy (rx_busy),
       .rx_db_i (rx_db_i),
       .rx_db_o (rx_db_o),
       .rx_db_t (rx_db_t),
       .rx_rd_n (rx_rd_n),
       .rx_wr_n (rx_wr_n),
       .rx_cs_n (rx_cs_n),
-      .sys_clk (sys_clk));
-  
+      .sys_clk (sys_clk),
+      .rx_busy (rx_busy));
+
      test_harness `TH (
       .rx_cnvst (rx_cnvst),
       .rx_busy (rx_busy),
@@ -101,8 +100,8 @@ module system_tb();
       .rx_wr_n (rx_wr_n),
       .rx_cs_n (rx_cs_n),
       .sys_clk (sys_clk));
-  
+
       assign rx_busy = rx_cnvst;
-    end    
+    end
     endgenerate
 endmodule

--- a/ad7616/tests/test_program_si.sv
+++ b/ad7616/tests/test_program_si.sv
@@ -47,6 +47,8 @@ import test_harness_env_pkg::*;
 `define AXI_PWMGEN                      32'h44B0_0000
 `define DDR_BASE                        32'h8000_0000
 
+localparam AXI_CLKGEN                 = 32'h44A7_0000;
+
 localparam SPI_ENG_ADDR_VERSION       = 32'h0000_0000;
 localparam SPI_ENG_ADDR_ID            = 32'h0000_0004;
 localparam SPI_ENG_ADDR_SCRATCH       = 32'h0000_0008;
@@ -294,7 +296,6 @@ initial begin
   end
 end
 
-
 //---------------------------------------------------------------------------
 // SDI data generator
 //---------------------------------------------------------------------------
@@ -434,7 +435,6 @@ initial begin
   end
 end
 
-
 //---------------------------------------------------------------------------
 // Offload SPI Test
 //---------------------------------------------------------------------------
@@ -445,26 +445,26 @@ task offload_spi_test;
   begin
 
     //config cnv
-    #100 axi_write (AXI_PWMGEN + 32'h00000010, 32'h00000000);
+    #100 axi_write (AXI_PWMGEN + 32'h00000010, 32'h00000001);
     #100 axi_write (AXI_PWMGEN + 32'h00000040, 'h64);
     #100 axi_write (AXI_PWMGEN + 32'h00000010, 32'h00000002);
 
     //Configure DMA
-    env.mng.RegWrite32(`AD7616_DMA+32'h400, 32'h00000001); // Enable DMA
-    env.mng.RegWrite32(`AD7616_DMA+32'h40c, 32'h00000006); // use TLAST
-    env.mng.RegWrite32(`AD7616_DMA+32'h418, (NUM_OF_TRANSFERS*4)-1); // X_LENGHTH = 1024-1
-    env.mng.RegWrite32(`AD7616_DMA+32'h410, `DDR_BASE); // DEST_ADDRESS
-    env.mng.RegWrite32(`AD7616_DMA+32'h408, 32'h00000001); // Submit transfer DMA
+    #100 axi_write (`AD7616_DMA+32'h400, 32'h00000001); // Enable DMA
+    #100 axi_write (`AD7616_DMA+32'h40c, 32'h00000006); // use TLAST
+    #100 axi_write (`AD7616_DMA+32'h418, (NUM_OF_TRANSFERS*4)-1); // X_LENGHTH = 1024-1
+    #100 axi_write (`AD7616_DMA+32'h410, `DDR_BASE); // DEST_ADDRESS
+    #100 axi_write (`AD7616_DMA+32'h408, 32'h00000001); // Submit transfer DMA
 
     // Configure the Offload module
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CFG);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_PRESCALE);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_DLENGTH);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_ON);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_RD);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_OFF);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_SYNC | 2);
-    axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_SDO, 16'hBEAF << (DATA_WIDTH - DATA_DLENGTH));
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CFG);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_PRESCALE);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_DLENGTH);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_ON);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_RD);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_OFF);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_CMD, INST_SYNC | 2);
+    #100 axi_write (AD7616_BASE + SPI_ENG_ADDR_OFFLOAD_SDO, 16'hBEAF << (DATA_WIDTH - DATA_DLENGTH));
 
     offload_status = 1;
 
@@ -504,6 +504,9 @@ bit   [31:0]  sdi_fifo_data = 0;
 
 task fifo_spi_test;
 begin
+
+  // Start spi clk generator
+  axi_write (AXI_CLKGEN + 32'h00000040, 32'h0000003);
 
   axi_write (AD7616_BASE + AD7616_CNVST_EN, 32'h00000003);
   axi_write (AD7616_BASE + AD7616_CNVST_RATE, 32'h00000128);

--- a/ad7616/waves/cfg_pi.wcfg
+++ b/ad7616/waves/cfg_pi.wcfg
@@ -5,7 +5,7 @@
    <db_ref_list>
       <db_ref path="system_tb_behav.wdb" id="1">
          <top_modules>
-            <top_module name="\$unit_logger_pkg_sv " />
+            <top_module name="\$unit_logger_pkg_sv_4101713013 " />
             <top_module name="axi4stream_vip_pkg" />
             <top_module name="axi_vip_pkg" />
             <top_module name="glbl" />
@@ -25,11 +25,53 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="0 ps"></ZoomStartTime>
-      <ZoomEndTime time="-11 ps"></ZoomEndTime>
-      <Cursor1Time time="0 ps"></Cursor1Time>
+      <ZoomStartTime time="30,754,996 ps"></ZoomStartTime>
+      <ZoomEndTime time="30,755,001 ps"></ZoomEndTime>
+      <Cursor1Time time="30,755,000 ps"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
+      <NameColumnWidth column_width="236"></NameColumnWidth>
+      <ValueColumnWidth column_width="135"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="0" />
+   <WVObjectSize size="10" />
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /rx_db_i">
+      <obj_property name="ElementShortName">rx_db_i[15:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_db_i[15:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /rx_db_t">
+      <obj_property name="ElementShortName">rx_db_t</obj_property>
+      <obj_property name="ObjectShortName">rx_db_t</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /rx_rd_n">
+      <obj_property name="ElementShortName">rx_rd_n</obj_property>
+      <obj_property name="ObjectShortName">rx_rd_n</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /rx_wr_n">
+      <obj_property name="ElementShortName">rx_wr_n</obj_property>
+      <obj_property name="ObjectShortName">rx_wr_n</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /rx_cs_n">
+      <obj_property name="ElementShortName">rx_cs_n</obj_property>
+      <obj_property name="ObjectShortName">rx_cs_n</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /rx_db_o">
+      <obj_property name="ElementShortName">rx_db_o[15:0]</obj_property>
+      <obj_property name="ObjectShortName">rx_db_o[15:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /sys_clk">
+      <obj_property name="ElementShortName">sys_clk</obj_property>
+      <obj_property name="ObjectShortName">sys_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test /rx_busy">
+      <obj_property name="ElementShortName">rx_busy</obj_property>
+      <obj_property name="ObjectShortName">rx_busy</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /dma_data_store_arr">
+      <obj_property name="ElementShortName">dma_data_store_arr[9:0][31:0]</obj_property>
+      <obj_property name="ObjectShortName">dma_data_store_arr[9:0][31:0]</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /captured_word_arr">
+      <obj_property name="ElementShortName">captured_word_arr[9:0][31:0]</obj_property>
+      <obj_property name="ObjectShortName">captured_word_arr[9:0][31:0]</obj_property>
+   </wvobject>
 </wave_config>

--- a/ad7616/waves/cfg_si.wcfg
+++ b/ad7616/waves/cfg_si.wcfg
@@ -5,7 +5,7 @@
    <db_ref_list>
       <db_ref path="system_tb_behav.wdb" id="1">
          <top_modules>
-            <top_module name="\$unit_logger_pkg_sv " />
+            <top_module name="\$unit_logger_pkg_sv_3017496229 " />
             <top_module name="axi4stream_vip_pkg" />
             <top_module name="axi_vip_pkg" />
             <top_module name="glbl" />
@@ -26,75 +26,47 @@
    </db_ref_list>
    <zoom_setting>
       <ZoomStartTime time="0.000000 us"></ZoomStartTime>
-      <ZoomEndTime time="25.455001 us"></ZoomEndTime>
-      <Cursor1Time time="25.455000 us"></Cursor1Time>
+      <ZoomEndTime time="23.349555 us"></ZoomEndTime>
+      <Cursor1Time time="26.955000 us"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
       <NameColumnWidth column_width="236"></NameColumnWidth>
-      <ValueColumnWidth column_width="139"></ValueColumnWidth>
+      <ValueColumnWidth column_width="135"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="16" />
-   <wvobject type="logic" fp_name="/system_tb/test/spi_clk">
+   <WVObjectSize size="9" />
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test_harness /ad7616_pwm_gen_pwm_0">
+      <obj_property name="ElementShortName">ad7616_pwm_gen_pwm_0</obj_property>
+      <obj_property name="ObjectShortName">ad7616_pwm_gen_pwm_0</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test_harness /rx_busy">
+      <obj_property name="ElementShortName">rx_busy</obj_property>
+      <obj_property name="ObjectShortName">rx_busy</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test_harness /rx_cnvst">
+      <obj_property name="ElementShortName">rx_cnvst</obj_property>
+      <obj_property name="ObjectShortName">rx_cnvst</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test_harness /spi_clk">
       <obj_property name="ElementShortName">spi_clk</obj_property>
       <obj_property name="ObjectShortName">spi_clk</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/adc_busy">
-      <obj_property name="ElementShortName">adc_busy</obj_property>
-      <obj_property name="ObjectShortName">adc_busy</obj_property>
+   <wvobject type="logic" fp_name="/system_tb/\genblk1.test_harness /ad7616_spi_sclk">
+      <obj_property name="ElementShortName">ad7616_spi_sclk</obj_property>
+      <obj_property name="ObjectShortName">ad7616_spi_sclk</obj_property>
    </wvobject>
-   <wvobject fp_name="divider104" type="divider">
-      <obj_property name="label">kk</obj_property>
-      <obj_property name="DisplayName">label</obj_property>
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test_harness /ad7616_spi_cs">
+      <obj_property name="ElementShortName">ad7616_spi_cs[0:0]</obj_property>
+      <obj_property name="ObjectShortName">ad7616_spi_cs[0:0]</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/ad7616_echo_sclk">
-      <obj_property name="ElementShortName">ad7616_echo_sclk</obj_property>
-      <obj_property name="ObjectShortName">ad7616_echo_sclk</obj_property>
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test_harness /ad7616_spi_sdi">
+      <obj_property name="ElementShortName">ad7616_spi_sdi[1:0]</obj_property>
+      <obj_property name="ObjectShortName">ad7616_spi_sdi[1:0]</obj_property>
    </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/m_spi_csn_negedge_s">
-      <obj_property name="ElementShortName">m_spi_csn_negedge_s</obj_property>
-      <obj_property name="ObjectShortName">m_spi_csn_negedge_s</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/sdi_shiftreg">
-      <obj_property name="ElementShortName">sdi_shiftreg[15:0]</obj_property>
-      <obj_property name="ObjectShortName">sdi_shiftreg[15:0]</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/end_of_word">
-      <obj_property name="ElementShortName">end_of_word</obj_property>
-      <obj_property name="ObjectShortName">end_of_word</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/rx_sclk_bfm">
-      <obj_property name="ElementShortName">rx_sclk_bfm</obj_property>
-      <obj_property name="ObjectShortName">rx_sclk_bfm</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/shiftreg_sampled">
-      <obj_property name="ElementShortName">shiftreg_sampled</obj_property>
-      <obj_property name="ObjectShortName">shiftreg_sampled</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/sdi_data_store">
-      <obj_property name="ElementShortName">sdi_data_store[31:0]</obj_property>
-      <obj_property name="ObjectShortName">sdi_data_store[31:0]</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/sdi_store_cnt">
-      <obj_property name="ElementShortName">sdi_store_cnt[15:0]</obj_property>
-      <obj_property name="ObjectShortName">sdi_store_cnt[15:0]</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/sdi_fifo_data">
-      <obj_property name="ElementShortName">sdi_fifo_data[31:0]</obj_property>
-      <obj_property name="ObjectShortName">sdi_fifo_data[31:0]</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/sdi_fifo_data_store">
-      <obj_property name="ElementShortName">sdi_fifo_data_store[31:0]</obj_property>
-      <obj_property name="ObjectShortName">sdi_fifo_data_store[31:0]</obj_property>
-   </wvobject>
-   <wvobject type="logic" fp_name="/system_tb/test/offload_status">
-      <obj_property name="ElementShortName">offload_status</obj_property>
-      <obj_property name="ObjectShortName">offload_status</obj_property>
-   </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/offload_sdi_data_store_arr">
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /offload_sdi_data_store_arr">
       <obj_property name="ElementShortName">offload_sdi_data_store_arr[9:0][31:0]</obj_property>
       <obj_property name="ObjectShortName">offload_sdi_data_store_arr[9:0][31:0]</obj_property>
    </wvobject>
-   <wvobject type="array" fp_name="/system_tb/test/offload_captured_word_arr">
+   <wvobject type="array" fp_name="/system_tb/\genblk1.test /offload_captured_word_arr">
       <obj_property name="ElementShortName">offload_captured_word_arr[9:0][31:0]</obj_property>
       <obj_property name="ObjectShortName">offload_captured_word_arr[9:0][31:0]</obj_property>
    </wvobject>


### PR DESCRIPTION
This commit fixes both the serial and parallel interface tests. These modifications reflect the HDL reference design updates:

1. The following IPs have been added: 
- axi_clkgen
- axi_pwm_gen

2. The configuration build parameter has been renamed to SER_PAR_N, set by default to 1, using the serial configuration.