### PR TITLE
ad7616: Rename irq port

### DIFF
--- a/ad7616/system_bd.tcl
+++ b/ad7616/system_bd.tcl
@@ -53,10 +53,10 @@ source ../../projects/ad7616_sdz/common/ad7616_bd.tcl
 if {$SER_PAR_N == 1} {
 
   create_bd_port -dir O spi_clk
-  create_bd_port -dir O irq
+  create_bd_port -dir O ad7616_irq
 
   ad_connect spi_clk sys_cpu_clk
-  ad_connect irq spi_ad7616/irq
+  ad_connect ad7616_irq spi_ad7616/irq
 
 } else {
 

--- a/ad7616/system_tb.sv
+++ b/ad7616/system_tb.sv
@@ -47,18 +47,18 @@ module system_tb();
       wire       adc_busy;
       wire       adc_cnvst;
       wire       spi_clk;
-      wire       irq;
+      wire       ad7616_irq;
 
     `TEST_PROGRAM test(
       .spi_clk (spi_clk),
-      .irq (irq),
+      .ad7616_irq (ad7616_irq),
       .ad7616_spi_sdi(ad7616_spi_sdi),
       .ad7616_spi_cs (ad7616_spi_cs),
       .ad7616_spi_sclk (ad7616_spi_sclk));
 
     test_harness `TH (
       .spi_clk (spi_clk),
-      .irq (irq),
+      .ad7616_irq (ad7616_irq),
       .rx_busy (adc_busy),
       .rx_cnvst (adc_cnvst),
       .ad7616_spi_sdo (ad7616_spi_sdo),

--- a/ad7616/tests/test_program_si.sv
+++ b/ad7616/tests/test_program_si.sv
@@ -121,7 +121,7 @@ localparam AXI_PWMGEN = `AXI_PWMGEN;
 
 program test_program_si (
   input       spi_clk,
-  input       irq,
+  input       ad7616_irq,
   input       ad7616_spi_sclk,
   input       ad7616_spi_sdo,
   input [1:0] ad7616_spi_sdi,
@@ -240,7 +240,7 @@ reg [7:0] sync_id = 0;
 
 initial begin
   while (1) begin
-    @(posedge irq);
+    @(posedge ad7616_irq);
     // read pending IRQs
     axi_read (`AD7616_REGMAP + SPI_ENG_ADDR_IRQPEND, irq_pending);
     // IRQ launched by Offload SYNC command


### PR DESCRIPTION
Rename the "irq" port into "ad7616_irq", as the "irq" will be used in the common test harness.