### PR TITLE
data_offload: Add missing library dependency

### DIFF
--- a/data_offload/Makefile
+++ b/data_offload/Makefile
@@ -24,6 +24,7 @@ ENV_DEPS += ../scripts/run_sim.tcl
 
 LIB_DEPS := util_cdc
 LIB_DEPS += util_axis_fifo
+LIB_DEPS += util_do_ram
 LIB_DEPS += axi_dmac
 LIB_DEPS += data_offload
 LIB_DEPS += util_hbm

--- a/data_offload_2/Makefile
+++ b/data_offload_2/Makefile
@@ -25,6 +25,7 @@ ENV_DEPS += ../scripts/run_sim.tcl
 
 LIB_DEPS := util_cdc
 LIB_DEPS += util_axis_fifo
+LIB_DEPS += util_do_ram
 LIB_DEPS += axi_dmac
 LIB_DEPS += data_offload
 LIB_DEPS += util_hbm


### PR DESCRIPTION
Adds missing library dependency to the Makefiles. 