### PR TITLE
Lock cfgs, fix printed message, include .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+runs/
+results/
+*.log
+*.pb

--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -85,7 +85,7 @@ define sim
 $(1) += $(addprefix runs/,$(addprefix $(1)/,$(2).log))
 $(addprefix runs/,$(addprefix $(1)/,$(2).log)): $(addprefix runs/,$(1)/system_project.log) $(addprefix tests/,$(2).sv) $(SV_DEPS) FORCE
 	$(RUN_PRE_OPT)$$(call simulate, \
-		$(CMD_PRE) $(M_VIVADO) $(RUN_SIM_PATH) -tclargs $(1) $(2) $(MODE) $(CMD_POST), \
+		$(CMD_PRE) flock runs/$(1)/.lock -c "$(M_VIVADO) $(RUN_SIM_PATH) -tclargs $(1) $(2) $(MODE) $(CMD_POST)", \
 		$$@, \
 		Running $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
 		Run $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
@@ -103,7 +103,7 @@ TESTS += $(CFG):$(TST)
 endif
 endif
 
-MODE ?= "batch"
+MODE ?= batch
 
 STOP_ON_ERROR ?= y
 
@@ -149,9 +149,9 @@ $(foreach cfg, $(BUILD_CFGS), $(eval $(call build, $(cfg))))
 # Create here the targets which run the actual simulations
 # TESTS format:  <configuration>:<test name>
 $(foreach cfg_test, $(TESTS),\
-	$(eval cfg = $(word 1,$(subst :, ,$(cfg_test)))) \
-	$(eval test = $(word 2,$(subst :, ,$(cfg_test)))) \
-	$(eval $(call sim, $(cfg), $(test))) \
+	$(eval cfg = $(strip $(word 1,$(subst :, ,$(cfg_test))))) \
+	$(eval test = $(strip $(word 2,$(subst :, ,$(cfg_test))))) \
+	$(eval $(call sim,$(cfg),$(test))) \
 )
 
 # Group sim targets based on env config so we can run easily all test 

--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -16,12 +16,13 @@ SHELL:=/bin/bash
 # simulate - Run a sim command and look in logfile for errors; creates JUnit XML
 # $(1): Command to execute
 # $(2): Logfile name
-# $(3): Textual description of the task
-# $(4): configuration name
-# $(5): test  name
+# $(3): Textual description of the start of the task
+# $(4): Textual description of the end of the task
+# $(5): configuration name
+# $(6): test  name
 FOLDER=$(shell basename $(CURDIR))
 define simulate
-@echo -n "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."
+@echo "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."
 START=$$(date +%s); \
 $(strip $(1)) >> $(strip $(2)) 2>&1; \
 (ERR=$$?; \
@@ -29,9 +30,10 @@ END=$$(date +%s); \
 DIFF=$$(( $$END - $$START )); \
 ERRS=`grep -v ^# $(2) | grep -w -i -e ^error -e ^fatal -e ^fatal_error -e "\[ERROR\]" -e "while\\ executing" -C 10 |  sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`; \
 if [[ $$ERRS > 0 ]] ; then ERR=1; fi;\
-JUnitFile='results/$(strip $(4))_$(strip $(5)).xml'; \
+JUnitFile='results/$(strip $(5))_$(strip $(6)).xml'; \
 echo \<testsuite\> > $$JUnitFile; \
-echo \<testcase classname=\"$(FOLDER)_$(strip $(4))\" name=\"$(strip $(5))\" time=\"$$DIFF\" \> >> $$JUnitFile; \
+echo \<testcase classname=\"$(FOLDER)_$(strip $(5))\" name=\"$(strip $(6))\" time=\"$$DIFF\" \> >> $$JUnitFile; \
+echo -n "$(strip $(4)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)]"; \
 if [ $$ERR = 0 ]; then \
 	echo " $(GREEN)OK$(NC)"; \
 	echo \<passed\/\> >> $$JUnitFile; \
@@ -71,6 +73,7 @@ $(addprefix runs/,$(1)/system_project.log) : $(addprefix cfgs/,$(1).tcl) $(ENV_D
 		$(CMD_PRE) $(M_VIVADO_BATCH) system_project.tcl -tclargs $(1).tcl $(CMD_POST), \
 		$$@, \
 		Building $(HL)$(strip $(1))$(NC) env, \
+		Build $(HL)$(strip $(1))$(NC) env, \
 		$(1), \
 		BuildEnv)
 endef
@@ -85,6 +88,7 @@ $(addprefix runs/,$(addprefix $(1)/,$(2).log)): $(addprefix runs/,$(1)/system_pr
 		$(CMD_PRE) $(M_VIVADO) $(RUN_SIM_PATH) -tclargs $(1) $(2) $(MODE) $(CMD_POST), \
 		$$@, \
 		Running $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
+		Run $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
 		$(1), \
 		$(2))
 FORCE:


### PR DESCRIPTION
* Print different line for start and finish process (e.g. `Running ....` and `Run OK`), so when running in parallel `make -j` the console log is not scrambled.

<details>
<summary>Example output, jesd_loopback with 5 parallel runs</summary>

```
jesd_loopback$ make -j5
Building cfg1 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg1/system_project.log] ...
Building cfg2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2/system_project.log] ...
Building cfg2_np12 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2_np12/system_project.log] ...
Building cfg3_np12_L2M8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg3_np12_L2M8/system_project.log] ...
Building cfg4_F8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg4_F8/system_project.log] ...
Build cfg4_F8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg4_F8/system_project.log] OK
Build cfg3_np12_L2M8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg3_np12_L2M8/system_project.log] OK
Build cfg1 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg1/system_project.log] OK
Build cfg2_np12 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2_np12/system_project.log] OK
Build cfg2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2/system_project.log] OK
Building cfg5_64b66b env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg5_64b66b/system_project.log] ...
Building cfg6_F64 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg6_F64/system_project.log] ...
Building cfg7_np12_L12M2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg7_np12_L12M2/system_project.log] ...
Build cfg7_np12_L12M2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg7_np12_L12M2/system_project.log] OK
Build cfg5_64b66b env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg5_64b66b/system_project.log] OK
Running test_program test on cfg1 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg1/test_program.log] ...
Running test_program test on cfg2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2/test_program.log] ...
Running test_program test on cfg2_np12 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2_np12/test_program.log] ...
Running test_program test on cfg3_np12_L2M8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg3_np12_L2M8/test_program.log] ...
Build cfg6_F64 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg6_F64/system_project.log] OK
Running test_program test on cfg4_F8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg4_F8/test_program.log] ...
Run test_program test on cfg1 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg1/test_program.log] OK
Running test_program test on cfg5_64b66b env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg5_64b66b/test_program.log] ...
Run test_program test on cfg2_np12 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2_np12/test_program.log] OK
Running test_program test on cfg6_F64 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg6_F64/test_program.log] ...
Run test_program test on cfg3_np12_L2M8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg3_np12_L2M8/test_program.log] OK
Running test_program test on cfg7_np12_L12M2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg7_np12_L12M2/test_program.log] ...
Run test_program test on cfg4_F8 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg4_F8/test_program.log] OK
Run test_program test on cfg6_F64 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg6_F64/test_program.log] FAILED
For details see /home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg6_F64/test_program.log

make: *** [../scripts/project-sim.mk:151: runs/cfg6_F64/test_program.log] Error 1
make: *** Waiting for unfinished jobs....
Run test_program test on cfg5_64b66b env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg5_64b66b/test_program.log] OK
Run test_program test on cfg2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg2/test_program.log] OK
Run test_program test on cfg7_np12_L12M2 env [/home/me/Documents/adi/hdl/testbenches/jesd_loopback/runs/cfg7_np12_L12M2/test_program.log] OK
```

</details>

* Add a lock for each runs/cfg, to avoid them running together.
* Add .gitignore

Follow-up from #56