### PR TITLE
Use axi_pwm_gen package in all testbenches

### DIFF
--- a/ad463x/Makefile
+++ b/ad463x/Makefile
@@ -15,6 +15,7 @@ SV_DEPS += ../common/sv/s_axi_sequencer.sv
 SV_DEPS += ../common/sv/dmac_api.sv
 SV_DEPS += ../common/sv/adi_regmap_pkg.sv
 SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_pwm_gen_pkg.sv
 SV_DEPS += ../common/sv/dma_trans.sv
 SV_DEPS += system_tb.sv
 

--- a/ad463x/system_project.tcl
+++ b/ad463x/system_project.tcl
@@ -30,6 +30,7 @@ adi_sim_project_files [list \
  "../common/sv/dmac_api.sv" \
  "../common/sv/adi_regmap_pkg.sv" \
  "../common/sv/adi_regmap_dmac_pkg.sv" \
+ "../common/sv/adi_regmap_pwm_gen_pkg.sv" \
  "../common/sv/dma_trans.sv" \
  "../common/sv/test_harness_env.sv" \
  "tests/test_program.sv" \

--- a/ad463x/tests/test_program.sv
+++ b/ad463x/tests/test_program.sv
@@ -41,6 +41,8 @@ import axi_vip_pkg::*;
 import axi4stream_vip_pkg::*;
 import logger_pkg::*;
 import test_harness_env_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
 
 `define AD469X_DMA                  32'h44A3_0000
 `define AD469X_REGMAP               32'h44A0_0000
@@ -538,14 +540,15 @@ bit   [31:0]  sdi_fifo_data = 0;
 task fifo_spi_test;
 begin
 
-  //start spi clk generator
-  #100 axi_write (AD469X_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+  // Start spi clk generator
+  axi_write (AD469X_CLKGEN_BASE + 32'h00000040, 32'h0000003);
 
-  //config cnv (with averaging)
-  #100 axi_write (AD469X_CNV_BASE + 32'h00000010, 32'h00000000);
-  #100 axi_write (AD469X_CNV_BASE + 32'h00000040, ('h64 * 'd16) - 'h0);
-  #100 axi_write (AD469X_CNV_BASE + 32'h0000004c, ('h64 * 'd4) - 'h0);
-  #100 axi_write (AD469X_CNV_BASE + 32'h00000010, 32'h00000002);
+  // Config cnv (with averaging)
+  axi_write (AD469X_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+  axi_write (AD469X_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD(('h64 * 'd16) - 'h0)); // set PWM 0 period
+  axi_write (AD469X_CNV_BASE + GetAddrs(REG_PULSE_1_PERIOD), `SET_REG_PULSE_1_PERIOD_PULSE_1_PERIOD(('h64 * 'd4) - 'h0)); // set PWM 1 period
+  axi_write (AD469X_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+  $display("[%t] axi_pwm_gen started.", $time);
 
   // Enable SPI Engine
   axi_write (AD469X_BASE + SPI_ENG_ADDR_ENABLE, 0);

--- a/ad7606x/tests/test_program.sv
+++ b/ad7606x/tests/test_program.sv
@@ -73,8 +73,6 @@ program test_program (
   output        rx_busy,
   output bit [1:0] adc_config_mode);
 
-assign rx_db_i = tx_data_buf;
-
 test_harness_env env;
 
 // --------------------------
@@ -131,13 +129,13 @@ initial begin
   sanity_test;
 
   #100 adc_config_SIMPLE_test;
-  
+
   #200 adc_config_CRC_test;
-  
+
   #200 adc_config_STATUS_test;
-  
+
   #200 adc_config_STATUS_CRC_test;
-  
+
   #200 adc_config_SIMPLE_test;
 
   #100 db_transmission_test;
@@ -169,6 +167,7 @@ end
   reg [15:0]  tx_data_buf = 16'h0;
   bit [15:0]  tx_crc;
 
+  assign rx_db_i = tx_data_buf;
   assign tx_crc = (DEV_CONFIG == 0 || DEV_CONFIG == 1) ? ((adc_config_mode == 1) ? 16'hE0E2 : ((adc_config_mode == 3) ? 16'h6B33 : 16'h0)) : ((adc_config_mode == 1) ? 16'hD885 : ((adc_config_mode == 3) ? 16'hAF8B : 16'h0));
 
   wire [4:0] num_of_transfers;
@@ -213,7 +212,7 @@ initial begin
                         tx_data_buf = tx_ch2;
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -233,7 +232,7 @@ initial begin
                         tx_data_buf = tx_ch4;
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -253,7 +252,7 @@ initial begin
                         tx_data_buf = tx_ch6;
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -273,7 +272,7 @@ initial begin
                         tx_data_buf = tx_ch8;
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -292,7 +291,7 @@ initial begin
                         tx_data_buf = {8'b0,tx_status_5};
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -309,7 +308,7 @@ initial begin
                         tx_data_buf = {8'b0,tx_status_6};
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -326,7 +325,7 @@ initial begin
                         tx_data_buf = {8'b0,tx_status_7};
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -343,7 +342,7 @@ initial begin
                         tx_data_buf = {8'b0,tx_status_8};
                       end
                       if (DEV_CONFIG == 2) begin
-                        if (adc_config_mode == 0 || adc_config_mode == 1) begin 
+                        if (adc_config_mode == 0 || adc_config_mode == 1) begin
                           tx_data_buf = {tx_ch1[1:0],14'b0};
                         end else if (adc_config_mode == 2 || adc_config_mode == 3) begin
                           tx_data_buf = {tx_ch1[1:0],5'b0,tx_status_1};
@@ -518,20 +517,21 @@ endtask
 //---------------------------------------------------------------------------
 bit [31:0] capp_word;
 task db_transmission_test;
-  begin 
+  begin
     #100 transfer_status = 1;
 
     // Generate cnvst_n pulse using AXI_PWM_GEN
-    #100 axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(0)); // PWM_GEN reset in regmap (ACTIVE HIGH)
-    #100 axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('h64)); // set PWM period
-    #100 axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_WIDTH), `SET_REG_PULSE_0_WIDTH_PULSE_0_WIDTH('h63)); // set PWM pulse width
-    #100 axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(0)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('h64)); // set PWM period
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_WIDTH), `SET_REG_PULSE_0_WIDTH_PULSE_0_WIDTH('h63)); // set PWM pulse width
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
     $display("[%t] axi_pwm_gen started.", $time);
 
     wait(rx_ch_count == num_of_transfers);
 
     // Stop pwm gen
-    axi_write (`AXI_PWMGEN + 32'h00000010, 'h2); // stop PWM_GEN
+    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1));
     $display("[%t] axi_pwm_gen stopped.", $time);
   end
 endtask

--- a/ad7616/Makefile
+++ b/ad7616/Makefile
@@ -15,6 +15,7 @@ SV_DEPS += ../common/sv/s_axi_sequencer.sv
 SV_DEPS += ../common/sv/dmac_api.sv
 SV_DEPS += ../common/sv/adi_regmap_pkg.sv
 SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_pwm_gen_pkg.sv
 SV_DEPS += ../common/sv/dma_trans.sv
 SV_DEPS += system_tb.sv
 

--- a/ad7616/system_project.tcl
+++ b/ad7616/system_project.tcl
@@ -50,6 +50,7 @@ adi_sim_project_files [list \
  "../common/sv/dmac_api.sv" \
  "../common/sv/adi_regmap_pkg.sv" \
  "../common/sv/adi_regmap_dmac_pkg.sv" \
+ "../common/sv/adi_regmap_pwm_gen_pkg.sv" \
  "../common/sv/dma_trans.sv" \
  "../common/sv/test_harness_env.sv" \
  "tests/test_program_si.sv" \

--- a/ad7616/tests/test_program_pi.sv
+++ b/ad7616/tests/test_program_pi.sv
@@ -41,6 +41,8 @@ import axi_vip_pkg::*;
 import axi4stream_vip_pkg::*;
 import logger_pkg::*;
 import test_harness_env_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
 
 localparam AD7616_DMA                 = 32'h44A3_0000;
 localparam AXI_AD7616                 = 32'h44A8_0000;
@@ -217,10 +219,9 @@ task data_acquisition_test;
     axi_write (AXI_CLKGEN + 32'h00000040, 32'h0000003);
 
     // Configure pwm gen
-    axi_write (AXI_PWMGEN + 32'h00000010, 32'h00000001);
-    axi_write (AXI_PWMGEN + 32'h00000040, 'h64);
-    axi_write (AXI_PWMGEN + 32'h00000080, 'h1);
-    axi_write (AXI_PWMGEN + 32'h00000010, 32'h00000002);
+    axi_write (AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (AXI_PWMGEN + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('h64)); // set PWM period
+    axi_write (AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
     $display("[%t] axi_pwm_gen started.", $time);
 
      //Configure DMA

--- a/pulsar_adc_pmdz/Makefile
+++ b/pulsar_adc_pmdz/Makefile
@@ -15,6 +15,7 @@ SV_DEPS += ../common/sv/s_axi_sequencer.sv
 SV_DEPS += ../common/sv/dmac_api.sv
 SV_DEPS += ../common/sv/adi_regmap_pkg.sv
 SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_pwm_gen_pkg.sv
 SV_DEPS += ../common/sv/dma_trans.sv
 SV_DEPS += system_tb.sv
 

--- a/pulsar_adc_pmdz/system_project.tcl
+++ b/pulsar_adc_pmdz/system_project.tcl
@@ -32,6 +32,7 @@ adi_sim_project_files [list \
  "../common/sv/s_axi_sequencer.sv" \
  "../common/sv/dmac_api.sv" \
  "../common/sv/adi_regmap_pkg.sv" \
+ "../common/sv/adi_regmap_pwm_gen_pkg.sv" \
  "../common/sv/adi_regmap_dmac_pkg.sv" \
  "../common/sv/dma_trans.sv" \
  "../common/sv/test_harness_env.sv" \

--- a/pulsar_adc_pmdz/tests/test_program.sv
+++ b/pulsar_adc_pmdz/tests/test_program.sv
@@ -40,6 +40,8 @@
 
 import axi_vip_pkg::*;
 import axi4stream_vip_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
 import logger_pkg::*;
 import test_harness_env_pkg::*;
 
@@ -472,13 +474,14 @@ bit   [31:0]  sdi_fifo_data = 0;
 task fifo_spi_test;
 begin
 
-  //start spi clk generator
-  #100 axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+  // Start spi clk generator
+  axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
 
-  //config cnv
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000001);
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000040, 32'd00000121);
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000002);
+  // Config cnv
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d121)); // set PWM period
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+  $display("[%t] axi_pwm_gen started.", $time);
 
   // Enable SPI Engine
   axi_write (PULSAR_ADC_BASE + `SPI_ENG_ADDR_ENABLE, 0);

--- a/pulsar_adc_pmdz/tests/test_sleep_delay.sv
+++ b/pulsar_adc_pmdz/tests/test_sleep_delay.sv
@@ -38,6 +38,8 @@
 
 import axi_vip_pkg::*;
 import axi4stream_vip_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
 import logger_pkg::*;
 import test_harness_env_pkg::*;
 
@@ -433,13 +435,14 @@ task sleep_delay_test;
   input [7:0] sleep_param;
 begin
 
-  //start spi clk generator
-  #100 axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+  // Start spi clk generator
+  axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
 
-  //config cnv
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000000);
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000040, 32'd00001000);
-  #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000002);
+  // Config cnv
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d1000)); // set PWM period
+  axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+  $display("[%t] axi_pwm_gen started.", $time);
 
   // Enable SPI Engine
   axi_write (PULSAR_ADC_BASE + `SPI_ENG_ADDR_ENABLE, 0);
@@ -484,13 +487,14 @@ task cs_delay_test;
   input [1:0] cs_deactivate_delay;
 begin
 
-    //start spi clk generator
-    #100 axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+    // Start spi clk generator
+    axi_write (PULSAR_ADC_CLKGEN_BASE + 32'h00000040, 32'h0000003);
 
-    //config cnv
-    #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000001);
-    #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000040, 32'd00001000);
-    #100 axi_write (PULSAR_ADC_CNV_BASE + 32'h00000010, 32'h00000002);
+    // Config cnv
+    axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d1000)); // set PWM period
+    axi_write (PULSAR_ADC_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+    $display("[%t] axi_pwm_gen started.", $time);
 
     //Configure DMA
     env.mng.RegWrite32(PULSAR_ADC_DMA+32'h400, 32'h00000001); // Enable DMA


### PR DESCRIPTION
Use the axi_pwm_gen.pkg across all the testbenches, delete the unnecessary delays related to pwm axi_writes and small cosmetic changes.