### PR TITLE
SPI Engine: Add testbench

### DIFF
--- a/spi_engine/Makefile
+++ b/spi_engine/Makefile
@@ -1,0 +1,63 @@
+####################################################################################
+####################################################################################
+## Copyright 2021(c) Analog Devices, Inc.
+####################################################################################
+####################################################################################
+
+# All test-bench dependencies except test programs
+SV_DEPS += ../common/sv/utils.svh
+SV_DEPS += ../common/sv/logger_pkg.sv
+SV_DEPS += ../common/sv/reg_accessor.sv
+SV_DEPS += ../common/sv/m_axis_sequencer.sv
+SV_DEPS += ../common/sv/s_axis_sequencer.sv
+SV_DEPS += ../common/sv/m_axi_sequencer.sv
+SV_DEPS += ../common/sv/s_axi_sequencer.sv
+SV_DEPS += ../common/sv/dmac_api.sv
+SV_DEPS += ../common/sv/adi_regmap_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_pwm_gen_pkg.sv
+SV_DEPS += ../common/sv/dma_trans.sv
+SV_DEPS += system_tb.sv
+
+ENV_DEPS +=../../library/util_cdc/sync_bits.v
+ENV_DEPS +=../../library/common/ad_edge_detect.v
+
+ENV_DEPS += system_project.tcl
+ENV_DEPS += system_bd.tcl
+ENV_DEPS +=../scripts/adi_sim.tcl
+ENV_DEPS +=../scripts/run_sim.tcl
+
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_pwm_gen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_sysid
+LIB_DEPS += spi_engine/axi_spi_engine
+LIB_DEPS += spi_engine/spi_engine_execution
+LIB_DEPS += spi_engine/spi_engine_interconnect
+LIB_DEPS += spi_engine/spi_engine_offload
+LIB_DEPS += sysid_rom
+
+# default test programs
+# Format is: <test name>
+TP := $(notdir $(basename $(wildcard tests/*.sv)))
+
+# config files should have the following format
+#  cfg_<param1>_<param2>.tcl
+CFG_FILES := $(notdir $(wildcard cfgs/cfg*.tcl))
+
+# List of tests and configuration combinations that has to be run
+# Format is:  <configuration>:<test name>
+TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(addprefix $(cfg):, $(TP)))
+
+include ../scripts/project-sim.mk
+
+# usage :
+#
+# run specific test on a specific configuration in gui mode
+# 	make CFG=cfg1 TST=test_program MODE=gui
+#
+# run all test from a configuration
+# 	make cfg1
+
+####################################################################################
+####################################################################################

--- a/spi_engine/README.md
+++ b/spi_engine/README.md
@@ -1,0 +1,27 @@
+Usage :
+
+Run all tests in batch mode:
+
+	make
+
+
+Run all tests in GUI mode:
+
+	make MODE=gui
+
+
+Run specific test on a specific configuration in gui mode:
+
+	make CFG=<name of cfg> TST=<name of test> MODE=gui
+
+
+Run all test from a configuration:
+
+	make <name of cfg>
+
+
+Where:
+
+ * <name of cfg> is a file from the cfgs directory without the tcl extension of format cfg\*
+ * <name of test> is a file from the tests directory without the tcl extension
+

--- a/spi_engine/cfgs/cfg1.tcl
+++ b/spi_engine/cfgs/cfg1.tcl
@@ -1,0 +1,15 @@
+global ad_project_params
+
+set ad_project_params(DATA_WIDTH)           32
+set ad_project_params(ASYNC_SPI_CLK)        1
+set ad_project_params(NUM_OF_CS)            1
+set ad_project_params(NUM_OF_SDI)           1
+set ad_project_params(NUM_OF_SDO)           1
+set ad_project_params(SDI_DELAY)            1
+set ad_project_params(ECHO_SCLK)            0
+set ad_project_params(CMD_MEM_ADDR_WIDTH)   4
+set ad_project_params(DATA_MEM_ADDR_WIDTH)  4
+set ad_project_params(SDI_FIFO_ADDR_WIDTH)  5
+set ad_project_params(SDO_FIFO_ADDR_WIDTH)  5
+set ad_project_params(SYNC_FIFO_ADDR_WIDTH) 4
+set ad_project_params(CMD_FIFO_ADDR_WIDTH)  4

--- a/spi_engine/spi_engine.svh
+++ b/spi_engine/spi_engine.svh
@@ -1,0 +1,62 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/1ps
+
+`ifndef _SPI_ENGINE_SVH_
+`define _SPI_ENGINE_SVH_
+
+`define SPI_ENG_ADDR_VERSION        32'h0000_0000
+`define SPI_ENG_ADDR_ID             32'h0000_0004
+`define SPI_ENG_ADDR_SCRATCH        32'h0000_0008
+`define SPI_ENG_ADDR_ENABLE         32'h0000_0040
+`define SPI_ENG_ADDR_IRQMASK        32'h0000_0080
+`define SPI_ENG_ADDR_IRQPEND        32'h0000_0084
+`define SPI_ENG_ADDR_IRQSRC         32'h0000_0088
+`define SPI_ENG_ADDR_SYNCID         32'h0000_00C0
+`define SPI_ENG_ADDR_CMDFIFO_ROOM   32'h0000_00D0
+`define SPI_ENG_ADDR_SDOFIFO_ROOM   32'h0000_00D4
+`define SPI_ENG_ADDR_SDIFIFO_LEVEL  32'h0000_00D8
+`define SPI_ENG_ADDR_CMDFIFO        32'h0000_00E0
+`define SPI_ENG_ADDR_SDOFIFO        32'h0000_00E4
+`define SPI_ENG_ADDR_SDIFIFO        32'h0000_00E8
+`define SPI_ENG_ADDR_SDIFIFO_PEEK   32'h0000_00F0
+`define SPI_ENG_ADDR_OFFLOAD_EN     32'h0000_0100
+`define SPI_ENG_ADDR_OFFLOAD_RESET  32'h0000_0108
+`define SPI_ENG_ADDR_OFFLOAD_CMD    32'h0000_0110
+`define SPI_ENG_ADDR_OFFLOAD_SDO    32'h0000_0114
+
+
+`endif

--- a/spi_engine/spi_engine_test_bd.tcl
+++ b/spi_engine/spi_engine_test_bd.tcl
@@ -1,0 +1,93 @@
+###############################################################################
+## Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
+
+set DATA_WIDTH              $ad_project_params(DATA_WIDTH)
+set ASYNC_SPI_CLK           $ad_project_params(ASYNC_SPI_CLK)
+set NUM_OF_CS               $ad_project_params(NUM_OF_CS)
+set NUM_OF_SDI              $ad_project_params(NUM_OF_SDI)
+set NUM_OF_SDO              $ad_project_params(NUM_OF_SDO)
+set SDI_DELAY               $ad_project_params(SDI_DELAY)
+set ECHO_SCLK               $ad_project_params(ECHO_SCLK)
+set CMD_MEM_ADDR_WIDTH      $ad_project_params(CMD_MEM_ADDR_WIDTH)
+set DATA_MEM_ADDR_WIDTH     $ad_project_params(DATA_MEM_ADDR_WIDTH)
+set SDI_FIFO_ADDR_WIDTH     $ad_project_params(SDI_FIFO_ADDR_WIDTH)
+set SDO_FIFO_ADDR_WIDTH     $ad_project_params(SDO_FIFO_ADDR_WIDTH)
+set SYNC_FIFO_ADDR_WIDTH    $ad_project_params(SYNC_FIFO_ADDR_WIDTH)
+set CMD_FIFO_ADDR_WIDTH     $ad_project_params(CMD_FIFO_ADDR_WIDTH)
+
+set data_width              $DATA_WIDTH
+set async_spi_clk           $ASYNC_SPI_CLK
+set num_cs                  $NUM_OF_CS
+set num_sdi                 $NUM_OF_SDI
+set num_sdo                 $NUM_OF_SDO
+set sdi_delay               $SDI_DELAY
+set echo_sclk               $ECHO_SCLK
+set cmd_mem_addr_width      $CMD_MEM_ADDR_WIDTH
+set data_mem_addr_width     $DATA_MEM_ADDR_WIDTH
+set sdi_fifo_addr_width     $SDI_FIFO_ADDR_WIDTH
+set sdo_fifo_addr_width     $SDO_FIFO_ADDR_WIDTH
+set sync_fifo_addr_width    $SYNC_FIFO_ADDR_WIDTH
+set cmd_fifo_addr_width     $CMD_FIFO_ADDR_WIDTH
+
+create_bd_intf_port -mode Master -vlnv analog.com:interface:spi_engine_rtl:1.0 spi_engine_spi
+
+set hier_spi_engine spi_engine
+
+spi_engine_create $hier_spi_engine  $data_width $async_spi_clk $num_cs $num_sdi  \
+                                    $num_sdo $sdi_delay $echo_sclk \
+                                    $cmd_mem_addr_width $data_mem_addr_width \
+                                    $sdi_fifo_addr_width $sdo_fifo_addr_width \
+                                    $sync_fifo_addr_width $cmd_fifo_addr_width
+
+ad_ip_instance axi_clkgen spi_clkgen
+ad_ip_parameter spi_clkgen CONFIG.CLK0_DIV 5
+ad_ip_parameter spi_clkgen CONFIG.VCO_DIV 1
+ad_ip_parameter spi_clkgen CONFIG.VCO_MUL 8
+
+ad_ip_instance axi_pwm_gen spi_engine_trigger_gen
+ad_ip_parameter spi_engine_trigger_gen CONFIG.PULSE_0_PERIOD 120
+ad_ip_parameter spi_engine_trigger_gen CONFIG.PULSE_0_WIDTH 1
+
+# dma to receive data stream
+ad_ip_instance axi_dmac axi_spi_engine_dma
+ad_ip_parameter axi_spi_engine_dma CONFIG.DMA_TYPE_SRC 1
+ad_ip_parameter axi_spi_engine_dma CONFIG.DMA_TYPE_DEST 0
+ad_ip_parameter axi_spi_engine_dma CONFIG.CYCLIC 0
+ad_ip_parameter axi_spi_engine_dma CONFIG.SYNC_TRANSFER_START 0
+ad_ip_parameter axi_spi_engine_dma CONFIG.AXI_SLICE_SRC 0
+ad_ip_parameter axi_spi_engine_dma CONFIG.AXI_SLICE_DEST 1
+ad_ip_parameter axi_spi_engine_dma CONFIG.DMA_2D_TRANSFER 0
+ad_ip_parameter axi_spi_engine_dma CONFIG.DMA_DATA_WIDTH_SRC $data_width
+ad_ip_parameter axi_spi_engine_dma CONFIG.DMA_DATA_WIDTH_DEST 64
+
+ad_connect $sys_cpu_clk spi_clkgen/clk
+ad_connect spi_clk spi_clkgen/clk_0
+
+ad_connect spi_clk spi_engine_trigger_gen/ext_clk
+ad_connect $sys_cpu_clk spi_engine_trigger_gen/s_axi_aclk
+ad_connect sys_cpu_resetn spi_engine_trigger_gen/s_axi_aresetn
+ad_connect spi_engine_trigger_gen/pwm_0 $hier_spi_engine/trigger
+
+ad_connect axi_spi_engine_dma/s_axis $hier_spi_engine/M_AXIS_SAMPLE
+ad_connect $hier_spi_engine/m_spi spi_engine_spi
+
+ad_connect $sys_cpu_clk $hier_spi_engine/clk
+ad_connect spi_clk $hier_spi_engine/spi_clk
+ad_connect spi_clk axi_spi_engine_dma/s_axis_aclk
+ad_connect sys_cpu_resetn $hier_spi_engine/resetn
+ad_connect sys_cpu_resetn axi_spi_engine_dma/m_dest_axi_aresetn
+
+ad_cpu_interconnect 0x44a00000 $hier_spi_engine/${hier_spi_engine}_axi_regmap
+ad_cpu_interconnect 0x44a30000 axi_spi_engine_dma
+ad_cpu_interconnect 0x44a70000 spi_clkgen
+ad_cpu_interconnect 0x44b00000 spi_engine_trigger_gen
+
+ad_cpu_interrupt "ps-13" "mb-13" axi_spi_engine_dma/irq
+ad_cpu_interrupt "ps-12" "mb-12" /$hier_spi_engine/irq
+
+ad_mem_hp1_interconnect $sys_cpu_clk sys_ps7/S_AXI_HP1
+ad_mem_hp1_interconnect $sys_cpu_clk axi_spi_engine_dma/m_dest_axi

--- a/spi_engine/system_bd.tcl
+++ b/spi_engine/system_bd.tcl
@@ -1,0 +1,63 @@
+# ***************************************************************************
+# ***************************************************************************
+# Copyright 2024 (c) Analog Devices, Inc. All rights reserved.
+#
+# In this HDL repository, there are many different and unique modules, consisting
+# of various HDL (Verilog or VHDL) components. The individual modules are
+# developed independently, and may be accompanied by separate and unique license
+# terms.
+#
+# The user should read each of these license terms, and understand the
+# freedoms and responsibilities that he or she has by using this source/core.
+#
+# This core is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.
+#
+# Redistribution and use of source or resulting binaries, with or without modification
+# of this file, are permitted under one of the following two license terms:
+#
+#   1. The GNU General Public License version 2 as published by the
+#      Free Software Foundation, which can be found in the top level directory
+#      of this repository (LICENSE_GPL2), and also online at:
+#      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+#
+# OR
+#
+#   2. An ADI specific BSD license, which can be found in the top level directory
+#      of this repository (LICENSE_ADIBSD), and also on-line at:
+#      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+#      This will allow to generate bit files and not release the source code,
+#      as long as it attaches to an ADI device.
+#
+# ***************************************************************************
+# ***************************************************************************
+
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
+
+
+global ad_project_params
+
+adi_project_files [list \
+    "../../library/common/ad_edge_detect.v" \
+    "../../library/util_cdc/sync_bits.v" \
+        "../../library/common/ad_iobuf.v" \
+]
+
+#
+#  Block design under test
+#
+
+source ./spi_engine_test_bd.tcl
+
+create_bd_port -dir O spi_engine_spi_clk
+create_bd_port -dir O spi_engine_irq
+if {$ad_project_params(ECHO_SCLK)} {
+    create_bd_port -dir I spi_engine_echo_sclk
+    ad_connect spi_engine_echo_sclk spi_engine/echo_sclk
+}
+
+ad_connect spi_engine_spi_clk spi_clkgen/clk_0
+ad_connect spi_engine_irq spi_engine/irq
+

--- a/spi_engine/system_project.tcl
+++ b/spi_engine/system_project.tcl
@@ -1,0 +1,52 @@
+source ../scripts/adi_sim.tcl
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+if {$argc < 1} {
+  puts "Expecting at least one argument that specifies the test configuration"
+  exit 1
+} else {
+  set cfg_file [lindex $argv 0]
+}
+
+# Read common config file
+source "cfgs/${cfg_file}"
+
+# Set the project name
+set project_name [file rootname $cfg_file]
+
+# Set to use SmartConnect or AXI Interconnect
+set use_smartconnect 1
+
+# Create the project
+adi_sim_project_xilinx $project_name "xc7z007sclg400-1"
+
+# Add test files to the project
+adi_sim_project_files [list \
+ "../common/sv/utils.svh" \
+ "../common/sv/logger_pkg.sv" \
+ "../common/sv/reg_accessor.sv" \
+ "../common/sv/m_axis_sequencer.sv" \
+ "../common/sv/s_axis_sequencer.sv" \
+ "../common/sv/m_axi_sequencer.sv" \
+ "../common/sv/s_axi_sequencer.sv" \
+ "../common/sv/dmac_api.sv" \
+ "../common/sv/adi_regmap_pkg.sv" \
+ "../common/sv/adi_regmap_pwm_gen_pkg.sv" \
+ "../common/sv/adi_regmap_dmac_pkg.sv" \
+ "../common/sv/dma_trans.sv" \
+ "../common/sv/test_harness_env.sv" \
+ "spi_engine.svh" \
+ "tests/test_program.sv" \
+ "tests/test_sleep_delay.sv"\
+ "system_tb.sv" \
+ ]
+
+#set a default test program
+adi_sim_add_define "TEST_PROGRAM=test_program"
+
+if {$ad_project_params(ECHO_SCLK)} {
+  adi_sim_add_define DEF_ECHO_SCLK
+}
+
+adi_sim_generate $project_name

--- a/spi_engine/system_tb.sv
+++ b/spi_engine/system_tb.sv
@@ -1,0 +1,72 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2021 - 2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/1ps
+
+`include "utils.svh"
+
+module system_tb();
+  wire spi_engine_spi_cs;
+  wire spi_engine_spi_sclk;
+  wire spi_engine_spi_clk;
+  wire spi_engine_spi_sdi;
+  wire spi_engine_spi_sdo;
+  wire spi_engine_irq;
+`ifdef DEF_ECHO_SCLK
+  wire spi_engine_echo_sclk;
+`endif
+
+  `TEST_PROGRAM test(
+    .spi_engine_irq(spi_engine_irq),
+    .spi_engine_spi_sclk(spi_engine_spi_sclk),
+    .spi_engine_spi_cs(spi_engine_spi_cs),
+    .spi_engine_spi_clk(spi_engine_spi_clk),
+    `ifdef DEF_ECHO_SCLK
+    .spi_engine_echo_sclk(spi_engine_echo_sclk),
+    `endif
+    .spi_engine_spi_sdi(spi_engine_spi_sdi));
+
+  test_harness `TH (
+    .spi_engine_irq(spi_engine_irq),
+    .spi_engine_spi_cs(spi_engine_spi_cs),
+    .spi_engine_spi_sclk(spi_engine_spi_sclk),
+    .spi_engine_spi_clk(spi_engine_spi_clk),
+    .spi_engine_spi_sdi(spi_engine_spi_sdi),
+    `ifdef DEF_ECHO_SCLK
+    .spi_engine_echo_sclk(spi_engine_echo_sclk),
+    `endif
+    .spi_engine_spi_sdo(spi_engine_spi_sdo));
+
+endmodule

--- a/spi_engine/tests/test_program.sv
+++ b/spi_engine/tests/test_program.sv
@@ -1,0 +1,532 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2021 - 2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+//
+//
+
+`include "utils.svh"
+`include "spi_engine.svh"
+
+import axi_vip_pkg::*;
+import axi4stream_vip_pkg::*;
+import adi_regmap_dmac_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
+import logger_pkg::*;
+import test_harness_env_pkg::*;
+
+localparam SPI_ENGINE_DMA             = 32'h44A3_0000;
+localparam SPI_ENGINE_BASE            = 32'h44A0_0000;
+localparam SPI_ENGINE_CLKGEN_BASE     = 32'h44A7_0000;
+localparam SPI_ENGINE_CNV_BASE        = 32'h44B0_0000;
+localparam DDR_BASE                   = 32'h8000_0000;
+
+//---------------------------------------------------------------------------
+// SPI Engine configuration parameters
+//---------------------------------------------------------------------------
+localparam PCORE_VERSION              = 32'h0001_0171;
+localparam SAMPLE_PERIOD              = 500;
+localparam ASYNC_SPI_CLK              = 1;
+localparam DATA_WIDTH                 = 32;
+localparam DATA_DLENGTH               = 18;
+localparam ECHO_SCLK                  = 0;
+localparam SDI_PHY_DELAY              = 18;
+localparam SDI_DELAY                  = 0;
+localparam NUM_OF_CS                  = 1;
+localparam THREE_WIRE                 = 0;
+localparam CPOL                       = 0;
+localparam CPHA                       = 1;
+localparam CLOCK_DIVIDER              = 0;
+localparam NUM_OF_WORDS               = 1;
+localparam NUM_OF_TRANSFERS           = 8;
+
+//---------------------------------------------------------------------------
+// SPI Engine instructions
+//---------------------------------------------------------------------------
+
+// Chip select instructions
+localparam INST_CS_OFF                = 32'h0000_10FF;
+localparam INST_CS_ON                 = 32'h0000_10FE;
+
+// Transfer instructions
+localparam INST_WR                    = 32'h0000_0100 | (NUM_OF_WORDS-1);
+localparam INST_RD                    = 32'h0000_0200 | (NUM_OF_WORDS-1);
+localparam INST_WRD                   = 32'h0000_0300 | (NUM_OF_WORDS-1);
+
+// Configuration register instructions
+localparam INST_CFG                   = 32'h0000_2100 | (THREE_WIRE << 2) | (CPOL << 1) | CPHA;
+localparam INST_PRESCALE              = 32'h0000_2000 | CLOCK_DIVIDER;
+localparam INST_DLENGTH               = 32'h0000_2200 | DATA_DLENGTH;
+
+// Synchronization
+localparam INST_SYNC                  = 32'h0000_3000;
+
+// Sleep instruction
+localparam INST_SLEEP                 = 32'h0000_3100;
+`define sleep(a)                      (INST_SLEEP | (a & 8'hFF))
+
+program test_program (
+  input spi_engine_irq,
+  input spi_engine_spi_sclk,
+  input [(`NUM_OF_CS - 1):0] spi_engine_spi_cs,
+  input spi_engine_spi_clk,
+  `ifdef DEF_ECHO_SCLK
+  input spi_engine_echo_sclk,
+  `endif
+  input [(`NUM_OF_SDI - 1):0] spi_engine_spi_sdi);
+
+test_harness_env env;
+
+// --------------------------
+// Wrapper function for AXI read verify
+// --------------------------
+task axi_read_v(
+    input   [31:0]  raddr,
+    input   [31:0]  vdata);
+begin
+  env.mng.RegReadVerify32(raddr,vdata);
+end
+endtask
+
+task axi_read(
+    input   [31:0]  raddr,
+    output  [31:0]  data);
+begin
+  env.mng.RegRead32(raddr,data);
+end
+endtask
+
+// --------------------------
+// Wrapper function for AXI write
+// --------------------------
+task axi_write;
+  input [31:0]  waddr;
+  input [31:0]  wdata;
+begin
+  env.mng.RegWrite32(waddr,wdata);
+end
+endtask
+
+// --------------------------
+// Main procedure
+// --------------------------
+initial begin
+
+  //creating environment
+  env = new(`TH.`SYS_CLK.inst.IF,
+            `TH.`DMA_CLK.inst.IF,
+            `TH.`DDR_CLK.inst.IF,
+            `TH.`SYS_RST.inst.IF,
+            `TH.`MNG_AXI.inst.IF,
+            `TH.`DDR_AXI.inst.IF);
+
+  setLoggerVerbosity(6);
+  env.start();
+
+  //asserts all the resets for 100 ns
+  `TH.`SYS_RST.inst.IF.assert_reset;
+  #100
+  `TH.`SYS_RST.inst.IF.deassert_reset;
+  #100
+
+  sanity_test;
+
+  #100
+
+  fifo_spi_test;
+
+  #100
+
+  offload_spi_test;
+  `INFO(("Test Done"));
+
+  $finish;
+
+end
+
+//---------------------------------------------------------------------------
+// Sanity test reg interface
+//---------------------------------------------------------------------------
+
+task sanity_test;
+begin
+  #100 axi_read_v (SPI_ENGINE_BASE + 32'h0000000, 'h0001_0171);
+  #100 axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SCRATCH, 32'hDEADBEEF);
+  #100 axi_read_v (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SCRATCH, 32'hDEADBEEF);
+  `INFO(("Sanity Test Done"));
+end
+endtask
+
+//---------------------------------------------------------------------------
+// SPI Engine generate transfer
+//---------------------------------------------------------------------------
+
+task generate_transfer_cmd;
+  input [7:0] sync_id;
+  begin
+    // assert CSN
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_CS_ON);
+    // transfer data
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_WRD);
+    // de-assert CSN
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_CS_OFF);
+    // SYNC command to generate interrupt
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, (INST_SYNC | sync_id));
+    $display("[%t] NOTE: Transfer generation finished.", $time);
+  end
+endtask
+
+//---------------------------------------------------------------------------
+// IRQ callback
+//---------------------------------------------------------------------------
+
+reg [4:0] irq_pending = 0;
+reg [7:0] sync_id = 0;
+
+initial begin
+  while (1) begin
+    @(posedge spi_engine_irq); // TODO: Make sure irq resets even the source remain active after clearing the IRQ register
+    // read pending IRQs
+    axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQPEND, irq_pending);
+    // IRQ launched by Offload SYNC command
+    if (irq_pending & 5'b10000) begin
+      axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SYNCID, sync_id);
+      $display("[%t] NOTE: Offload SYNC %d IRQ. An offload transfer just finished.", $time, sync_id);
+    end
+    // IRQ launched by SYNC command
+    if (irq_pending & 5'b01000) begin
+      axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SYNCID, sync_id);
+      $display("[%t] NOTE: SYNC %d IRQ. FIFO transfer just finished.", $time, sync_id);
+    end
+    // IRQ launched by SDI FIFO
+    if (irq_pending & 5'b00100) begin
+      $display("[%t] NOTE: SDI FIFO IRQ.", $time);
+    end
+    // IRQ launched by SDO FIFO
+    if (irq_pending & 5'b00010) begin
+      $display("[%t] NOTE: SDO FIFO IRQ.", $time);
+    end
+    // IRQ launched by SDO FIFO
+    if (irq_pending & 5'b00001) begin
+      $display("[%t] NOTE: CMD FIFO IRQ.", $time);
+    end
+    // Clear all pending IRQs
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQPEND, irq_pending);
+  end
+end
+
+//---------------------------------------------------------------------------
+// Echo SCLK generation - we need this only if ECHO_SCLK is enabled
+//---------------------------------------------------------------------------
+
+  reg     [SDI_PHY_DELAY:0] echo_delay_sclk = {SDI_PHY_DELAY{1'b0}};
+  reg     delay_clk = 0;
+  wire    m_spi_sclk;
+
+  assign  m_spi_sclk = spi_engine_spi_sclk;
+
+  // Add an arbitrary delay to the echo_sclk signal
+  initial begin
+    while(1) begin
+      @(posedge delay_clk) begin
+        echo_delay_sclk <= {echo_delay_sclk, m_spi_sclk};
+       end
+    end
+  end
+  assign spi_engine_echo_sclk = echo_delay_sclk[SDI_PHY_DELAY-1];
+
+initial begin
+  while(1) begin
+    #0.5   delay_clk = ~delay_clk;
+  end
+end
+
+//---------------------------------------------------------------------------
+// SDI data generator
+//---------------------------------------------------------------------------
+
+wire          end_of_word;
+wire          spi_sclk_bfm = spi_engine_echo_sclk;
+wire          m_spi_csn_negedge_s;
+wire          m_spi_csn_int_s = &spi_engine_spi_cs;
+bit           m_spi_csn_int_d = 0;
+bit   [31:0]  sdi_shiftreg;
+bit   [7:0]   spi_sclk_pos_counter = 0;
+bit   [7:0]   spi_sclk_neg_counter = 0;
+bit   [31:0]  sdi_preg[$];
+bit   [31:0]  sdi_nreg[$];
+
+initial begin
+  while(1) begin
+    @(posedge spi_engine_spi_clk);
+      m_spi_csn_int_d <= m_spi_csn_int_s;
+  end
+end
+
+assign m_spi_csn_negedge_s = ~m_spi_csn_int_s & m_spi_csn_int_d;
+
+genvar i;
+for (i = 0; i < `NUM_OF_SDI; i++) begin
+  assign spi_engine_spi_sdi[i] = sdi_shiftreg[DATA_DLENGTH-1]; // all SDI lanes got the same data
+end
+
+assign end_of_word = (CPOL ^ CPHA) ?
+                     (spi_sclk_pos_counter == DATA_DLENGTH) :
+                     (spi_sclk_neg_counter == DATA_DLENGTH);
+
+initial begin
+  while(1) begin
+    @(posedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if (m_spi_csn_negedge_s) begin
+      spi_sclk_pos_counter <= 8'b0;
+    end else begin
+      spi_sclk_pos_counter <= (spi_sclk_pos_counter == DATA_DLENGTH) ? 0 : spi_sclk_pos_counter+1;
+    end
+  end
+end
+
+initial begin
+  while(1) begin
+    @(negedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if (m_spi_csn_negedge_s) begin
+      spi_sclk_neg_counter <= 8'b0;
+    end else begin
+      spi_sclk_neg_counter <= (spi_sclk_neg_counter == DATA_DLENGTH) ? 0 : spi_sclk_neg_counter+1;
+    end
+  end
+end
+
+// SDI shift register
+initial begin
+  while(1) begin
+    // synchronization
+    if (CPHA ^ CPOL)
+      @(posedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    else
+      @(negedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if ((m_spi_csn_negedge_s) || (end_of_word)) begin
+      // delete the last word at end_of_word
+      if (end_of_word) begin
+        sdi_preg.pop_back();
+        sdi_nreg.pop_back();
+      end
+      if (m_spi_csn_negedge_s) begin
+        // NOTE: assuming queue is empty
+        repeat (NUM_OF_WORDS) begin
+          sdi_preg.push_front($urandom);
+          sdi_nreg.push_front($urandom);
+        end
+        #1; // prevent race condition
+        sdi_shiftreg <= (CPOL ^ CPHA) ?
+                        sdi_preg[$] :
+                        sdi_nreg[$];
+      end else begin
+        sdi_shiftreg <= (CPOL ^ CPHA) ?
+                        sdi_preg[$] :
+                        sdi_nreg[$];
+      end
+      if (m_spi_csn_negedge_s) @(posedge spi_sclk_bfm); // NOTE: when PHA=1 first shift should be at the second positive edge
+    end else begin /* if ((m_spi_csn_negedge_s) || (end_of_word)) */
+      sdi_shiftreg <= {sdi_shiftreg[DATA_DLENGTH-2:0], 1'b0};
+    end
+  end
+end
+
+//---------------------------------------------------------------------------
+// Storing SDI Data for later comparison
+//---------------------------------------------------------------------------
+
+bit         offload_status = 0;
+bit         shiftreg_sampled = 0;
+bit [15:0]  sdi_store_cnt = 'h0;
+bit [31:0]  offload_sdi_data_store_arr [(NUM_OF_TRANSFERS) - 1:0];
+bit [31:0]  sdi_fifo_data_store;
+bit [DATA_DLENGTH-1:0]  sdi_data_store;
+
+initial begin
+  while(1) begin
+    @(posedge spi_engine_echo_sclk);
+    sdi_data_store <= {sdi_shiftreg[27:0], 4'b0};
+    if (sdi_data_store == 'h0 && shiftreg_sampled == 'h1 && sdi_shiftreg != 'h0) begin
+      shiftreg_sampled <= 'h0;
+      if (offload_status) begin
+        sdi_store_cnt <= sdi_store_cnt + 1;
+      end
+    end else if (shiftreg_sampled == 'h0 && sdi_data_store != 'h0) begin
+      if (offload_status) begin
+        offload_sdi_data_store_arr [sdi_store_cnt] = sdi_shiftreg;
+      end else begin
+        sdi_fifo_data_store = sdi_shiftreg;
+      end
+      shiftreg_sampled <= 'h1;
+    end
+  end
+end
+
+//---------------------------------------------------------------------------
+// Offload Transfer Counter
+//---------------------------------------------------------------------------
+
+bit [31:0] offload_transfer_cnt;
+
+initial begin
+  while(1) begin
+    @(posedge shiftreg_sampled && offload_status);
+      offload_transfer_cnt <= offload_transfer_cnt + 'h1;
+  end
+end
+
+//---------------------------------------------------------------------------
+// Offload SPI Test
+//---------------------------------------------------------------------------
+
+bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
+
+task offload_spi_test;
+  begin
+
+    //Configure DMA
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_CONTROL), `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_FLAGS),
+      `SET_DMAC_FLAGS_TLAST(1) |
+      `SET_DMAC_FLAGS_PARTIAL_REPORTING_EN(1)
+      ); // Use TLAST
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_X_LENGTH), `SET_DMAC_X_LENGTH_X_LENGTH((NUM_OF_TRANSFERS*4)-1)); // X_LENGHTH = 1024-1
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_DEST_ADDRESS), `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(DDR_BASE));  // DEST_ADDRESS
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_TRANSFER_SUBMIT), `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer DMA
+
+    // Configure the Offload module
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CFG);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_PRESCALE);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_DLENGTH);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_ON);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_RD);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_OFF);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_SYNC | 2);
+
+    offload_status = 1;
+
+    // Start the offload
+    #100
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 1);
+    $display("[%t] Offload started.", $time);
+
+    wait(offload_transfer_cnt == NUM_OF_TRANSFERS);
+
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 0);
+    offload_status = 0;
+
+    $display("[%t] Offload stopped.", $time);
+
+    #2000
+
+    for (int i=0; i<=((NUM_OF_TRANSFERS) -1); i=i+1) begin
+      #1
+      offload_captured_word_arr[i] = env.ddr_axi_agent.mem_model.backdoor_memory_read_4byte(DDR_BASE + 4*i);
+    end
+
+    if (irq_pending == 'h0) begin
+      `ERROR(("IRQ Test FAILED"));
+    end else begin
+      `INFO(("IRQ Test PASSED"));
+    end
+
+    if (offload_captured_word_arr [(NUM_OF_TRANSFERS) - 1:2] != offload_sdi_data_store_arr [(NUM_OF_TRANSFERS) - 1:2]) begin
+      `ERROR(("Offload Test FAILED"));
+    end else begin
+      `INFO(("Offload Test PASSED"));
+    end
+
+  end
+endtask
+
+//---------------------------------------------------------------------------
+// FIFO SPI Test
+//---------------------------------------------------------------------------
+
+bit   [31:0]  sdi_fifo_data = 0;
+
+task fifo_spi_test;
+begin
+
+  // Start spi clk generator
+  axi_write (SPI_ENGINE_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+
+  // Config cnv
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d121)); // set PWM period
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+  $display("[%t] axi_pwm_gen started.", $time);
+
+  // Enable SPI Engine
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_ENABLE, 0);
+
+  // Configure the execution module
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_CFG);
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_PRESCALE);
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_DLENGTH);
+
+  // Set up the interrupts
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQMASK, 32'h00018);
+
+  #100
+  // Generate a FIFO transaction, write SDO first
+  repeat (NUM_OF_WORDS) begin
+    #100
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SDOFIFO, (16'hDEAD << (DATA_WIDTH - DATA_DLENGTH)));
+  end
+
+  generate_transfer_cmd(1);
+
+  #100
+  wait(sync_id == 1);
+  #100
+
+  repeat (NUM_OF_WORDS) begin
+  #100
+    axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SDIFIFO, sdi_fifo_data);
+  end
+
+  if (sdi_fifo_data != sdi_fifo_data_store) begin
+    $display("sdi_fifo_data: %x; sdi_fifo_data_store %x", sdi_fifo_data, sdi_fifo_data_store);
+    `ERROR(("Fifo Read Test FAILED"));
+  end else begin
+    $display("sdi_fifo_data: %x; sdi_fifo_data_store %x", sdi_fifo_data, sdi_fifo_data_store);
+    `INFO(("Fifo Read Test PASSED"));
+  end
+
+end
+endtask
+
+endprogram

--- a/spi_engine/tests/test_sleep_delay.sv
+++ b/spi_engine/tests/test_sleep_delay.sv
@@ -1,0 +1,634 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2023 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`include "utils.svh"
+`include "spi_engine.svh"
+
+import axi_vip_pkg::*;
+import axi4stream_vip_pkg::*;
+import adi_regmap_dmac_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_pwm_gen_pkg::*;
+import logger_pkg::*;
+import test_harness_env_pkg::*;
+
+localparam SPI_ENGINE_DMA             = 32'h44A3_0000;
+localparam SPI_ENGINE_BASE            = 32'h44A0_0000;
+localparam SPI_ENGINE_CLKGEN_BASE     = 32'h44A7_0000;
+localparam SPI_ENGINE_CNV_BASE        = 32'h44B0_0000;
+localparam DDR_BASE                   = 32'h8000_0000;
+
+//---------------------------------------------------------------------------
+// SPI Engine configuration parameters
+//---------------------------------------------------------------------------
+localparam PCORE_VERSION              = 32'h0001_0171;
+localparam SAMPLE_PERIOD              = 500;
+localparam ASYNC_SPI_CLK              = 1;
+localparam DATA_WIDTH                 = 32;
+localparam DATA_DLENGTH               = 18;
+localparam ECHO_SCLK                  = 0;
+localparam SDI_PHY_DELAY              = 18;
+localparam SDI_DELAY                  = 0;
+localparam NUM_OF_CS                  = 1;
+localparam THREE_WIRE                 = 0;
+localparam CPOL                       = 0;
+localparam CPHA                       = 1;
+localparam CLOCK_DIVIDER              = 2;
+localparam NUM_OF_WORDS               = 1;
+localparam NUM_OF_TRANSFERS           = 1;
+
+//---------------------------------------------------------------------------
+// SPI Engine instructions
+//---------------------------------------------------------------------------
+
+// Chip select instructions
+localparam INST_CS_OFF                = 32'h0000_10FF;
+localparam INST_CS_ON                 = 32'h0000_10FE;
+localparam INST_CS_OFF_DELAY          = 32'h0000_13FF;
+localparam INST_CS_ON_DELAY           = 32'h0000_13FE;
+
+// Transfer instructions
+localparam INST_WR                    = 32'h0000_0100 | (NUM_OF_WORDS-1);
+localparam INST_RD                    = 32'h0000_0200 | (NUM_OF_WORDS-1);
+localparam INST_WRD                   = 32'h0000_0300 | (NUM_OF_WORDS-1);
+
+// Configuration register instructions
+localparam INST_CFG                   = 32'h0000_2100 | (THREE_WIRE << 2) | (CPOL << 1) | CPHA;
+localparam INST_PRESCALE              = 32'h0000_2000 | CLOCK_DIVIDER;
+localparam INST_DLENGTH               = 32'h0000_2200 | DATA_DLENGTH;
+
+// Synchronization
+localparam INST_SYNC                  = 32'h0000_3000;
+
+// Sleep instruction
+localparam INST_SLEEP                 = 32'h0000_3100;
+`define sleep(a)                      (INST_SLEEP | (a & 8'hFF))
+
+program test_sleep_delay (
+  input spi_engine_irq,
+  input spi_engine_spi_sclk,
+  input spi_engine_spi_cs,
+  input spi_engine_spi_clk,
+  `ifdef DEF_ECHO_SCLK
+  input spi_engine_echo_sclk,
+  `endif
+  input [(`NUM_OF_SDI - 1):0] spi_engine_spi_sdi);
+
+test_harness_env env;
+
+// --------------------------
+// Wrapper function for AXI read verify
+// --------------------------
+task axi_read_v(
+    input   [31:0]  raddr,
+    input   [31:0]  vdata);
+begin
+  env.mng.RegReadVerify32(raddr,vdata);
+end
+endtask
+
+task axi_read(
+    input   [31:0]  raddr,
+    output  [31:0]  data);
+begin
+  env.mng.RegRead32(raddr,data);
+end
+endtask
+
+// --------------------------
+// Wrapper function for AXI write
+// --------------------------
+task axi_write;
+  input [31:0]  waddr;
+  input [31:0]  wdata;
+begin
+  env.mng.RegWrite32(waddr,wdata);
+end
+endtask
+
+// --------------------------
+// Main procedure
+// --------------------------
+initial begin
+
+  //creating environment
+  env = new(`TH.`SYS_CLK.inst.IF,
+            `TH.`DMA_CLK.inst.IF,
+            `TH.`DDR_CLK.inst.IF,
+            `TH.`SYS_RST.inst.IF,
+            `TH.`MNG_AXI.inst.IF,
+            `TH.`DDR_AXI.inst.IF);
+
+  setLoggerVerbosity(6);
+  env.start();
+
+  //asserts all the resets for 100 ns
+  `TH.`SYS_RST.inst.IF.assert_reset;
+  #100
+  `TH.`SYS_RST.inst.IF.deassert_reset;
+  #100
+
+  sanity_test;
+
+  #100
+
+  sleep_delay_test(7);
+
+  cs_delay_test(3,3);
+
+  `INFO(("Test Done"));
+
+  $finish;
+
+end
+
+//---------------------------------------------------------------------------
+// Sanity test reg interface
+//---------------------------------------------------------------------------
+
+task sanity_test;
+begin
+  #100 axi_read_v (SPI_ENGINE_BASE + 32'h0000000, 'h0001_0171);
+  #100 axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SCRATCH, 32'hDEADBEEF);
+  #100 axi_read_v (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SCRATCH, 32'hDEADBEEF);
+  `INFO(("Sanity Test Done"));
+end
+endtask
+
+//---------------------------------------------------------------------------
+// IRQ callback
+//---------------------------------------------------------------------------
+
+reg [4:0] irq_pending = 0;
+reg [7:0] sync_id = 0;
+
+initial begin
+  while (1) begin
+    @(posedge spi_engine_irq); // TODO: Make sure irq resets even the source remain active after clearing the IRQ register
+    // read pending IRQs
+    axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQPEND, irq_pending);
+    // IRQ launched by Offload SYNC command
+    if (irq_pending & 5'b10000) begin
+      axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SYNCID, sync_id);
+      $display("[%t] NOTE: Offload SYNC %d IRQ. An offload transfer just finished.", $time, sync_id);
+    end
+    // IRQ launched by SYNC command
+    if (irq_pending & 5'b01000) begin
+      axi_read (SPI_ENGINE_BASE + `SPI_ENG_ADDR_SYNCID, sync_id);
+      $display("[%t] NOTE: SYNC %d IRQ. FIFO transfer just finished.", $time, sync_id);
+    end
+    // IRQ launched by SDI FIFO
+    if (irq_pending & 5'b00100) begin
+      $display("[%t] NOTE: SDI FIFO IRQ.", $time);
+    end
+    // IRQ launched by SDO FIFO
+    if (irq_pending & 5'b00010) begin
+      $display("[%t] NOTE: SDO FIFO IRQ.", $time);
+    end
+    // IRQ launched by SDO FIFO
+    if (irq_pending & 5'b00001) begin
+      $display("[%t] NOTE: CMD FIFO IRQ.", $time);
+    end
+    // Clear all pending IRQs
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQPEND, irq_pending);
+  end
+end
+
+//---------------------------------------------------------------------------
+// Echo SCLK generation - we need this only if ECHO_SCLK is enabled
+//---------------------------------------------------------------------------
+
+  reg     [SDI_PHY_DELAY:0] echo_delay_sclk = {SDI_PHY_DELAY{1'b0}};
+  reg     delay_clk = 0;
+  wire    m_spi_sclk;
+
+  assign  m_spi_sclk = spi_engine_spi_sclk;
+
+  // Add an arbitrary delay to the echo_sclk signal
+  initial begin
+    while(1) begin
+      @(posedge delay_clk) begin
+        echo_delay_sclk <= {echo_delay_sclk, m_spi_sclk};
+       end
+    end
+  end
+  assign spi_engine_echo_sclk = echo_delay_sclk[SDI_PHY_DELAY-1];
+
+initial begin
+  while(1) begin
+    #0.5   delay_clk = ~delay_clk;
+  end
+end
+
+//---------------------------------------------------------------------------
+// SDI data generator
+//---------------------------------------------------------------------------
+
+wire          end_of_word;
+wire          spi_sclk_bfm = spi_engine_echo_sclk;
+wire          m_spi_csn_negedge_s;
+wire          m_spi_csn_int_s = &spi_engine_spi_cs;
+bit           m_spi_csn_int_d = 0;
+bit   [31:0]  sdi_shiftreg;
+bit   [7:0]   spi_sclk_pos_counter = 0;
+bit   [7:0]   spi_sclk_neg_counter = 0;
+bit   [31:0]  sdi_preg[$];
+bit   [31:0]  sdi_nreg[$];
+
+initial begin
+  while(1) begin
+    @(posedge spi_engine_spi_clk);
+      m_spi_csn_int_d <= m_spi_csn_int_s;
+  end
+end
+
+assign m_spi_csn_negedge_s = ~m_spi_csn_int_s & m_spi_csn_int_d;
+
+genvar i;
+for (i = 0; i < `NUM_OF_SDI; i++) begin
+  assign spi_engine_spi_sdi[i] = sdi_shiftreg[DATA_DLENGTH-1]; // all SDI lanes got the same data
+end
+
+assign end_of_word = (CPOL ^ CPHA) ?
+                     (spi_sclk_pos_counter == DATA_DLENGTH) :
+                     (spi_sclk_neg_counter == DATA_DLENGTH);
+
+initial begin
+  while(1) begin
+    @(posedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if (m_spi_csn_negedge_s) begin
+      spi_sclk_pos_counter <= 8'b0;
+    end else begin
+      spi_sclk_pos_counter <= (spi_sclk_pos_counter == DATA_DLENGTH) ? 0 : spi_sclk_pos_counter+1;
+    end
+  end
+end
+
+initial begin
+  while(1) begin
+    @(negedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if (m_spi_csn_negedge_s) begin
+      spi_sclk_neg_counter <= 8'b0;
+    end else begin
+      spi_sclk_neg_counter <= (spi_sclk_neg_counter == DATA_DLENGTH) ? 0 : spi_sclk_neg_counter+1;
+    end
+  end
+end
+
+// SDI shift register
+initial begin
+  while(1) begin
+    // synchronization
+    if (CPHA ^ CPOL)
+      @(posedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    else
+      @(negedge spi_sclk_bfm or posedge m_spi_csn_negedge_s);
+    if ((m_spi_csn_negedge_s) || (end_of_word)) begin
+      // delete the last word at end_of_word
+      if (end_of_word) begin
+        sdi_preg.pop_back();
+        sdi_nreg.pop_back();
+      end
+      if (m_spi_csn_negedge_s) begin
+        // NOTE: assuming queue is empty
+        repeat (NUM_OF_WORDS) begin
+          sdi_preg.push_front($urandom);
+          sdi_nreg.push_front($urandom);
+        end
+        #1; // prevent race condition
+        sdi_shiftreg <= (CPOL ^ CPHA) ?
+                        sdi_preg[$] :
+                        sdi_nreg[$];
+      end else begin
+        sdi_shiftreg <= (CPOL ^ CPHA) ?
+                        sdi_preg[$] :
+                        sdi_nreg[$];
+      end
+      if (m_spi_csn_negedge_s) @(posedge spi_sclk_bfm); // NOTE: when PHA=1 first shift should be at the second positive edge
+    end else begin /* if ((m_spi_csn_negedge_s) || (end_of_word)) */
+      sdi_shiftreg <= {sdi_shiftreg[DATA_DLENGTH-2:0], 1'b0};
+    end
+  end
+end
+
+//---------------------------------------------------------------------------
+// Storing SDI Data for later comparison
+//---------------------------------------------------------------------------
+
+bit         offload_status = 0;
+bit         shiftreg_sampled = 0;
+bit [15:0]  sdi_store_cnt = 'h0;
+bit [31:0]  offload_sdi_data_store_arr [(NUM_OF_TRANSFERS) - 1:0];
+bit [31:0]  sdi_fifo_data_store;
+bit [DATA_DLENGTH-1:0]  sdi_data_store;
+
+initial begin
+  while(1) begin
+    @(posedge spi_engine_echo_sclk);
+    sdi_data_store <= {sdi_shiftreg[27:0], 4'b0};
+    if (sdi_data_store == 'h0 && shiftreg_sampled == 'h1 && sdi_shiftreg != 'h0) begin
+      shiftreg_sampled <= 'h0;
+      if (offload_status) begin
+        sdi_store_cnt <= sdi_store_cnt + 1;
+      end
+    end else if (shiftreg_sampled == 'h0 && sdi_data_store != 'h0) begin
+      if (offload_status) begin
+        offload_sdi_data_store_arr [sdi_store_cnt] = sdi_shiftreg;
+      end else begin
+        sdi_fifo_data_store = sdi_shiftreg;
+      end
+      shiftreg_sampled <= 'h1;
+    end
+  end
+end
+
+//---------------------------------------------------------------------------
+// Offload Transfer Counter
+//---------------------------------------------------------------------------
+
+bit [31:0] offload_transfer_cnt;
+
+initial begin
+  while(1) begin
+    @(posedge shiftreg_sampled && offload_status);
+      offload_transfer_cnt <= offload_transfer_cnt + 'h1;
+  end
+end
+
+//---------------------------------------------------------------------------
+// Sleep and Chip Select Instruction time counter
+//---------------------------------------------------------------------------
+
+bit [31:0] sleep_instr_time[$];
+bit [31:0] sleep_current_duration;
+bit [31:0] cs_instr_time[$];
+bit [31:0] cs_current_duration;
+wire [15:0] cmd, cmd_d1;
+wire cmd_valid, cmd_ready;
+wire idle;
+
+assign cmd          = test_harness.spi_engine.spi_engine_execution.inst.cmd;
+assign cmd_d1       = test_harness.spi_engine.spi_engine_execution.inst.cmd_d1;
+assign cmd_valid    = test_harness.spi_engine.spi_engine_execution.inst.cmd_valid;
+assign cmd_ready    = test_harness.spi_engine.spi_engine_execution.inst.cmd_ready;
+assign idle         = test_harness.spi_engine.spi_engine_execution.inst.idle;
+
+initial begin
+  sleep_current_duration = 0;
+  while(1) begin
+    @(posedge spi_engine_spi_clk);
+      if (idle && (cmd_d1[15:8] == 8'h31)) begin
+        sleep_instr_time.push_front(sleep_current_duration+1); // add one to account for this cycle
+      end
+      if (cmd_valid && cmd_ready && (cmd[15:8] == 8'h31)) begin
+        sleep_current_duration = 0;
+      end else begin
+        sleep_current_duration = sleep_current_duration+1;
+      end
+      if (idle && (cmd_d1[15:10] == 6'h4)) begin
+        cs_instr_time.push_front(cs_current_duration+1); // add one to account for this cycle
+      end
+      if (cmd_valid && cmd_ready && (cmd[15:10] == 6'h4)) begin
+        cs_current_duration = 0;
+      end else begin
+        cs_current_duration = cs_current_duration+1;
+      end
+  end
+end
+
+//---------------------------------------------------------------------------
+// Sleep delay Test
+//---------------------------------------------------------------------------
+
+bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
+bit [31:0] sleep_time;
+bit [31:0] expected_sleep_time;
+
+task sleep_delay_test;
+  input [7:0] sleep_param;
+begin
+
+  // Start spi clk generator
+  axi_write (SPI_ENGINE_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+
+  // Config cnv
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d1000)); // set PWM period
+  axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+  $display("[%t] axi_pwm_gen started.", $time);
+
+  // Enable SPI Engine
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_ENABLE, 0);
+
+  // Set up the interrupts
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQMASK, 32'h00018);
+
+  // Write commnads stack
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_CFG);
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_PRESCALE);
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, INST_DLENGTH);
+
+  expected_sleep_time = 2+(sleep_param)*((CLOCK_DIVIDER+1)*2);
+  // Start the test
+  #100
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_CMDFIFO, (`sleep(sleep_param)));
+
+  #2000
+  sleep_time = sleep_instr_time.pop_back();
+  if ((sleep_time != expected_sleep_time)) begin
+      `ERROR(("Sleep Test FAILED: unexpected sleep instruction duration. Expected=%d, Got=%d",expected_sleep_time,sleep_time));
+  end else begin
+      `INFO(("Sleep Test PASSED"));
+  end
+  // Disable SPI Engine
+  axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_ENABLE, 1);
+end
+endtask
+
+//---------------------------------------------------------------------------
+// CS delay Test
+//---------------------------------------------------------------------------
+
+bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
+bit [31:0] cs_activate_time;
+bit [31:0] expected_cs_activate_time;
+bit [31:0] cs_deactivate_time;
+bit [31:0] expected_cs_deactivate_time;
+
+task cs_delay_test;
+  input [1:0] cs_activate_delay;
+  input [1:0] cs_deactivate_delay;
+begin
+
+    // Start spi clk generator
+    axi_write (SPI_ENGINE_CLKGEN_BASE + 32'h00000040, 32'h0000003);
+
+    // Config cnv
+    axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('d1000)); // set PWM period
+    axi_write (SPI_ENGINE_CNV_BASE + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+    $display("[%t] axi_pwm_gen started.", $time);
+
+    //Configure DMA
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_CONTROL), `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_FLAGS),
+      `SET_DMAC_FLAGS_TLAST(1) |
+      `SET_DMAC_FLAGS_PARTIAL_REPORTING_EN(1)
+      ); // Use TLAST
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_X_LENGTH), `SET_DMAC_X_LENGTH_X_LENGTH((NUM_OF_TRANSFERS*4)-1)); // X_LENGHTH = 1024-1
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_DEST_ADDRESS), `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(DDR_BASE));  // DEST_ADDRESS
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_TRANSFER_SUBMIT), `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer DMA
+
+    // Enable SPI Engine
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_ENABLE, 0);
+
+    // Set up the interrupts
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_IRQMASK, 32'h00018);
+
+    // Configure the Offload module
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_RESET, 1);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_RESET, 0);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CFG);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_PRESCALE);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_DLENGTH);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_ON);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_RD);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_OFF);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_SYNC | 1);
+
+    offload_transfer_cnt = 0;
+    offload_status = 1;
+    expected_cs_activate_time = 2;
+    expected_cs_deactivate_time = 2;
+
+    // Start the offload
+    #100
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 1);
+    $display("[%t] Offload started (no delay on CS change).", $time);
+
+    wait(offload_transfer_cnt == NUM_OF_TRANSFERS);
+
+    offload_status = 0;
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 0);
+
+
+    $display("[%t] Offload stopped (no delay on CS change).", $time);
+
+    #2000
+
+    for (int i=0; i<=((NUM_OF_TRANSFERS) -1); i=i+1) begin
+      #1
+      offload_captured_word_arr[i] = env.ddr_axi_agent.mem_model.backdoor_memory_read_4byte(DDR_BASE + 4*i);
+    end
+
+    if (irq_pending == 'h0) begin
+      `ERROR(("IRQ Test FAILED"));
+    end else begin
+      `INFO(("IRQ Test PASSED"));
+    end
+
+    if (offload_captured_word_arr [(NUM_OF_TRANSFERS) - 1:2] != offload_sdi_data_store_arr [(NUM_OF_TRANSFERS) - 1:2]) begin
+      `ERROR(("CS Delay Test FAILED: bad data"));
+    end
+
+    cs_activate_time = cs_instr_time.pop_back();
+    cs_deactivate_time = cs_instr_time.pop_back();
+    if ((cs_activate_time != expected_cs_activate_time)) begin
+      `ERROR(("CS Delay Test FAILED: unexpected chip select activate instruction duration. Expected=%d, Got=%d",expected_cs_activate_time,cs_activate_time));
+    end
+    if (cs_deactivate_time != expected_cs_deactivate_time) begin
+      `ERROR(("CS Delay Test FAILED: unexpected chip select deactivate instruction duration. Expected=%d, Got=%d",expected_cs_deactivate_time,cs_deactivate_time));
+    end
+    `INFO(("CS Delay Test PASSED"));
+
+    #2000
+    env.mng.RegWrite32(SPI_ENGINE_DMA + GetAddrs(DMAC_TRANSFER_SUBMIT), `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer DMA
+
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_RESET, 1);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_RESET, 0);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_ON | ((cs_activate_delay & 2'b11) << 8));
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_RD);
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_CS_OFF | ((cs_deactivate_delay & 2'b11) << 8));
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_CMD, INST_SYNC | 2);
+
+    offload_transfer_cnt = 0;
+    sdi_store_cnt = 0;
+    offload_status = 1;
+
+    // breakdown: cs_activate_delay*(1+CLOCK_DIVIDER)*2, times 2 since it's before and after cs transition, and added 3 cycles (1 for each timer comparison, plus one for fetching next instruction)
+    expected_cs_activate_time = 2+2*cs_activate_delay*(1+CLOCK_DIVIDER)*2;
+    expected_cs_deactivate_time = 2+2*cs_deactivate_delay*(1+CLOCK_DIVIDER)*2;
+
+    // Start the offload
+    #100
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 1);
+    $display("[%t] Offload started (with delay on CS change).", $time);
+
+    wait(offload_transfer_cnt == NUM_OF_TRANSFERS);
+
+    offload_status = 0;
+    axi_write (SPI_ENGINE_BASE + `SPI_ENG_ADDR_OFFLOAD_EN, 0);
+
+    $display("[%t] Offload stopped (with delay on CS change).", $time);
+
+    #2000
+
+    for (int i=0; i<=((NUM_OF_TRANSFERS) -1); i=i+1) begin
+      #1
+      offload_captured_word_arr[i] = env.ddr_axi_agent.mem_model.backdoor_memory_read_4byte(DDR_BASE + 4*i);
+    end
+
+    if (irq_pending == 'h0) begin
+      `ERROR(("IRQ Test FAILED"));
+    end else begin
+      `INFO(("IRQ Test PASSED"));
+    end
+
+    if (offload_captured_word_arr [(NUM_OF_TRANSFERS) - 1:2] != offload_sdi_data_store_arr [(NUM_OF_TRANSFERS) - 1:2]) begin
+      `ERROR(("CS Delay Test FAILED: bad data"));
+    end
+    cs_activate_time = cs_instr_time.pop_back();
+    cs_deactivate_time = cs_instr_time.pop_back();
+    if ((cs_activate_time != expected_cs_activate_time)) begin
+      `ERROR(("CS Delay Test FAILED: unexpected chip select activate instruction duration. Expected=%d, Got=%d",expected_cs_activate_time,cs_activate_time));
+    end
+    if (cs_deactivate_time != expected_cs_deactivate_time) begin
+      `ERROR(("CS Delay Test FAILED: unexpected chip select deactivate instruction duration. Expected=%d, Got=%d",expected_cs_deactivate_time,cs_deactivate_time));
+    end
+    `INFO(("CS Delay Test PASSED"));
+
+  end
+endtask
+endprogram

--- a/spi_engine/waves/cfg1.wcfg
+++ b/spi_engine/waves/cfg1.wcfg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wave_config>
+   <wave_state>
+   </wave_state>
+   <db_ref_list>
+      <db_ref path="system_tb_behav.wdb" id="1">
+         <top_modules>
+            <top_module name="\$unit_logger_pkg_sv " />
+            <top_module name="axi4stream_vip_pkg" />
+            <top_module name="axi_vip_pkg" />
+            <top_module name="glbl" />
+            <top_module name="ipif_pkg" />
+            <top_module name="logger_pkg" />
+            <top_module name="m_axi_sequencer_pkg" />
+            <top_module name="reg_accessor_pkg" />
+            <top_module name="s_axi_sequencer_pkg" />
+            <top_module name="std" />
+            <top_module name="system_tb" />
+            <top_module name="test_harness_ddr_axi_vip_0_pkg" />
+            <top_module name="test_harness_env_pkg" />
+            <top_module name="test_harness_mng_axi_vip_0_pkg" />
+            <top_module name="vpkg" />
+            <top_module name="xil_common_vip_pkg" />
+         </top_modules>
+      </db_ref>
+   </db_ref_list>
+   <zoom_setting>
+      <ZoomStartTime time="0.000000 us"></ZoomStartTime>
+      <ZoomEndTime time="133.600001 us"></ZoomEndTime>
+      <Cursor1Time time="29.885000 us"></Cursor1Time>
+   </zoom_setting>
+   <column_width_setting>
+      <NameColumnWidth column_width="204"></NameColumnWidth>
+      <ValueColumnWidth column_width="127"></ValueColumnWidth>
+   </column_width_setting>
+   <WVObjectSize size="8" />
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_spi_cs">
+      <obj_property name="ElementShortName">pulsar_adc_spi_cs</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_spi_cs</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_spi_sclk">
+      <obj_property name="ElementShortName">pulsar_adc_spi_sclk</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_spi_sclk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_spi_clk">
+      <obj_property name="ElementShortName">pulsar_adc_spi_clk</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_spi_clk</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_spi_sdi">
+      <obj_property name="ElementShortName">pulsar_adc_spi_sdi</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_spi_sdi</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_spi_sdo">
+      <obj_property name="ElementShortName">pulsar_adc_spi_sdo</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_spi_sdo</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/pulsar_adc_irq">
+      <obj_property name="ElementShortName">pulsar_adc_irq</obj_property>
+      <obj_property name="ObjectShortName">pulsar_adc_irq</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test/offload_captured_word_arr">
+      <obj_property name="ElementShortName">offload_captured_word_arr[19:0][31:0]</obj_property>
+      <obj_property name="ObjectShortName">offload_captured_word_arr[19:0][31:0]</obj_property>
+      <obj_property name="isExpanded"></obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test/offload_sdi_data_store_arr">
+      <obj_property name="ElementShortName">offload_sdi_data_store_arr[19:0][31:0]</obj_property>
+      <obj_property name="ObjectShortName">offload_sdi_data_store_arr[19:0][31:0]</obj_property>
+      <obj_property name="isExpanded"></obj_property>
+   </wvobject>
+</wave_config>


### PR DESCRIPTION
Add a testbench for SPI Engine, separate from the Pulsar one. This allows us to test new features and/or configurations that don't necessarily make sense for Pulsar.