### PR TITLE
Define the base addresses at block design level

### DIFF
--- a/ad7606x/system_bd.tcl
+++ b/ad7606x/system_bd.tcl
@@ -57,3 +57,15 @@ ad_connect sys_clk sys_cpu_clk
 
 ad_ip_parameter axi_ad7606x CONFIG.DEV_CONFIG $DEV_CONFIG
 ad_ip_parameter axi_ad7606x CONFIG.EXT_CLK $EXT_CLK
+
+set BA_AD7606X 0x44A00000
+set_property offset $BA_AD7606X [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad7606x}]
+adi_sim_add_define "AXI_AD7606X_BA=[format "%d" ${BA_AD7606X}]"
+
+set BA_DMA 0x44A30000
+set_property offset $BA_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad7606x_dma}]
+adi_sim_add_define "AD7606X_DMA_BA=[format "%d" ${BA_DMA}]"
+
+set BA_PWM 0x44A60000
+set_property offset $BA_PWM [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_pwm_gen}]
+adi_sim_add_define "AXI_PWMGEN_BA=[format "%d" ${BA_PWM}]"

--- a/ad7606x/tests/test_program.sv
+++ b/ad7606x/tests/test_program.sv
@@ -47,16 +47,9 @@ import adi_regmap_common_pkg::*;
 import adi_regmap_dmac_pkg::*;
 import adi_regmap_pwm_gen_pkg::*;
 
-`define AD7606X_DMA                     32'h44A3_0000
-`define AXI_AD7606X                     32'h44A0_0000
-`define AXI_PWMGEN                      32'h44A6_0000
-`define DDR_BASE                        32'h8000_0000
-
 parameter DEV_CONFIG = 0;
 parameter SIMPLE_STATUS_CRC = 0;
 parameter EXT_CLK = 0;
-
-localparam AD7606X_BASE = `AXI_AD7606X;
 
 program test_program (
   input         rx_cnvst_n,
@@ -181,7 +174,7 @@ end
 task sanity_test;
   begin
     // check ADC VERSION
-    axi_read_v (AD7606X_BASE + GetAddrs(REG_VERSION),
+    axi_read_v (`AXI_AD7606X_BA + GetAddrs(REG_VERSION),
                     `SET_REG_VERSION_VERSION('h000a0300));
     $display("[%t] Sanity Test Done.", $time);
   end
@@ -381,26 +374,26 @@ bit        ctrl_status_STATUS_CRC = 'h0; // ctrl_status bit from ADC common core
 
 task adc_config_SIMPLE_test;
   begin
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // set static data setup in device's reg 0x21
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_SIMPLE); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // set static data setup in device's reg 0x21
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_SIMPLE); // read last config result
     `INFO(("Config_SIMPLE is set up, ADC_CONFIG_WR contains 0x%h",config_SIMPLE));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_SIMPLE); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_SIMPLE); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_SIMPLE));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_SIMPLE); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_SIMPLE); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_SIMPLE));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
 
     //set HDL config mode
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h100); // set default
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h100); // set default
 
     adc_config_mode = 2'h0;
   end
@@ -408,26 +401,26 @@ endtask
 
 task adc_config_CRC_test;
   begin
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // set CRC and static data setup in device's reg 0x21
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_CRC); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // set CRC and static data setup in device's reg 0x21
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_CRC); // read last config result
     `INFO(("Config_CRC is set up, ADC_CONFIG_WR contains 0x%h",config_CRC));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
 
     //set HDL config mode
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h101); // set default
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h101); // set default
 
     adc_config_mode = 2'h1;
   end
@@ -435,39 +428,39 @@ endtask
 
 task adc_config_STATUS_test;
   begin
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // static data setup in device's reg 0x21
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // static data setup in device's reg 0x21
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
     `INFO(("Config_SIMPLE is set up, ADC_CONFIG_WR contains 0x%h",config_STATUS));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_STATUS));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000248)); // set STATUS header in device's reg 0x02
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000248)); // set STATUS header in device's reg 0x02
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
     `INFO(("Config_STATUS is set up, ADC_CONFIG_WR contains 0x%h",config_STATUS));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_STATUS));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
 
     //set HDL config mode
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h102); // set default
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h102); // set default
 
     adc_config_mode = 2'h2;
   end
@@ -475,39 +468,39 @@ endtask
 
 task adc_config_STATUS_CRC_test;
   begin
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // static data and CRC setup in device's reg 0x21
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // static data and CRC setup in device's reg 0x21
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
     `INFO(("Config_SIMPLE is set up, ADC_CONFIG_WR contains 0x%h",config_STATUS));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_STATUS));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000248)); // set STATUS header in device's reg 0x02
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000248)); // set STATUS header in device's reg 0x02
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
     `INFO(("Config_STATUS is set up, ADC_CONFIG_WR contains 0x%h",config_STATUS));
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_STATUS); // read last config result
     `INFO(("Write request sent, ADC_CONFIG_CTRL contains 0x%h",config_wr_STATUS));
 
     `INFO(("Data on DB_O port: 0x%h",rx_db_o)); // read written data
 
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
-    axi_read(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), config_wr_CRC); // read last config result
     `INFO(("ADC_CONFIG_CTRL contains 0x%h",config_wr_CRC));
 
-    #200 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
-    axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
+    #200 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00000000)); // set exit from register mode sequence
+    axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000001)); // send WR request
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_CTRL), `SET_ADC_COMMON_REG_ADC_CONFIG_CTRL_ADC_CONFIG_CTRL(32'h00000000)); // set default control value (no rd/wr request)
 
    //set HDL config mode
-    #20 axi_write(`AXI_AD7606X + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h103); // set default
+    #20 axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h103); // set default
 
     adc_config_mode = 2'h3;
   end
@@ -522,17 +515,17 @@ task db_transmission_test;
     #100 transfer_status = 1;
 
     // Generate cnvst_n pulse using AXI_PWM_GEN
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(0)); // PWM_GEN reset in regmap (ACTIVE HIGH)
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('h64)); // set PWM period
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_PULSE_0_WIDTH), `SET_REG_PULSE_0_WIDTH_PULSE_0_WIDTH('h63)); // set PWM pulse width
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(0)); // PWM_GEN reset in regmap (ACTIVE HIGH)
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_PULSE_0_PERIOD), `SET_REG_PULSE_0_PERIOD_PULSE_0_PERIOD('h64)); // set PWM period
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_PULSE_0_WIDTH), `SET_REG_PULSE_0_WIDTH_PULSE_0_WIDTH('h63)); // set PWM pulse width
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_RSTN), `SET_REG_RSTN_LOAD_CONFIG(1)); // load AXI_PWM_GEN configuration
     $display("[%t] axi_pwm_gen started.", $time);
 
     wait(rx_ch_count == num_of_transfers);
 
     // Stop pwm gen
-    axi_write (`AXI_PWMGEN + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1));
+    axi_write (`AXI_PWMGEN_BA + GetAddrs(REG_RSTN), `SET_REG_RSTN_RESET(1));
     $display("[%t] axi_pwm_gen stopped.", $time);
   end
 endtask

--- a/ad9083/system_bd.tcl
+++ b/ad9083/system_bd.tcl
@@ -250,3 +250,34 @@ ad_cpu_interconnect 0x7c430000 axi_ad9083_tx_dma
 #
 source $ad_hdl_dir/projects/ad9083_evb/common/ad9083_evb_bd.tcl
 
+set RX_DMA 0x7C400000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9083_rx_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set RX_XCVR 0x44A60000
+set_property offset $RX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9083_rx_xcvr}]
+adi_sim_add_define "RX_XCVR_BA=[format "%d" ${RX_XCVR}]"
+
+set AXI_JESD_RX 0x44AA0000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9083_rx_jesd}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set ADC_TPL 0x44A00000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_rx_ad9083_tpl_core}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set TX_DMA 0x7C430000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9083_tx_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set TX_XCVR 0x44B60000
+set_property offset $TX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_xcvr}]
+adi_sim_add_define "TX_XCVR_BA=[format "%d" ${TX_XCVR}]"
+
+set AXI_JESD_TX 0x44B90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_link}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+set DAC_TPL 0x44B10000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_transport}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"

--- a/ad9083/tests/test_program.sv
+++ b/ad9083/tests/test_program.sv
@@ -52,18 +52,6 @@ import adi_regmap_xcvr_pkg::*;
 import adi_jesd204_pkg::*;
 import adi_xcvr_pkg::*;
 
-`define RX_DMA      32'h7c40_0000
-`define RX_XCVR     32'h44a6_0000
-`define AXI_JESD_RX 32'h44aa_0000
-`define ADC_TPL     32'h44a0_0000
-
-`define TX_DMA      32'h7c43_0000
-`define TX_XCVR     32'h44b6_0000   
-`define AXI_JESD_TX 32'h44b9_0000 
-`define DAC_TPL     32'h44b1_0000
-
-`define DDR_BASE    32'h8000_0000
-
 parameter RX_OUT_BYTES = 8;
 parameter TX_OUT_BYTES = 8;
 program test_program;
@@ -129,29 +117,29 @@ program test_program;
     //
 
     // Enable Rx channel
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
 
     // Select DDS as source
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
     // Configure tone amplitude and frequency
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(32'h00000fff));
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INIT_1(16'h0000)|
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
 
     // Pull out TPL cores from reset
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
     // Sync DDS cores
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
 
     //
@@ -159,25 +147,25 @@ program test_program;
     //
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_SYSREF_CONF),
                        `SET_JESD_TX_SYSREF_CONF_SYSREF_DISABLE(0)); // Enable SYSREF handling
 
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_CONF0),
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_FRAME(`TX_JESD_F-1)|
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`TX_JESD_F*`TX_JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_CONF4),
                        `SET_JESD_TX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`TX_JESD_F*`TX_JESD_K)/TX_OUT_BYTES-1));
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_CONF1),
                        `SET_JESD_TX_LINK_CONF1_SCRAMBLER_DISABLE(0)); // Scrambler enable
 
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
 
     //
@@ -185,39 +173,39 @@ program test_program;
     //
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
 
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_SYSREF_CONF),
                        `SET_JESD_RX_SYSREF_CONF_SYSREF_DISABLE(0)); // Enable SYSREF handling
 
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_CONF0),
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_FRAME(`RX_JESD_F-1)|
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`RX_JESD_F*`RX_JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_CONF4),
                        `SET_JESD_RX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`RX_JESD_F*`RX_JESD_K)/RX_OUT_BYTES-1)); // Beats per multiframe
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_CONF1),
                        `SET_JESD_RX_LINK_CONF1_DESCRAMBLER_DISABLE(0)); // Scrambler enable
 
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
 
     //XCVR INIT
     //REG CTRL
-    env.mng.RegWrite32(`RX_XCVR + GetAddrs(XCVR_CONTROL),
+    env.mng.RegWrite32(`RX_XCVR_BA + GetAddrs(XCVR_CONTROL),
                        `SET_XCVR_CONTROL_LPM_DFE_N(1)|
                        `SET_XCVR_CONTROL_OUTCLK_SEL(4)); // RXOUTCLK uses DIV2
-    env.mng.RegWrite32(`TX_XCVR + GetAddrs(XCVR_CONTROL),
+    env.mng.RegWrite32(`TX_XCVR_BA + GetAddrs(XCVR_CONTROL),
                        `SET_XCVR_CONTROL_LPM_DFE_N(1)|
                        `SET_XCVR_CONTROL_OUTCLK_SEL(4)); // TXOUTCLK uses DIV2
 
-    env.mng.RegWrite32(`RX_XCVR + GetAddrs(XCVR_RESETN),
+    env.mng.RegWrite32(`RX_XCVR_BA + GetAddrs(XCVR_RESETN),
                        `SET_XCVR_RESETN_RESETN(1));
-    env.mng.RegWrite32(`TX_XCVR + GetAddrs(XCVR_RESETN),
+    env.mng.RegWrite32(`TX_XCVR_BA + GetAddrs(XCVR_RESETN),
                        `SET_XCVR_RESETN_RESETN(1));
 
     // Give time the PLLs to lock
@@ -225,22 +213,22 @@ program test_program;
 
     //Read status back
     // Check SYSREF_STATUS
-    env.mng.RegReadVerify32(`AXI_JESD_RX + GetAddrs(JESD_RX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_SYSREF_STATUS),
                             `SET_JESD_RX_SYSREF_STATUS_SYSREF_DETECTED(1));
-    env.mng.RegReadVerify32(`AXI_JESD_TX + GetAddrs(JESD_TX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_SYSREF_STATUS),
                             `SET_JESD_TX_SYSREF_STATUS_SYSREF_DETECTED(1));
 
     // Check if in DATA state and SYNC is 1
-    env.mng.RegReadVerify32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
-    env.mng.RegReadVerify32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_SYNC(1)|
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE(3));
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
     //  -------------------------------------------------------
@@ -251,90 +239,90 @@ program test_program;
     // .step (1),
     // .max_sample(2048)
     for (int i=0;i<2048*2 ;i=i+2) begin
-      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,(((i+1)) << 16) | i ,15);
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)) << 16) | i ,15);
     end
 
     #5us;
 
     // Reset TPL cores
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_DAC_COMMON_REG_RSTN_RSTN(0));
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_ADC_COMMON_REG_RSTN_RSTN(0));
     // Pull out TPL cores from reset
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_MMCM_RSTN(1)|
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
     // Configure Transport Layer for DMA
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
 
     #1us;
 
     // Configure TX DMA
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_CYCLIC(0)|
                        `SET_DMAC_FLAGS_TLAST(1)); // use TLAST, disable CYCLIC
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF)); // X_LENGTH = 992-1
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_SRC_ADDRESS),
-                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BASE)); // SRC_ADDRESS
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA)); // SRC_ADDRESS
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer
                        
     
     // Configure RX DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_CYCLIC(0)|
                        `SET_DMAC_FLAGS_TLAST(1)); // use TLAST, disable CYCLIC
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF)); // X_LENGTH = 992-1
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_DEST_ADDRESS),
-                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BASE+32'h00001000)); // DEST_ADDRESS
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00001000)); // DEST_ADDRESS
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer
                        
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
 
     #25us;
 
     //Read status back
     // Check SYSREF_STATUS
-    env.mng.RegReadVerify32(`AXI_JESD_RX + GetAddrs(JESD_RX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_SYSREF_STATUS),
                             `SET_JESD_RX_SYSREF_STATUS_SYSREF_DETECTED(1));
-    env.mng.RegReadVerify32(`AXI_JESD_TX + GetAddrs(JESD_TX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_SYSREF_STATUS),
                             `SET_JESD_TX_SYSREF_STATUS_SYSREF_DETECTED(1));
 
     #1us;
 
     // Check if in DATA state and SYNC is 1
-    env.mng.RegReadVerify32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
-    env.mng.RegReadVerify32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_SYNC(1)|
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE(3));
     
     #5us;
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(0));
     #5us;
 
     check_captured_data(
-      .address (`DDR_BASE+'h00001000),
+      .address (`DDR_BA+'h00001000),
       .length (992),
       .step (1),
       .max_sample(496)
@@ -342,51 +330,51 @@ program test_program;
 
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     #5us;
 
     // Configure TX DMA
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_CYCLIC(0)|
                        `SET_DMAC_FLAGS_TLAST(1)); // use TLAST, disable CYCLIC
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF)); // X_LENGTH = 992-1
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_SRC_ADDRESS),
-                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BASE)); // SRC_ADDRESS
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA)); // SRC_ADDRESS
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer
 
     // Configure RX DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_CYCLIC(0)|
                        `SET_DMAC_FLAGS_TLAST(1)); // use TLAST, disable CYCLIC
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF)); // X_LENGTH = 992-1
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_DEST_ADDRESS),
-                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BASE+32'h00002000)); // DEST_ADDRESS
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00002000)); // DEST_ADDRESS
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1)); // Submit transfer DMA
                        
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
 
     #10us;
 
     check_captured_data(
-      .address (`DDR_BASE+'h00002000),
+      .address (`DDR_BA+'h00002000),
       .length (992),
       .step (1),
       .max_sample(496)

--- a/ad_quadmxfe1_ebz/system_bd.tcl
+++ b/ad_quadmxfe1_ebz/system_bd.tcl
@@ -93,3 +93,38 @@ if {$ad_project_params(JESD_MODE) == "8B10B"} {
 }
 
 adi_sim_add_define "JESD_MODE=\"$JESD_MODE\""
+
+set RX_DMA 0x7C420000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set AXI_JESD_RX 0x44A90000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_jesd}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set ADC_TPL 0x44A10000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_rx_mxfe_tpl_core}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set TX_DMA 0x7C430000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set AXI_JESD_TX 0x44B90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_jesd}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+set DAC_TPL 0x44B10000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_tx_mxfe_tpl_core}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"
+
+set RX_XCVR 0x44A60000
+adi_sim_add_define "RX_XCVR_BA=[format "%d" ${RX_XCVR}]"
+
+set TX_XCVR 0x44B60000
+adi_sim_add_define "TX_XCVR_BA=[format "%d" ${TX_XCVR}]"
+
+if {$ad_project_params(JESD_MODE) == "8B10B"} {
+  set_property offset $RX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_xcvr}]
+  set_property offset $TX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_xcvr}]
+}

--- a/ad_quadmxfe1_ebz/tests/test_dma.sv
+++ b/ad_quadmxfe1_ebz/tests/test_dma.sv
@@ -49,16 +49,6 @@ import adi_regmap_common_pkg::*;
 import adi_regmap_dac_pkg::*;
 import adi_regmap_adc_pkg::*;
 
-`define RX_DMA      32'h7c42_0000
-`define RX_XCVR     32'h44a6_0000
-`define TX_DMA      32'h7c43_0000
-`define TX_XCVR     32'h44b6_0000
-`define AXI_JESD_RX 32'h44a9_0000
-`define ADC_TPL     32'h44a1_0000
-`define DAC_TPL     32'h44b1_0000
-`define AXI_JESD_TX 32'h44b9_0000
-`define DDR_BASE    32'h8000_0000
-
 parameter RX_OUT_BYTES = (`RX_JESD_F % 3 != 0) ? (`JESD_MODE == "64B66B") ? 8 : 4
                                                : (`JESD_MODE == "64B66B") ? 12 : 6;
 parameter TX_OUT_BYTES = (`TX_JESD_F % 3 != 0) ? (`JESD_MODE == "64B66B") ? 8 : 4
@@ -135,43 +125,43 @@ program test_dma;
     // Init test data
     //
     for (int i=0;i<1024;i=i+2) begin
-      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,
                                                               ((((i+1) % 1024)<<16) <<4) | ((i % 1024) << 4) ,
                                                               4'b1111);
     end
 
     // Configure TX DMA
 
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h00000FFF));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_CYCLIC(1));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_SRC_ADDRESS),
-                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BASE+32'h00000000));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+                       `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA+32'h00000000));
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
 
 
     // Configure Transport Layer to send DMA data on CH0-CH_COUNT-1
     for (int i=0;i<`CH_COUNT;i=i+1) begin
-      env.mng.RegWrite32(`DAC_TPL+((30'h0106+('h10*i))<<2),
+      env.mng.RegWrite32(`DAC_TPL_BA+((30'h0106+('h10*i))<<2),
                          `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
       // Enable Rx channel
-      env.mng.RegWrite32(`ADC_TPL+((30'h0100+('h10*i))<<2),
+      env.mng.RegWrite32(`ADC_TPL_BA+((30'h0100+('h10*i))<<2),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
 
     // Pull out TPL cores from reset
-    env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
  
     // Sync DDS cores
-    env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
 
     //
@@ -179,54 +169,54 @@ program test_dma;
     //
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_SYSREF_CONF),
                        `SET_JESD_TX_SYSREF_CONF_SYSREF_DISABLE(0));
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF0),
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_FRAME(`TX_JESD_F-1) | 
 		       `SET_JESD_TX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`TX_JESD_F*`TX_JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF4),
                        `SET_JESD_TX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`TX_JESD_F*`TX_JESD_K)/TX_OUT_BYTES-1));
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF1),
                        `SET_JESD_TX_LINK_CONF1_SCRAMBLER_DISABLE(0)); 
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
     //
     // Configure RX Link Layer
     //
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_SYSREF_CONF),
                        `SET_JESD_RX_SYSREF_CONF_SYSREF_DISABLE(0)); 
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF0),
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_FRAME(`RX_JESD_F-1) | 
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`RX_JESD_F*`RX_JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF4),
                        `SET_JESD_RX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`RX_JESD_F*`RX_JESD_K)/RX_OUT_BYTES-1));
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF1),
                        `SET_JESD_RX_LINK_CONF1_DESCRAMBLER_DISABLE(0)); 
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
 
     //XCVR INIT
     //REG CTRL
     if (`JESD_MODE != "64B66B") begin
-    env.mng.RegWrite32(`RX_XCVR+32'h0020,32'h00001004);   // RXOUTCLK uses DIV2
-    env.mng.RegWrite32(`TX_XCVR+32'h0020,32'h00001004);
+    env.mng.RegWrite32(`RX_XCVR_BA+32'h0020,32'h00001004);   // RXOUTCLK uses DIV2
+    env.mng.RegWrite32(`TX_XCVR_BA+32'h0020,32'h00001004);
 
-    env.mng.RegWrite32(`RX_XCVR+32'h0010,32'h00000001);
-    env.mng.RegWrite32(`TX_XCVR+32'h0010,32'h00000001);
+    env.mng.RegWrite32(`RX_XCVR_BA+32'h0010,32'h00000001);
+    env.mng.RegWrite32(`TX_XCVR_BA+32'h0010,32'h00000001);
     end
 
      // Wait until link is up
@@ -242,45 +232,45 @@ program test_dma;
 
     //Read status back
     // Check SYSREF_STATUS
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_SYSREF_STATUS),
                             `SET_JESD_TX_SYSREF_STATUS_SYSREF_DETECTED(1));
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_SYSREF_STATUS),
                             `SET_JESD_RX_SYSREF_STATUS_SYSREF_DETECTED(1));
     // Check if in DATA state and SYNC is 1
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE('h3));
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE('h3) | 
                             `SET_JESD_TX_LINK_STATUS_STATUS_SYNC(ref_sync_status));
     // Configure RX DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_TLAST(1));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_DEST_ADDRESS),
-                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BASE+32'h00001000));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+                       `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00001000));
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
     #5us;
     for (int i=0;i<`CH_COUNT;i=i+1) begin
       // Disable Rx channels
-      env.mng.RegWrite32(`ADC_TPL+((30'h0100+('h10*i))<<2), 32'h0000000);
+      env.mng.RegWrite32(`ADC_TPL_BA+((30'h0100+('h10*i))<<2), 32'h0000000);
     end
     #5us;
 
     check_captured_data(
-      .address (`DDR_BASE+'h00001000),
+      .address (`DDR_BA+'h00001000),
       .length (1024),
       .step (1),
       .max_sample(512)
     );
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
 

--- a/ad_quadmxfe1_ebz/tests/test_program_64b66b.sv
+++ b/ad_quadmxfe1_ebz/tests/test_program_64b66b.sv
@@ -49,16 +49,6 @@ import adi_regmap_common_pkg::*;
 import adi_regmap_dac_pkg::*;
 import adi_regmap_adc_pkg::*;
 
-`define RX_DMA      32'h7c42_0000
-`define RX_XCVR     32'h44a6_0000
-`define TX_DMA      32'h7c43_0000
-`define TX_XCVR     32'h44b6_0000
-`define AXI_JESD_RX 32'h44a9_0000
-`define ADC_TPL     32'h44a1_0000
-`define DAC_TPL     32'h44b1_0000
-`define AXI_JESD_TX 32'h44b9_0000
-`define DDR_BASE    32'h8000_0000
-
 `define PHY121 32'h44A4_0000
 `define PHY125 32'h44A5_0000
 
@@ -89,17 +79,17 @@ program test_program_64b66b;
     env.start();
 
     #1us;
-    env.mng.RegRead32(`DAC_TPL+'h0c,tmp);
+    env.mng.RegRead32(`DAC_TPL_BA+'h0c,tmp);
     `INFO(("DAC TPL CONFIG is %h",tmp));
-    env.mng.RegRead32(`DAC_TPL+'h418,tmp);
+    env.mng.RegRead32(`DAC_TPL_BA+'h418,tmp);
     `INFO(("DAC TPL CH0 SEL is %h",tmp));
-    env.mng.RegRead32(`DAC_TPL+'h458,tmp);
+    env.mng.RegRead32(`DAC_TPL_BA+'h458,tmp);
     `INFO(("DAC TPL CH1 SEL is %h",tmp));
 
-    env.mng.RegRead32(`RX_DMA+32'h0010,tmp);
-   `INFO(("RX_DMA interface setup is %h",tmp));
-    env.mng.RegRead32(`TX_DMA+32'h0010,tmp);
-   `INFO(("TX_DMA interface setup is %h",tmp));
+    env.mng.RegRead32(`RX_DMA_BA+32'h0010,tmp);
+   `INFO(("RX_DMA_BA interface setup is %h",tmp));
+    env.mng.RegRead32(`TX_DMA_BA+32'h0010,tmp);
+   `INFO(("TX_DMA_BA interface setup is %h",tmp));
 
     //  -------------------------------------------------------
     //  Test DDS path
@@ -109,62 +99,62 @@ program test_program_64b66b;
     //
 
     // Enable Rx channel CH0
-    env.mng.RegWrite32(`ADC_TPL+(30'h0100<<2), 
+    env.mng.RegWrite32(`ADC_TPL_BA+(30'h0100<<2), 
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     // Enable Rx channel CH31
-    env.mng.RegWrite32(`ADC_TPL+(30'h02F0<<2),
+    env.mng.RegWrite32(`ADC_TPL_BA+(30'h02F0<<2),
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
 
     // Enable Rx channel CH63
-    env.mng.RegWrite32(`ADC_TPL+(30'h04F0<<2),
+    env.mng.RegWrite32(`ADC_TPL_BA+(30'h04F0<<2),
                        `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
  
     // Select DDS as source CH0
-    env.mng.RegWrite32(`DAC_TPL + (30'h0106<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h0106<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
     // Configure tone amplitude and frequency  CH0
-    env.mng.RegWrite32(`DAC_TPL + (30'h0100<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h0100<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h4000));
-    env.mng.RegWrite32(`DAC_TPL + (30'h0101<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h0101<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h28f5));
     // Select DDS as source CH31
-    env.mng.RegWrite32(`DAC_TPL + (30'h02F6<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h02F6<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
     // Select DDS as source CH63
-    env.mng.RegWrite32(`DAC_TPL + (30'h04F6<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h04F6<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
     // Configure tone amplitude and frequency  CH31
-    env.mng.RegWrite32(`DAC_TPL + (30'h02F0<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h02F0<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h4000));
-    env.mng.RegWrite32(`DAC_TPL + (30'h02F1<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h02F1<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h3333));
     // Configure tone amplitude and frequency  CH63
-    env.mng.RegWrite32(`DAC_TPL + (30'h04F0<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h04F0<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h02ff));
-    env.mng.RegWrite32(`DAC_TPL + (30'h04F1<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA + (30'h04F1<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0020));
 
     // Arm external sync
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_COMMON_REG_CNTRL),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_COMMON_REG_CNTRL),
                        `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
 
 
     // Configure RX DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
 
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL +  GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA +  GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
     // Sync DDS cores
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
 
     //
@@ -172,33 +162,33 @@ program test_program_64b66b;
     //
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_SYSREF_CONF),
                        `SET_JESD_RX_SYSREF_CONF_SYSREF_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_SYSREF_CONF),
                        `SET_JESD_TX_SYSREF_CONF_SYSREF_DISABLE(0));
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_CONF0),
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_FRAME('h3) | 
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_MULTIFRAME('hff));
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_CONF0),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_CONF0),
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_FRAME('h3) | 
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_MULTIFRAME('hff));
     
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_CONF1),
                        `SET_JESD_TX_LINK_CONF1_SCRAMBLER_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_CONF1),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_CONF1),
                        `SET_JESD_RX_LINK_CONF1_DESCRAMBLER_DISABLE(0));
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
     //enable near end loopback
 //    for (int i=0;i<8;i++) begin
@@ -210,31 +200,31 @@ program test_program_64b66b;
 
     //XCVR INIT
     //REG CTRL
-//    env.mng.RegWrite32(`RX_XCVR+32'h0020,32'h00001004);   // RXOUTCLK uses DIV2
-//    env.mng.RegWrite32(`TX_XCVR+32'h0020,32'h00001004);
+//    env.mng.RegWrite32(`RX_XCVR_BA+32'h0020,32'h00001004);   // RXOUTCLK uses DIV2
+//    env.mng.RegWrite32(`TX_XCVR_BA+32'h0020,32'h00001004);
 
-//    env.mng.RegWrite32(`RX_XCVR+32'h0010,32'h00000001);
-//    env.mng.RegWrite32(`TX_XCVR+32'h0010,32'h00000001);
+//    env.mng.RegWrite32(`RX_XCVR_BA+32'h0010,32'h00000001);
+//    env.mng.RegWrite32(`TX_XCVR_BA+32'h0010,32'h00000001);
 
     #35us;
 
     //Read status back
     // Check SYSREF_STATUS
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_SYSREF_STATUS),
                             `SET_JESD_RX_SYSREF_STATUS_SYSREF_DETECTED(1));
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_SYSREF_STATUS),
                             `SET_JESD_TX_SYSREF_STATUS_SYSREF_DETECTED(1));
 
     // Check if in DATA state
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE(3));
 
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
 
     //  -------------------------------------------------------
@@ -249,65 +239,65 @@ program test_program_64b66b;
     end
 
     // Arm external sync
-    env.mng.RegWrite32(`DAC_TPL + GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA + GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
-    env.mng.RegWrite32(`ADC_TPL + GetAddrs(ADC_COMMON_REG_CNTRL),
+    env.mng.RegWrite32(`ADC_TPL_BA + GetAddrs(ADC_COMMON_REG_CNTRL),
                        `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
  
     // Configure RX DMA
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
     // Configure TX DMA 
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_CONTROL),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
                        `SET_DMAC_CONTROL_ENABLE(1));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_FLAGS),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
                        `SET_DMAC_FLAGS_TLAST(1));
-    env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_X_LENGTH),
+    env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                        `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
-    env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+    env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                        `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
 
 
     #5us;
 
     // Configure Transport Layer for DMA  CH0
-    env.mng.RegWrite32(`DAC_TPL+(30'h0106<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA+(30'h0106<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
     // Configure Transport Layer for DMA  CH31
-    env.mng.RegWrite32(`DAC_TPL+(30'h02F6<<2),
+    env.mng.RegWrite32(`DAC_TPL_BA+(30'h02F6<<2),
                        `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
 
     // Enable broadcast of channel 0 to all others
     for (int i = 1; i < 31; i++) begin
-      env.mng.RegWrite32(`DAC_TPL+((30'h0106<<2)+(i*'h40)), 32'h00010000);
+      env.mng.RegWrite32(`DAC_TPL_BA+((30'h0106<<2)+(i*'h40)), 32'h00010000);
     end
 
     #1us;
 
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_TX + GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA + GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_RX + GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA + GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
 
     #35us;
 
     //Read status back
     // Check SYSREF_STATUS
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_SYSREF_STATUS),
                             `SET_JESD_RX_SYSREF_STATUS_SYSREF_DETECTED(1));
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_SYSREF_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_SYSREF_STATUS),
                             `SET_JESD_TX_SYSREF_STATUS_SYSREF_DETECTED(1));
     #1us;
 
     // Check if in DATA state
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
-    env.mng.RegReadVerify32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_STATUS),
                             `SET_JESD_TX_LINK_STATUS_STATUS_STATE(3));
     #2us;
 

--- a/adrv9001/system_bd.tcl
+++ b/adrv9001/system_bd.tcl
@@ -55,3 +55,22 @@ source $ad_hdl_dir/projects/adrv9001/common/adrv9001_bd.tcl
 ad_ip_parameter axi_adrv9001 CONFIG.USE_RX_CLK_FOR_TX $ad_project_params(USE_RX_CLK_FOR_TX)
 ad_ip_parameter axi_adrv9001 CONFIG.DDS_DISABLE $ad_project_params(DDS_DISABLE)
 
+set RX1_DMA 0x44A30000
+set_property offset $RX1_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9001_rx1_dma}]
+adi_sim_add_define "RX1_DMA_BA=[format "%d" ${RX1_DMA}]"
+
+set RX2_DMA 0x44A40000
+set_property offset $RX2_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9001_rx2_dma}]
+adi_sim_add_define "RX2_DMA_BA=[format "%d" ${RX2_DMA}]"
+
+set TX1_DMA 0x44A50000
+set_property offset $TX1_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9001_tx1_dma}]
+adi_sim_add_define "TX1_DMA_BA=[format "%d" ${TX1_DMA}]"
+
+set TX2_DMA 0x44A60000
+set_property offset $TX2_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9001_tx2_dma}]
+adi_sim_add_define "TX2_DMA_BA=[format "%d" ${TX2_DMA}]"
+
+set AXI_ADRV9001 0x44A00000
+set_property offset $AXI_ADRV9001 [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9001}]
+adi_sim_add_define "AXI_ADRV9001_BA=[format "%d" ${AXI_ADRV9001}]"

--- a/adrv9001/tests/test_program.sv
+++ b/adrv9001/tests/test_program.sv
@@ -49,13 +49,6 @@ import adi_regmap_common_pkg::*;
 import adi_regmap_jesd_tx_pkg::*;
 import adi_regmap_jesd_rx_pkg::*;
 
-`define RX1_DMA      32'h44A3_0000
-`define RX2_DMA      32'h44A4_0000
-`define TX1_DMA      32'h44A5_0000
-`define TX2_DMA      32'h44A6_0000
-`define AXI_ADRV9001 32'h44A0_0000
-`define DDR_BASE     32'h8000_0000
-
 `define PN7 0
 `define PN15 1
 `define NIBBLE_RAMP 2
@@ -72,31 +65,30 @@ program test_program;
   parameter IQCORRECTION_DISABLE = 1;
   parameter SYMB_OP = 0;
   parameter SYMB_8_16B = 0;
-  parameter BASE = `AXI_ADRV9001;
 
   parameter CH0 = 8'h00 * 4;
   parameter CH1 = 8'h10 * 4;
   parameter CH2 = 8'h20 * 4;
   parameter CH3 = 8'h30 * 4;
 
-  parameter RX1_COMMON  = BASE + 'h00_00 * 4;
-  parameter RX1_CHANNEL = BASE + 'h00_00 * 4;
+  parameter RX1_COMMON  = `AXI_ADRV9001_BA + 'h00_00 * 4;
+  parameter RX1_CHANNEL = `AXI_ADRV9001_BA + 'h00_00 * 4;
 
-  parameter RX1_DLY = BASE + 'h02_00 * 4;
+  parameter RX1_DLY = `AXI_ADRV9001_BA + 'h02_00 * 4;
 
-  parameter RX2_COMMON  = BASE + 'h04_00 * 4;
-  parameter RX2_CHANNEL = BASE + 'h04_00 * 4;
+  parameter RX2_COMMON  = `AXI_ADRV9001_BA + 'h04_00 * 4;
+  parameter RX2_CHANNEL = `AXI_ADRV9001_BA + 'h04_00 * 4;
 
-  parameter RX2_DLY = BASE + 'h06_00 * 4;
+  parameter RX2_DLY = `AXI_ADRV9001_BA + 'h06_00 * 4;
 
-  parameter TX1_COMMON  = BASE + 'h08_00 * 4;
-  parameter TX1_CHANNEL = BASE + 'h08_00 * 4;
+  parameter TX1_COMMON  = `AXI_ADRV9001_BA + 'h08_00 * 4;
+  parameter TX1_CHANNEL = `AXI_ADRV9001_BA + 'h08_00 * 4;
 
-  parameter TX2_COMMON  = BASE + 'h10_00 * 4;
-  parameter TX2_CHANNEL = BASE + 'h10_00 * 4;
+  parameter TX2_COMMON  = `AXI_ADRV9001_BA + 'h10_00 * 4;
+  parameter TX2_CHANNEL = `AXI_ADRV9001_BA + 'h10_00 * 4;
 
-  parameter TDD1 = BASE + 'h12_00 * 4;
-  parameter TDD2 = BASE + 'h13_00 * 4;
+  parameter TDD1 = `AXI_ADRV9001_BA + 'h12_00 * 4;
+  parameter TDD2 = `AXI_ADRV9001_BA + 'h13_00 * 4;
 
   test_harness_env env;
   bit [31:0] val;
@@ -495,20 +487,20 @@ program test_program;
     // Init test data
     for (int i=0;i<2048*2 ;i=i+2) begin
       if (SYMB_OP[0] & SYMB_8_16B[0]) begin
-        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,(((i+1)<<8) << 16) | i<<8 ,15);// (<< 8) - 8 LSBs are dropped in 8 bit data symbol format
+        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)<<8) << 16) | i<<8 ,15);// (<< 8) - 8 LSBs are dropped in 8 bit data symbol format
       end else begin
-        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,((i+1) << 16) | i,15);
+        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,((i+1) << 16) | i,15);
       end
       // Clear destination region
-      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+'h2000+i*2,'hBEEF,15);
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+'h2000+i*2,'hBEEF,15);
     end
 
     // Configure TX DMA
-    env.mng.RegWrite32(`TX1_DMA+32'h400, 32'h00000001); // Enable DMA
-    env.mng.RegWrite32(`TX1_DMA+32'h40c, 32'h00000001); // use CYCLIC
-    env.mng.RegWrite32(`TX1_DMA+32'h418, 32'h00000FFF); // X_LENGHT = 4k
-    env.mng.RegWrite32(`TX1_DMA+32'h414, `DDR_BASE+32'h00000000); // SRC_ADDRESS
-    env.mng.RegWrite32(`TX1_DMA+32'h408, 32'h00000001); // Submit transfer DMA
+    env.mng.RegWrite32(`TX1_DMA_BA+32'h400, 32'h00000001); // Enable DMA
+    env.mng.RegWrite32(`TX1_DMA_BA+32'h40c, 32'h00000001); // use CYCLIC
+    env.mng.RegWrite32(`TX1_DMA_BA+32'h418, 32'h00000FFF); // X_LENGHT = 4k
+    env.mng.RegWrite32(`TX1_DMA_BA+32'h414, `DDR_BA+32'h00000000); // SRC_ADDRESS
+    env.mng.RegWrite32(`TX1_DMA_BA+32'h408, 32'h00000001); // Submit transfer DMA
 
     // Select DMA as source
     axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
@@ -563,19 +555,19 @@ program test_program;
     #20us;
 
     // Configure RX DMA
-    env.mng.RegWrite32(`RX1_DMA+32'h080, 32'h00000001); // Mask SOT IRQ, Enable EOT IRQ
-    env.mng.RegWrite32(`RX1_DMA+32'h400, 32'h00000001); // Enable DMA
-    env.mng.RegWrite32(`RX1_DMA+32'h40c, 32'h00000006); // use TLAST
-    env.mng.RegWrite32(`RX1_DMA+32'h418, 32'h000003FF); // X_LENGHTH = 1024-1
-    env.mng.RegWrite32(`RX1_DMA+32'h410, `DDR_BASE+32'h00002000); // DEST_ADDRESS
-    env.mng.RegWrite32(`RX1_DMA+32'h408, 32'h00000001); // Submit transfer DMA
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h080, 32'h00000001); // Mask SOT IRQ, Enable EOT IRQ
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h400, 32'h00000001); // Enable DMA
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h40c, 32'h00000006); // use TLAST
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h418, 32'h000003FF); // X_LENGHTH = 1024-1
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h410, `DDR_BA+32'h00002000); // DEST_ADDRESS
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h408, 32'h00000001); // Submit transfer DMA
 
     @(posedge system_tb.test_harness.axi_adrv9001_rx1_dma.irq);
     //Clear interrupt
-    env.mng.RegWrite32(`RX1_DMA+32'h084, 32'h00000002);
+    env.mng.RegWrite32(`RX1_DMA_BA+32'h084, 32'h00000002);
 
     check_captured_data(
-      .address (`DDR_BASE+'h00002000),
+      .address (`DDR_BA+'h00002000),
       .length (1024),
       .step (1),
       .max_sample(2048)
@@ -597,20 +589,20 @@ program test_program;
     // Init test data
     for (int i=0;i<2048*2 ;i=i+2) begin
       if (SYMB_OP[0] & SYMB_8_16B[0]) begin
-        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,(((i+1)<<8) << 16) | i<<8 ,15);// (<< 8) - 8 LSBs are dropped in 8 bit data symbol format
+        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)<<8) << 16) | i<<8 ,15);// (<< 8) - 8 LSBs are dropped in 8 bit data symbol format
       end else begin
-        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,((i+1) << 16) | i,15);
+        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,((i+1) << 16) | i,15);
       end
       // Clear destination region
-      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+'h2000+i*2,'hBEEF,15);
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+'h2000+i*2,'hBEEF,15);
     end
 
     // Configure TX DMA
-    env.mng.RegWrite32(`TX2_DMA+32'h400, 32'h00000001); // Enable DMA
-    env.mng.RegWrite32(`TX2_DMA+32'h40c, 32'h00000001); // use CYCLIC
-    env.mng.RegWrite32(`TX2_DMA+32'h418, 32'h00000FFF); // X_LENGHT = 4k
-    env.mng.RegWrite32(`TX2_DMA+32'h414, `DDR_BASE+32'h00000000); // SRC_ADDRESS
-    env.mng.RegWrite32(`TX2_DMA+32'h408, 32'h00000001); // Submit transfer DMA
+    env.mng.RegWrite32(`TX2_DMA_BA+32'h400, 32'h00000001); // Enable DMA
+    env.mng.RegWrite32(`TX2_DMA_BA+32'h40c, 32'h00000001); // use CYCLIC
+    env.mng.RegWrite32(`TX2_DMA_BA+32'h418, 32'h00000FFF); // X_LENGHT = 4k
+    env.mng.RegWrite32(`TX2_DMA_BA+32'h414, `DDR_BA+32'h00000000); // SRC_ADDRESS
+    env.mng.RegWrite32(`TX2_DMA_BA+32'h408, 32'h00000001); // Submit transfer DMA
 
     // Select DDS as source
     axi_write (TX2_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
@@ -641,19 +633,19 @@ program test_program;
     #20us;
 
     // Configure RX DMA
-    env.mng.RegWrite32(`RX2_DMA+32'h080, 32'h00000001); // Mask SOT IRQ, Enable EOT IRQ
-    env.mng.RegWrite32(`RX2_DMA+32'h400, 32'h00000001); // Enable DMA
-    env.mng.RegWrite32(`RX2_DMA+32'h40c, 32'h00000006); // use TLAST
-    env.mng.RegWrite32(`RX2_DMA+32'h418, 32'h000003FF); // X_LENGHTH = 1024-1
-    env.mng.RegWrite32(`RX2_DMA+32'h410, `DDR_BASE+32'h00002000); // DEST_ADDRESS
-    env.mng.RegWrite32(`RX2_DMA+32'h408, 32'h00000001); // Submit transfer DMA
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h080, 32'h00000001); // Mask SOT IRQ, Enable EOT IRQ
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h400, 32'h00000001); // Enable DMA
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h40c, 32'h00000006); // use TLAST
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h418, 32'h000003FF); // X_LENGHTH = 1024-1
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h410, `DDR_BA+32'h00002000); // DEST_ADDRESS
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h408, 32'h00000001); // Submit transfer DMA
 
     @(posedge system_tb.test_harness.axi_adrv9001_rx2_dma.irq);
     //Clear interrupt
-    env.mng.RegWrite32(`RX2_DMA+32'h084, 32'h00000002);
+    env.mng.RegWrite32(`RX2_DMA_BA+32'h084, 32'h00000002);
 
     check_captured_data(
-      .address (`DDR_BASE+'h00002000),
+      .address (`DDR_BA+'h00002000),
       .length (1024),
       .step (1),
       .max_sample(2048)

--- a/adrv9009/system_bd.tcl
+++ b/adrv9009/system_bd.tcl
@@ -286,3 +286,107 @@ for {set i 0} {$i < $RX_OS_NUM_OF_CONVERTERS} {incr i} {
 }
 
 assign_bd_address
+
+set AXI_JESD_RX_OS 0x44AB0000
+set_property offset $AXI_JESD_RX_OS [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_os_jesd}]
+adi_sim_add_define "AXI_JESD_RX_OS_BA=[format "%d" ${AXI_JESD_RX_OS}]"
+
+set AXI_JESD_RX 0x44AA0000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_jesd}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set AXI_JESD_TX 0x44A90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_tx_jesd}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+
+set TX_DMA 0x7C420000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_tx_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set RX_DMA 0x7C400000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set RX_OS_DMA 0x7C440000
+set_property offset $RX_OS_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_os_dma}]
+adi_sim_add_define "RX_OS_DMA_BA=[format "%d" ${RX_OS_DMA}]"
+
+
+set ADC_TPL 0x44A00000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_rx_adrv9009_tpl_core}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set ADC_OS_TPL 0x44A08000
+set_property offset $ADC_OS_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_rx_os_adrv9009_tpl_core}]
+adi_sim_add_define "ADC_OS_TPL_BA=[format "%d" ${ADC_OS_TPL}]"
+
+set DAC_TPL 0x44A04000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_tx_adrv9009_tpl_core}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"
+
+
+set EX_ADC_TPL 0x44A30000
+set_property offset $EX_ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_adc_tpl_core_axi_lite}]
+adi_sim_add_define "EX_ADC_TPL_BA=[format "%d" ${EX_ADC_TPL}]"
+
+set EX_DAC_TPL 0x44AC0000
+set_property offset $EX_DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_dac_tpl_core_axi_lite}]
+adi_sim_add_define "EX_DAC_TPL_BA=[format "%d" ${EX_DAC_TPL}]"
+
+set EX_DAC_OS_TPL 0x44AF0000
+set_property offset $EX_DAC_OS_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_dac_tpl_core_axi_lite_1}]
+adi_sim_add_define "EX_DAC_OS_TPL_BA=[format "%d" ${EX_DAC_OS_TPL}]"
+
+
+set DUT_AXI_XCVR_RX_OS 0x44A50000
+set_property offset $DUT_AXI_XCVR_RX_OS [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_os_xcvr}]
+adi_sim_add_define "DUT_AXI_XCVR_RX_OS_BA=[format "%d" ${DUT_AXI_XCVR_RX_OS}]"
+
+set DUT_AXI_XCVR_RX 0x44A60000
+set_property offset $DUT_AXI_XCVR_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_xcvr}]
+adi_sim_add_define "DUT_AXI_XCVR_RX_BA=[format "%d" ${DUT_AXI_XCVR_RX}]"
+
+set DUT_AXI_XCVR_TX 0x44A80000
+set_property offset $DUT_AXI_XCVR_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_tx_xcvr}]
+adi_sim_add_define "DUT_AXI_XCVR_TX_BA=[format "%d" ${DUT_AXI_XCVR_TX}]"
+
+
+set EX_AXI_XCVR_RX 0x44A20000
+set_property offset $EX_AXI_XCVR_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_axi_xcvr_axi_lite}]
+adi_sim_add_define "EX_AXI_XCVR_RX_BA=[format "%d" ${EX_AXI_XCVR_RX}]"
+
+set EX_AXI_JESD_RX 0x44A10000
+set_property offset $EX_AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_rx_axi_axi_lite}]
+adi_sim_add_define "EX_AXI_JESD_RX_BA=[format "%d" ${EX_AXI_JESD_RX}]"
+
+
+set EX_AXI_XCVR_TX 0x44A70000
+set_property offset $EX_AXI_XCVR_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_axi_xcvr_axi_lite_1}]
+adi_sim_add_define "EX_AXI_XCVR_TX_BA=[format "%d" ${EX_AXI_XCVR_TX}]"
+
+set EX_AXI_JESD_TX 0x44A40000
+set_property offset $EX_AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_tx_axi_axi_lite}]
+adi_sim_add_define "EX_AXI_JESD_TX_BA=[format "%d" ${EX_AXI_JESD_TX}]"
+
+
+set EX_AXI_XCVR_TX_OS 0x44AE0000
+set_property offset $EX_AXI_XCVR_TX_OS [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_axi_xcvr_axi_lite_2}]
+adi_sim_add_define "EX_AXI_XCVR_TX_OS_BA=[format "%d" ${EX_AXI_XCVR_TX_OS}]"
+
+set EX_AXI_JESD_TX_OS 0x44AD0000
+set_property offset $EX_AXI_JESD_TX_OS [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_tx_axi_axi_lite_1}]
+adi_sim_add_define "EX_AXI_JESD_TX_OS_BA=[format "%d" ${EX_AXI_JESD_TX_OS}]"
+
+
+set AXI_CLKGEN_TX 0x43C00000
+set_property offset $AXI_CLKGEN_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_tx_clkgen}]
+adi_sim_add_define "AXI_CLKGEN_TX_BA=[format "%d" ${AXI_CLKGEN_TX}]"
+
+set AXI_CLKGEN_RX 0x43C10000
+set_property offset $AXI_CLKGEN_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_clkgen}]
+adi_sim_add_define "AXI_CLKGEN_RX_BA=[format "%d" ${AXI_CLKGEN_RX}]"
+
+set AXI_CLKGEN_RX_OS 0x43C20000
+set_property offset $AXI_CLKGEN_RX_OS [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_adrv9009_rx_os_clkgen}]
+adi_sim_add_define "AXI_CLKGEN_RX_OS_BA=[format "%d" ${AXI_CLKGEN_RX_OS}]"

--- a/adrv9009/tests/test_program.sv
+++ b/adrv9009/tests/test_program.sv
@@ -51,42 +51,6 @@ import adi_regmap_adc_pkg::*;
 import adi_jesd204_pkg::*;
 import adi_xcvr_pkg::*;
 
-
-`define AXI_JESD_RX_OS 32'h44ab_0000
-`define AXI_JESD_RX    32'h44aa_0000
-`define AXI_JESD_TX    32'h44a9_0000
-
-`define TX_DMA    32'h7C42_0000
-`define RX_DMA    32'h7C40_0000
-`define RX_OS_DMA 32'h7C44_0000
-
-`define ADC_TPL    32'h44a0_0000
-`define ADC_OS_TPL 32'h44a0_8000
-`define DAC_TPL    32'h44a0_4000
-
-`define EX_ADC_TPL    32'h44a3_0000
-`define EX_DAC_TPL    32'h44ac_0000
-`define EX_DAC_OS_TPL 32'h44af_0000
-
-`define DUT_AXI_XCVR_RX_OS 32'h44a5_0000
-`define DUT_AXI_XCVR_RX    32'h44a6_0000
-`define DUT_AXI_XCVR_TX    32'h44a8_0000
-
-`define EX_AXI_XCVR_RX 32'h44a2_0000
-`define EX_AXI_JESD_RX 32'h44a1_0000
-
-`define EX_AXI_XCVR_TX 32'h44a7_0000
-`define EX_AXI_JESD_TX 32'h44a4_0000
-
-`define EX_AXI_XCVR_TX_OS 32'h44ae_0000
-`define EX_AXI_JESD_TX_OS 32'h44ad_0000
-
-`define AXI_CLKGEN_TX    32'h43c0_0000
-`define AXI_CLKGEN_RX    32'h43c1_0000
-`define AXI_CLKGEN_RX_OS 32'h43c2_0000
-
-`define DDR_BASE 32'h44A0_0000
-
 `define LINK_MODE 2
 `define MODE_8B10B 1
 `define MODE_64B66B 2
@@ -168,40 +132,40 @@ program test_program;
     rx_os_link.set_encoding(enc8b10b);
     rx_os_link.set_lane_rate(lane_rate);
 
-    ex_rx_ll = new("EX RX_LINK_LAYER", env.mng, `EX_AXI_JESD_RX, tx_link);
+    ex_rx_ll = new("EX RX_LINK_LAYER", env.mng, `EX_AXI_JESD_RX_BA, tx_link);
     ex_rx_ll.probe();
 
-    ex_tx_ll = new("EX TX_LINK_LAYER", env.mng, `EX_AXI_JESD_TX, rx_link);
+    ex_tx_ll = new("EX TX_LINK_LAYER", env.mng, `EX_AXI_JESD_TX_BA, rx_link);
     ex_tx_ll.probe();
 
-    ex_tx_os_ll = new("EX TX_OS_LINK_LAYER", env.mng, `EX_AXI_JESD_TX_OS, rx_os_link);
+    ex_tx_os_ll = new("EX TX_OS_LINK_LAYER", env.mng, `EX_AXI_JESD_TX_OS_BA, rx_os_link);
     ex_tx_os_ll.probe();
 
-    ex_rx_xcvr = new("EX RX_XCVR", env.mng, `EX_AXI_XCVR_RX);
+    ex_rx_xcvr = new("EX RX_XCVR", env.mng, `EX_AXI_XCVR_RX_BA);
     ex_rx_xcvr.probe();
 
-    ex_tx_xcvr = new("EX TX_XCVR", env.mng, `EX_AXI_XCVR_TX);
+    ex_tx_xcvr = new("EX TX_XCVR", env.mng, `EX_AXI_XCVR_TX_BA);
     ex_tx_xcvr.probe();
 
-    ex_tx_os_xcvr = new("EX TX_OS_XCVR", env.mng, `EX_AXI_XCVR_TX_OS);
+    ex_tx_os_xcvr = new("EX TX_OS_XCVR", env.mng, `EX_AXI_XCVR_TX_OS_BA);
     ex_tx_os_xcvr.probe();
 
-    dut_rx_xcvr = new("DUT RX_XCVR", env.mng, `DUT_AXI_XCVR_RX);
+    dut_rx_xcvr = new("DUT RX_XCVR", env.mng, `DUT_AXI_XCVR_RX_BA);
     dut_rx_xcvr.probe();
 
-    dut_rx_os_xcvr = new("DUT RX_OS_XCVR", env.mng, `DUT_AXI_XCVR_RX_OS);
+    dut_rx_os_xcvr = new("DUT RX_OS_XCVR", env.mng, `DUT_AXI_XCVR_RX_OS_BA);
     dut_rx_os_xcvr.probe();
 
-    dut_tx_xcvr = new("DUT TX_XCVR", env.mng, `DUT_AXI_XCVR_TX);
+    dut_tx_xcvr = new("DUT TX_XCVR", env.mng, `DUT_AXI_XCVR_TX_BA);
     dut_tx_xcvr.probe();
 
-    dut_rx_ll = new("DUT RX_LINK_LAYER", env.mng, `AXI_JESD_RX, rx_link);
+    dut_rx_ll = new("DUT RX_LINK_LAYER", env.mng, `AXI_JESD_RX_BA, rx_link);
     dut_rx_ll.probe();
 
-    dut_rx_os_ll = new("DUT RX_OS_LINK_LAYER", env.mng, `AXI_JESD_RX_OS, rx_os_link);
+    dut_rx_os_ll = new("DUT RX_OS_LINK_LAYER", env.mng, `AXI_JESD_RX_OS_BA, rx_os_link);
     dut_rx_os_ll.probe();
 
-    dut_tx_ll = new("DUT TX_LINK_LAYER", env.mng, `AXI_JESD_TX, tx_link);
+    dut_tx_ll = new("DUT TX_LINK_LAYER", env.mng, `AXI_JESD_TX_BA, tx_link);
     dut_tx_ll.probe();
 
     `TH.`REF_CLK.inst.IF.set_clk_frq(.user_frequency(`REF_CLK_RATE*1000000));
@@ -274,19 +238,19 @@ program test_program;
   task tx_tpl_test(int use_dds);
     if (!use_dds) begin
       for (int i=0;i<2048*2 ;i=i+2) begin
-        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,(((i+1)) << 16) | i ,15);
+        env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)) << 16) | i ,15);
       end
 
       // Configure TX DMA
-      env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_CONTROL),
+      env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
                          `SET_DMAC_CONTROL_ENABLE(1));
-      env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_FLAGS),
+      env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
                          `SET_DMAC_FLAGS_TLAST(1));
-      env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_X_LENGTH),
+      env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                          `SET_DMAC_X_LENGTH_X_LENGTH(32'h00000FFF));
-      env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_SRC_ADDRESS),
-                         `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BASE+32'h00000000));
-      env.mng.RegWrite32(`TX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+      env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+                         `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA+32'h00000000));
+      env.mng.RegWrite32(`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                          `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
       #5us;
     end
@@ -294,42 +258,42 @@ program test_program;
     for (int i = 0; i < `TX_JESD_M; i++) begin
       if (use_dds) begin
         // Select DDS as source
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
         // Configure tone amplitude and frequency
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
 
       end else begin
         // Set DMA as source for DAC TPL
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
       end
     end
 
     for (int i = 0; i < `TX_JESD_M; i++) begin
-      env.mng.RegWrite32(`EX_ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+      env.mng.RegWrite32(`EX_ADC_TPL_BA+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
 
-    env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`EX_ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`EX_ADC_TPL_BA+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
     if (use_dds) begin
       // Sync DDS cores
-      env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+      env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_CNTRL_1),
                          `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
     end
 
     // -----------------------
     // bringup DUT TX path
     // -----------------------
-    env.mng.RegWrite32(`AXI_CLKGEN_TX + 'h40, 3);
+    env.mng.RegWrite32(`AXI_CLKGEN_TX_BA + 'h40, 3);
     dut_tx_xcvr.up();
     dut_tx_ll.link_up();
 
@@ -349,35 +313,35 @@ program test_program;
     for (int i = 0; i < `RX_JESD_M; i++) begin
       if (use_dds) begin
         // Select DDS as source
-        env.mng.RegWrite32(`EX_DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`EX_DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
         // Configure tone amplitude and frequency
-        env.mng.RegWrite32(`EX_DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+        env.mng.RegWrite32(`EX_DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
-        env.mng.RegWrite32(`EX_DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+        env.mng.RegWrite32(`EX_DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
 
       end else begin
         // Set DMA as source for DAC TPL
-        env.mng.RegWrite32(`EX_DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`EX_DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
       end
     end
 
     for (int i = 0; i < `RX_JESD_M; i++) begin
-      env.mng.RegWrite32(`ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+      env.mng.RegWrite32(`ADC_TPL_BA+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
-    env.mng.RegWrite32(`EX_DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`EX_DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
     
     // -----------------------
     // bringup DUT RX path
     // -----------------------
-    env.mng.RegWrite32(`AXI_CLKGEN_RX + 'h40, 3);
+    env.mng.RegWrite32(`AXI_CLKGEN_RX_BA + 'h40, 3);
     ex_tx_xcvr.up();
     ex_tx_ll.link_up();
 
@@ -391,21 +355,21 @@ program test_program;
     
     // Configure RX DMA
     if (!use_dds) begin
-      env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_CONTROL),
+      env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
                          `SET_DMAC_CONTROL_ENABLE(1));
-      env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_FLAGS),
+      env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
                          `SET_DMAC_FLAGS_TLAST(1));
-      env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_X_LENGTH),
+      env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                          `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF));
-      env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_DEST_ADDRESS),
-                         `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BASE+32'h00001000));
-      env.mng.RegWrite32(`RX_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+      env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+                         `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00001000));
+      env.mng.RegWrite32(`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                          `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
   
       #5us;
   
       check_captured_data(
-        .address (`DDR_BASE+'h00001000),
+        .address (`DDR_BA+'h00001000),
         .length (992),
         .step (1),
         .max_sample(2048)
@@ -423,35 +387,35 @@ program test_program;
     for (int i = 0; i < `RX_OS_JESD_M; i++) begin
       if (use_dds) begin
         // Select DDS as source
-        env.mng.RegWrite32(`EX_DAC_OS_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`EX_DAC_OS_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
         // Configure tone amplitude and frequency
-        env.mng.RegWrite32(`EX_DAC_OS_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+        env.mng.RegWrite32(`EX_DAC_OS_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
-        env.mng.RegWrite32(`EX_DAC_OS_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+        env.mng.RegWrite32(`EX_DAC_OS_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
 
       end else begin
         // Set DMA as source for DAC TPL
-        env.mng.RegWrite32(`EX_DAC_OS_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`EX_DAC_OS_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
       end
     end
 
     for (int i = 0; i < `RX_OS_JESD_M; i++) begin
-      env.mng.RegWrite32(`ADC_OS_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+      env.mng.RegWrite32(`ADC_OS_TPL_BA+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
-    env.mng.RegWrite32(`EX_DAC_OS_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`EX_DAC_OS_TPL_BA+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_OS_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_OS_TPL_BA+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
     // -----------------------
     // bringup DUT RX OBS path
     // -----------------------
-    env.mng.RegWrite32(`AXI_CLKGEN_RX_OS + 'h40, 3);
+    env.mng.RegWrite32(`AXI_CLKGEN_RX_OS_BA + 'h40, 3);
     ex_tx_os_xcvr.up();
     ex_tx_os_ll.link_up();
 
@@ -465,21 +429,21 @@ program test_program;
     
     // Configure RX OBS DMA
     if (!use_dds) begin
-      env.mng.RegWrite32(`RX_OS_DMA+GetAddrs(DMAC_CONTROL),
+      env.mng.RegWrite32(`RX_OS_DMA_BA+GetAddrs(DMAC_CONTROL),
                          `SET_DMAC_CONTROL_ENABLE(1));
-      env.mng.RegWrite32(`RX_OS_DMA+GetAddrs(DMAC_FLAGS),
+      env.mng.RegWrite32(`RX_OS_DMA_BA+GetAddrs(DMAC_FLAGS),
                          `SET_DMAC_FLAGS_TLAST(1));
-      env.mng.RegWrite32(`RX_OS_DMA+GetAddrs(DMAC_X_LENGTH),
+      env.mng.RegWrite32(`RX_OS_DMA_BA+GetAddrs(DMAC_X_LENGTH),
                          `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003DF));
-      env.mng.RegWrite32(`RX_OS_DMA+GetAddrs(DMAC_DEST_ADDRESS),
-                         `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BASE+32'h00001000));
-      env.mng.RegWrite32(`RX_OS_DMA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+      env.mng.RegWrite32(`RX_OS_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+                         `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00001000));
+      env.mng.RegWrite32(`RX_OS_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
                          `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
   
       #5us;
   
       check_captured_data(
-        .address (`DDR_BASE+'h00001000),
+        .address (`DDR_BA+'h00001000),
         .length (992),
         .step (1),
         .max_sample(2048)

--- a/axi_tdd/system_bd.tcl
+++ b/axi_tdd/system_bd.tcl
@@ -67,3 +67,6 @@ ad_connect tdd_channel dut_tdd/tdd_channel
 
 ad_cpu_interconnect 0x7c420000 dut_tdd
 
+set TDD 0x7C420000
+set_property offset $TDD [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dut_tdd}]
+adi_sim_add_define "TDD_BA=[format "%d" ${TDD}]"

--- a/axi_tdd/tests/test_program.sv
+++ b/axi_tdd/tests/test_program.sv
@@ -113,7 +113,7 @@ program test_program;
 
     // Init test data
     // Read the interface description
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_INTERFACE_DESCRIPTION), val);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_INTERFACE_DESCRIPTION), val);
     channel_count     = `GET_TDDN_CNTRL_INTERFACE_DESCRIPTION_CHANNEL_COUNT_EXTRA(val);
     reg_count_width   = `GET_TDDN_CNTRL_INTERFACE_DESCRIPTION_REGISTER_WIDTH(val);
     burst_count_width = `GET_TDDN_CNTRL_INTERFACE_DESCRIPTION_BURST_COUNT_WIDTH(val);
@@ -123,41 +123,41 @@ program test_program;
     sync_ext_cdc      = `GET_TDDN_CNTRL_INTERFACE_DESCRIPTION_SYNC_EXTERNAL_CDC(val);
 
     // Register configuration
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
                        `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(32'hFFFFFFFF));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
                        `SET_TDDN_CNTRL_CHANNEL_POLARITY_CHANNEL_POLARITY(32'h00000000));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_BURST_COUNT),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT),
                        `SET_TDDN_CNTRL_BURST_COUNT_BURST_COUNT(channel_count+1));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_STARTUP_DELAY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_STARTUP_DELAY),
                        `SET_TDDN_CNTRL_STARTUP_DELAY_STARTUP_DELAY(32'h0000007F));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_FRAME_LENGTH),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_FRAME_LENGTH),
                        `SET_TDDN_CNTRL_FRAME_LENGTH_FRAME_LENGTH(32'h0000007F));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_LOW),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_LOW),
                        `SET_TDDN_CNTRL_SYNC_COUNTER_LOW_SYNC_COUNTER_LOW(32'h000001FF));
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_HIGH),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_HIGH),
                        `SET_TDDN_CNTRL_SYNC_COUNTER_HIGH_SYNC_COUNTER_HIGH(32'h00000000));
 
     // Reading back the actual register values (the values may change depending on the synthesis configuration)
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE), ch_en);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE), ch_en);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_BURST_COUNT), burst_count);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT), burst_count);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STARTUP_DELAY), startup_delay);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STARTUP_DELAY), startup_delay);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_FRAME_LENGTH), frame_length);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_FRAME_LENGTH), frame_length);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_LOW), sync_count_low);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_LOW), sync_count_low);
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_HIGH), sync_count_high);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_SYNC_COUNTER_HIGH), sync_count_high);
 
 
     //  -------------------------------------------------------
@@ -173,17 +173,17 @@ program test_program;
     end 
 
     for (int i=0; i<32; i++) begin
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8,
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8,
                          `SET_TDDN_CNTRL_CH0_ON_CH0_ON(ch_on[i]));
 
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8,
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8,
                          `SET_TDDN_CNTRL_CH0_OFF_CH0_OFF(ch_off[i]));
     end 
 
 
     // Read back the values; unimplemented channels should not store these values
     for (int i=0; i<32; i++) begin
-      env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8, val);
+      env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8, val);
 
       if (i <= channel_count) begin
         expected_val = ch_on[i];
@@ -197,7 +197,7 @@ program test_program;
         success_count++;
       end
 
-      env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8, val);
+      env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8, val);
 
       if (i <= channel_count) begin
         expected_val = ch_off[i];
@@ -213,7 +213,7 @@ program test_program;
     end 
 
     // Read the status register to validate the current state 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STATUS), current_state);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STATUS), current_state);
 
     if (current_state !== 2'b00) begin
       `ERROR(("Idle state: Expected 2'b00 found 2'b%b", current_state));
@@ -223,7 +223,7 @@ program test_program;
 
 
     // Enable the module; use internal sync for transfer triggering
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(1)|
@@ -239,7 +239,7 @@ program test_program;
 
     // Read the status register to validate the current state 
     repeat (8) @(posedge `TH.dut_tdd.inst.up_clk);
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STATUS), current_state);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STATUS), current_state);
 
     if (current_state !== 2'b10) begin
       `ERROR(("Waiting state: Expected 2'b10 found 2'b%b", current_state));
@@ -265,7 +265,7 @@ program test_program;
 
     // Read the status register to validate the current state issuing a parallel thread
     repeat (8) @(posedge `TH.dut_tdd.inst.up_clk);
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STATUS), current_state);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STATUS), current_state);
 
     if (current_state !== 2'b11) begin
       `ERROR(("Running state: Expected 2'b11 found 2'b%b", current_state));
@@ -282,7 +282,7 @@ program test_program;
     //*******//
     // Read the status register to validate the current state 
     repeat (8) @(posedge `TH.dut_tdd.inst.up_clk);
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STATUS), current_state);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STATUS), current_state);
 
     if (current_state !== 2'b01) begin
       `ERROR(("Armed state: Expected 2'b01 found 2'b%b", current_state));
@@ -291,17 +291,17 @@ program test_program;
     end
 
     // Disable the module to change the polarity
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     // Switch to inverted polarity
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
                        `SET_TDDN_CNTRL_CHANNEL_POLARITY_CHANNEL_POLARITY(32'hFFFFFFFF));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
 
     // Re-enable the module
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(1)|
@@ -322,14 +322,14 @@ program test_program;
     // ARMED //
     //*******//
     // Disable the module
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     // Switch to direct polarity
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
                        `SET_TDDN_CNTRL_CHANNEL_POLARITY_CHANNEL_POLARITY(32'h00000000));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
 
 
     //  -------------------------------------------------------
@@ -345,16 +345,16 @@ program test_program;
     end 
 
     for (int i=0; i<32; i++) begin
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8,
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8,
                          `SET_TDDN_CNTRL_CH0_ON_CH0_ON(ch_on[i]));
 
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8,
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8,
                          `SET_TDDN_CNTRL_CH0_OFF_CH0_OFF(ch_off[i]));
     end 
 
     // Read back the values; unimplemented channels should not store these values
     for (int i=0; i<32; i++) begin
-      env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8, val);
+      env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_ON)+i*8, val);
 
       if (i <= channel_count) begin
         expected_val = ch_on[i];
@@ -368,7 +368,7 @@ program test_program;
         success_count++;
       end
 
-      env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8, val);
+      env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CH0_OFF)+i*8, val);
 
       if (i <= channel_count) begin
         expected_val = ch_off[i];
@@ -385,7 +385,7 @@ program test_program;
 
 
     // Enable the module; use external sync for transfer triggering
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(1)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(0)|
@@ -409,17 +409,17 @@ program test_program;
     // ARMED //
     //*******//
     // Disable the module
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     // Switch to inverted polarity
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
                        `SET_TDDN_CNTRL_CHANNEL_POLARITY_CHANNEL_POLARITY(32'hFFFFFFFF));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
 
     // Keep the module enabled; issue a software sync
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(1)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(0)|
@@ -440,14 +440,14 @@ program test_program;
     // ARMED //
     //*******//
     // Disable the module
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     // Switch to direct polarity
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY),
                        `SET_TDDN_CNTRL_CHANNEL_POLARITY_CHANNEL_POLARITY(32'h00000000));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_POLARITY), ch_pol);
 
 
     //  -------------------------------------------------------
@@ -455,11 +455,11 @@ program test_program;
     //  -------------------------------------------------------
 
     // Increase the burst count value by 1
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_BURST_COUNT),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT),
                        `SET_TDDN_CNTRL_BURST_COUNT_BURST_COUNT(channel_count+2));
 
     // Keep the module enabled; issue a software sync; enable external sync and reset on sync
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(1)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(1)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(0)|
@@ -488,7 +488,7 @@ program test_program;
     end
 
     // Disable the module before the end of the burst
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     @(posedge `TH.dut_tdd.inst.tdd_endof_frame);
@@ -496,24 +496,24 @@ program test_program;
     // Check the pulse length using a loop on all available channels
     check_pulse_length;
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
                        `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(0));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE), ch_en);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE), ch_en);
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_BURST_COUNT),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT),
                        `SET_TDDN_CNTRL_BURST_COUNT_BURST_COUNT(0));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_BURST_COUNT), burst_count);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT), burst_count);
 
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_STARTUP_DELAY),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_STARTUP_DELAY),
                        `SET_TDDN_CNTRL_STARTUP_DELAY_STARTUP_DELAY(0));
 
-    env.mng.RegRead32(`TDD+GetAddrs(TDDN_CNTRL_STARTUP_DELAY), startup_delay);
+    env.mng.RegRead32(`TDD_BA+GetAddrs(TDDN_CNTRL_STARTUP_DELAY), startup_delay);
 
 
     // Enable the module with external synchronization actived
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_SYNC_SOFT(0)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(1)|
                        `SET_TDDN_CNTRL_CONTROL_SYNC_INT(0)|
@@ -536,7 +536,7 @@ program test_program;
         success_count++;
       end
 
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
                          `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(ch_en));
 
       ch_en = (ch_en << 1) | 32'b1;
@@ -554,7 +554,7 @@ program test_program;
         success_count++;
       end
 
-      env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
+      env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
                          `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(ch_en));
 
       ch_en = (ch_en >> 1);
@@ -562,7 +562,7 @@ program test_program;
     end
 
     // Disable the module
-    env.mng.RegWrite32(`TDD+GetAddrs(TDDN_CNTRL_CONTROL),
+    env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CONTROL),
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(0));
 
     stop_clocks();

--- a/dma_loopback/system_bd.tcl
+++ b/dma_loopback/system_bd.tcl
@@ -76,3 +76,10 @@ ad_mem_hp0_interconnect $sys_dma_clk dut_tx_dma/m_src_axi
 ad_cpu_interrupt ps-13 mb-12 dut_rx_dma/irq
 ad_cpu_interrupt ps-12 mb-13 dut_tx_dma/irq
 
+set RX_DMA 0x7C420000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dut_rx_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set TX_DMA 0x7C430000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dut_tx_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"

--- a/dma_loopback/tests/test_program.sv
+++ b/dma_loopback/tests/test_program.sv
@@ -46,10 +46,6 @@ import adi_regmap_dmac_pkg::*;
 import dmac_api_pkg::*;
 import dma_trans_pkg::*;
 
-`define RX_DMA      32'h7c42_0000
-`define TX_DMA      32'h7c43_0000
-`define DDR_BASE    32'h8000_0000
-
 program test_program;
 
   test_harness_env env;
@@ -72,10 +68,10 @@ program test_program;
     setLoggerVerbosity(6);
     env.start();
 
-    m_dmac_api = new("TX_DMA", env.mng, `TX_DMA);
+    m_dmac_api = new("TX_DMA_BA", env.mng, `TX_DMA_BA);
     m_dmac_api.probe();
 
-    s_dmac_api = new("RX_DMA", env.mng, `RX_DMA);
+    s_dmac_api = new("RX_DMA_BA", env.mng, `RX_DMA_BA);
     s_dmac_api.probe();
 
     start_clocks();
@@ -89,20 +85,20 @@ program test_program;
 
     // Init test data
     for (int i=0;i<2048*2 ;i=i+2) begin
-      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BASE+i*2,(((i+1)) << 16) | i ,'hF);
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)) << 16) | i ,'hF);
     end
 
     do_transfer(
-      .src_addr(`DDR_BASE+'h0000),
-      .dest_addr(`DDR_BASE+'h2000),
+      .src_addr(`DDR_BA+'h0000),
+      .dest_addr(`DDR_BA+'h2000),
       .length('h1000)
     );
 
     #20us;
 
     check_data(
-      .src_addr(`DDR_BASE+'h0000),
-      .dest_addr(`DDR_BASE+'h2000),
+      .src_addr(`DDR_BA+'h0000),
+      .dest_addr(`DDR_BA+'h2000),
       .length('h1000)
     );
 

--- a/fmcomms2/system_bd.tcl
+++ b/fmcomms2/system_bd.tcl
@@ -54,3 +54,16 @@ source $ad_hdl_dir/projects/fmcomms2/common/fmcomms2_bd.tcl
 
 
 ad_ip_parameter axi_ad9361 CONFIG.DELAY_REFCLK_FREQUENCY 400
+
+
+set RX_DMA 0x7C400000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361_adc_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set TX_DMA 0x7C420000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361_dac_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set AXI_AD9361 0x79020000
+set_property offset $AXI_AD9361 [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361}]
+adi_sim_add_define "AXI_AD9361_BA=[format "%d" ${AXI_AD9361}]"

--- a/jesd_loopback/system_bd.tcl
+++ b/jesd_loopback/system_bd.tcl
@@ -245,3 +245,26 @@ ad_connect dac_jesd204_transport/dac_tpl_core/dac_sync_manual_req_out manual_syn
 ad_connect manual_sync_or/Res dac_jesd204_transport/dac_tpl_core/dac_sync_manual_req_in
 ad_connect manual_sync_or/Res adc_jesd204_transport/adc_tpl_core/adc_sync_manual_req_in
 
+set ADC_XCVR 0x44A60000
+set_property offset $ADC_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_adc_jesd204_xcvr}]
+adi_sim_add_define "ADC_XCVR_BA=[format "%d" ${ADC_XCVR}]"
+
+set DAC_XCVR 0x44B60000
+set_property offset $DAC_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_xcvr}]
+adi_sim_add_define "DAC_XCVR_BA=[format "%d" ${DAC_XCVR}]"
+
+set AXI_JESD_RX 0x44A90000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_adc_jesd204_link}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set AXI_JESD_TX 0x44B90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_link}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+set ADC_TPL 0x44A10000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_adc_jesd204_transport}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set DAC_TPL 0x44B10000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_transport}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"

--- a/jesd_loopback_64b/system_bd.tcl
+++ b/jesd_loopback_64b/system_bd.tcl
@@ -242,3 +242,23 @@ for {set i $NUM_OF_CONVERTERS} {$i < $MAX_CONVERTERS} {incr i} {
 
 make_bd_pins_external  [get_bd_pins /dac_jesd204_transport/dac_dunf]
 make_bd_pins_external  [get_bd_pins /adc_jesd204_transport/adc_dovf]
+
+set JESD_PHY 0x44A60000
+set_property offset $JESD_PHY [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_jesd204_phy}]
+adi_sim_add_define "JESD_PHY_BA=[format "%d" ${JESD_PHY}]"
+
+set AXI_JESD_RX 0x44A90000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_adc_jesd204_link}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set AXI_JESD_TX 0x44B90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_link}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+set ADC_TPL 0x44A10000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_adc_jesd204_transport}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set DAC_TPL 0x44B10000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_dac_jesd204_transport}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"

--- a/jesd_loopback_64b/tests/test_program.sv
+++ b/jesd_loopback_64b/tests/test_program.sv
@@ -49,12 +49,6 @@ import adi_regmap_common_pkg::*;
 import adi_regmap_dac_pkg::*;
 import adi_regmap_adc_pkg::*;
 
-`define JESD_PHY    32'h44a6_0000
-`define AXI_JESD_RX 32'h44a9_0000
-`define AXI_JESD_TX 32'h44b9_0000
-`define ADC_TPL     32'h44a1_0000
-`define DAC_TPL     32'h44b1_0000
-
 parameter OUT_BYTES = (`JESD_F % 3 != 0) ? 8 : 12;
 
 program test_program;
@@ -108,101 +102,101 @@ program test_program;
     for (int i = 0; i < `JESD_M; i++) begin
       if (use_dds) begin
         // Select DDS as source
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
         // Configure tone amplitude and frequency
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
 
       end else begin
         // Set DMA as source for DAC TPL
-        env.mng.RegWrite32(`DAC_TPL+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+        env.mng.RegWrite32(`DAC_TPL_BA+'h40*i+GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
                            `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
       end
     end
 
     for (int i = 0; i < `JESD_M; i++) begin
-      env.mng.RegWrite32(`ADC_TPL+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+      env.mng.RegWrite32(`ADC_TPL_BA+'h40*i+GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
                          `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1));
     end
 
 
-    env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_RSTN),
                        `SET_DAC_COMMON_REG_RSTN_RSTN(1));
-    env.mng.RegWrite32(`ADC_TPL+GetAddrs(ADC_COMMON_REG_RSTN),
+    env.mng.RegWrite32(`ADC_TPL_BA+GetAddrs(ADC_COMMON_REG_RSTN),
                        `SET_ADC_COMMON_REG_RSTN_RSTN(1));
 
 
     // Sync DDS cores
-    env.mng.RegWrite32(`DAC_TPL+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+    env.mng.RegWrite32(`DAC_TPL_BA+GetAddrs(DAC_COMMON_REG_CNTRL_1),
                        `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
 
     //SYSREFCONF
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_SYSREF_CONF),
-                       `SET_JESD_RX_SYSREF_CONF_SYSREF_DISABLE(0)); 
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_SYSREF_CONF),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_SYSREF_CONF),
+                       `SET_JESD_RX_SYSREF_CONF_SYSREF_DISABLE(0));
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_SYSREF_CONF),
                        `SET_JESD_TX_SYSREF_CONF_SYSREF_DISABLE(0));
 
     //CONF0
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF0),
-                       `SET_JESD_RX_LINK_CONF0_OCTETS_PER_FRAME(`JESD_F-1) | 
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF0),
+                       `SET_JESD_RX_LINK_CONF0_OCTETS_PER_FRAME(`JESD_F-1) |
                        `SET_JESD_RX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`JESD_F*`JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF0),
-                       `SET_JESD_TX_LINK_CONF0_OCTETS_PER_FRAME(`JESD_F-1) | 
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF0),
+                       `SET_JESD_TX_LINK_CONF0_OCTETS_PER_FRAME(`JESD_F-1) |
                        `SET_JESD_TX_LINK_CONF0_OCTETS_PER_MULTIFRAME(`JESD_F*`JESD_K-1));
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF4),
                        `SET_JESD_RX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`JESD_F*`JESD_K)/`LL_OUT_BYTES-1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF4),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF4),
                        `SET_JESD_TX_LINK_CONF4_TPL_BEATS_PER_MULTIFRAME((`JESD_F*`JESD_K)/`LL_OUT_BYTES-1));
     //CONF1
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_CONF1),
-                       `SET_JESD_RX_LINK_CONF1_DESCRAMBLER_DISABLE(0)); 
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF1),
-                       `SET_JESD_TX_LINK_CONF1_SCRAMBLER_DISABLE(0)); 
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_CONF1),
+                       `SET_JESD_RX_LINK_CONF1_DESCRAMBLER_DISABLE(0));
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF1),
+                       `SET_JESD_TX_LINK_CONF1_SCRAMBLER_DISABLE(0));
 
     //CONF2
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_CONF2),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_CONF2),
                        `SET_JESD_TX_LINK_CONF2_CONTINUOUS_CGS(0));
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
 
     #25us;
     // Read status back
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
     #1us;
-    
+
     // --------------------------------------
     //  Attempt a second link bring-up
     // --------------------------------------
-    
+
     //LINK DISABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(1));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(1));
     #1us;
 
-    
+
     //LINK ENABLE
-    env.mng.RegWrite32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_DISABLE),
                        `SET_JESD_RX_LINK_DISABLE_LINK_DISABLE(0));
-    env.mng.RegWrite32(`AXI_JESD_TX+GetAddrs(JESD_TX_LINK_DISABLE),
+    env.mng.RegWrite32(`AXI_JESD_TX_BA+GetAddrs(JESD_TX_LINK_DISABLE),
                        `SET_JESD_TX_LINK_DISABLE_LINK_DISABLE(0));
 
     #25us;
     // Read status back
-    env.mng.RegReadVerify32(`AXI_JESD_RX+GetAddrs(JESD_RX_LINK_STATUS),
+    env.mng.RegReadVerify32(`AXI_JESD_RX_BA+GetAddrs(JESD_RX_LINK_STATUS),
                             `SET_JESD_RX_LINK_STATUS_STATUS_STATE(3));
   end
 

--- a/mxfe/cfgs/cfg1.tcl
+++ b/mxfe/cfgs/cfg1.tcl
@@ -22,3 +22,5 @@ set ad_project_params(TX_JESD_S) 1
 set ad_project_params(TX_JESD_NP) 16
 set ad_project_params(TX_JESD_F) 4
 set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(TDD_SUPPORT) 0

--- a/mxfe/cfgs/cfg2_64b66b_np8.tcl
+++ b/mxfe/cfgs/cfg2_64b66b_np8.tcl
@@ -22,3 +22,5 @@ set ad_project_params(TX_JESD_S) 4
 set ad_project_params(TX_JESD_NP) 8
 set ad_project_params(TX_JESD_F) 1
 set ad_project_params(TX_JESD_K) 256
+
+set ad_project_params(TDD_SUPPORT) 0

--- a/mxfe/cfgs/cfg3_64b66b_np12.tcl
+++ b/mxfe/cfgs/cfg3_64b66b_np12.tcl
@@ -22,3 +22,5 @@ set ad_project_params(TX_JESD_S) 2
 set ad_project_params(TX_JESD_NP) 12
 set ad_project_params(TX_JESD_F) 3
 set ad_project_params(TX_JESD_K) 256
+
+set ad_project_params(TDD_SUPPORT) 0

--- a/mxfe/cfgs/cfg4_8b10b_np12.tcl
+++ b/mxfe/cfgs/cfg4_8b10b_np12.tcl
@@ -22,3 +22,5 @@ set ad_project_params(TX_JESD_S) 1
 set ad_project_params(TX_JESD_NP) 12
 set ad_project_params(TX_JESD_F) 6
 set ad_project_params(TX_JESD_K) 32
+
+set ad_project_params(TDD_SUPPORT) 0

--- a/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
+++ b/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
@@ -22,3 +22,5 @@ set ad_project_params(TX_JESD_S) 1
 set ad_project_params(TX_JESD_NP) 16
 set ad_project_params(TX_JESD_F) 2
 set ad_project_params(TX_JESD_K) 128
+
+set ad_project_params(TDD_SUPPORT) 0

--- a/mxfe/system_bd.tcl
+++ b/mxfe/system_bd.tcl
@@ -41,10 +41,10 @@ source $ad_hdl_dir/projects/common/xilinx/adcfifo_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 
 ## ADC FIFO depth in samples per converter
-#set adc_fifo_samples_per_converter [expr 4*1024]
+set adc_fifo_samples_per_converter [expr 4*1024]
 set adc_fifo_samples_per_converter [expr 512]
 ## DAC FIFO depth in samples per converter
-#set dac_fifo_samples_per_converter [expr 4*1024]
+set dac_fifo_samples_per_converter [expr 4*1024]
 set dac_fifo_samples_per_converter [expr 512]
 
 # DRP clk for 204C phy
@@ -95,3 +95,51 @@ source $ad_hdl_dir/projects/ad9081_fmca_ebz/common/ad9081_fmca_ebz_bd.tcl
 #}
 
 adi_sim_add_define "JESD_MODE=\"$JESD_MODE\""
+
+
+set RX_DMA 0x7C420000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set RX_XCVR 0x44A60000
+set_property offset $RX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_xcvr}]
+adi_sim_add_define "RX_XCVR_BA=[format "%d" ${RX_XCVR}]"
+
+set TX_DMA 0x7C430000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set TX_XCVR 0x44B60000
+set_property offset $TX_XCVR [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_xcvr}]
+adi_sim_add_define "TX_XCVR_BA=[format "%d" ${TX_XCVR}]"
+
+set AXI_JESD_RX 0x44A90000
+set_property offset $AXI_JESD_RX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_rx_jesd}]
+adi_sim_add_define "AXI_JESD_RX_BA=[format "%d" ${AXI_JESD_RX}]"
+
+set ADC_TPL 0x44A10000
+set_property offset $ADC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_rx_mxfe_tpl_core}]
+adi_sim_add_define "ADC_TPL_BA=[format "%d" ${ADC_TPL}]"
+
+set DAC_TPL 0x44B10000
+set_property offset $DAC_TPL [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_tx_mxfe_tpl_core}]
+adi_sim_add_define "DAC_TPL_BA=[format "%d" ${DAC_TPL}]"
+
+set AXI_JESD_TX 0x44B90000
+set_property offset $AXI_JESD_TX [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_mxfe_tx_jesd}]
+adi_sim_add_define "AXI_JESD_TX_BA=[format "%d" ${AXI_JESD_TX}]"
+
+set RX_OFFLOAD 0x7C450000
+set_property offset $RX_OFFLOAD [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_mxfe_rx_data_offload}]
+adi_sim_add_define "RX_OFFLOAD_BA=[format "%d" ${RX_OFFLOAD}]"
+
+set TX_OFFLOAD 0x7C440000
+set_property offset $TX_OFFLOAD [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_mxfe_tx_data_offload}]
+adi_sim_add_define "TX_OFFLOAD_BA=[format "%d" ${TX_OFFLOAD}]"
+
+set TDD 0x7C460000
+adi_sim_add_define "TDD_BA=[format "%d" ${TDD}]"
+
+if {$TDD_SUPPORT == 1} {
+  set_property offset $TDD [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_tdd_0}]
+}  


### PR DESCRIPTION
Definition of base addresses up until this point happened at both block design and testbench level, which could lead to errors. 

Define the address at block design level and pass the parameter as definition to the testbench. 