### PR TITLE
Differentiate function calls from variables

### DIFF
--- a/ad463x/tests/test_program.sv
+++ b/ad463x/tests/test_program.sv
@@ -107,28 +107,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -153,15 +150,15 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
   #100
 
-  fifo_spi_test;
+  fifo_spi_test();
 
   #100
 
-  offload_spi_test;
+  offload_spi_test();
   `INFO(("Test Done"));
 
   $finish;
@@ -172,22 +169,20 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-begin
+task sanity_test();
   axi_read_v (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_VERSION), PCORE_VERSION);
   axi_write (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   axi_read_v (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // SPI Engine generate transfer
 //---------------------------------------------------------------------------
 
-task generate_transfer_cmd;
-  input [7:0] sync_id;
-  begin
+task generate_transfer_cmd(
+  input [7:0] sync_id);
+
     // assert CSN
     axi_write (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), INST_CS_ON);
     // transfer data
@@ -197,7 +192,6 @@ task generate_transfer_cmd;
     // SYNC command to generate interrupt
     axi_write (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), (INST_SYNC | sync_id));
     $display("[%t] NOTE: Transfer generation finished.", $time);
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -444,9 +438,7 @@ end
 
 bit [31:0] offload_captured_word_arr [(2 * NUM_OF_TRANSFERS) -1 :0];
 
-task offload_spi_test;
-  begin
-
+task offload_spi_test();
     //Configure DMA
 
     env.mng.RegWrite32(`AD469X_DMA_BA + GetAddrs(DMAC_CONTROL), `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
@@ -471,7 +463,6 @@ task offload_spi_test;
     offload_status = 1;
 
     // Start the offload
-    #100
     axi_write (`SPI_AD469X_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(1));
     $display("[%t] Offload started.", $time);
 
@@ -504,8 +495,6 @@ task offload_spi_test;
     end else begin
       `INFO(("Offload Test PASSED"));
     end
-
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -514,9 +503,7 @@ endtask
 
 bit   [31:0]  sdi_fifo_data = 0;
 
-task fifo_spi_test;
-begin
-
+task fifo_spi_test();
   // Start spi clk generator
   axi_write (`AD463X_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
     `SET_AXI_CLKGEN_REG_RSTN_MMCM_RSTN(1) |
@@ -564,8 +551,6 @@ begin
     `ERROR(("Fifo Read Test FAILED"));
 
   `INFO(("Fifo Read Test PASSED"));
-
-end
 endtask
 
 endprogram

--- a/ad7606x/tests/test_program.sv
+++ b/ad7606x/tests/test_program.sv
@@ -74,28 +74,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -120,19 +117,19 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
-  #100 adc_config_SIMPLE_test;
+  #100 adc_config_SIMPLE_test();
 
-  #200 adc_config_CRC_test;
+  #200 adc_config_CRC_test();
 
-  #200 adc_config_STATUS_test;
+  #200 adc_config_STATUS_test();
 
-  #200 adc_config_STATUS_CRC_test;
+  #200 adc_config_STATUS_CRC_test();
 
-  #200 adc_config_SIMPLE_test;
+  #200 adc_config_SIMPLE_test();
 
-  #100 db_transmission_test;
+  #100 db_transmission_test();
 
   `INFO(("Test Done"));
 
@@ -171,13 +168,11 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-  begin
+task sanity_test();
     // check ADC VERSION
     axi_read_v (`AXI_AD7606X_BA + GetAddrs(COMMON_REG_VERSION),
                     `SET_COMMON_REG_VERSION_VERSION('h000a0300));
     $display("[%t] Sanity Test Done.", $time);
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -372,8 +367,7 @@ bit        ctrl_status_SIMPLE = 'h0; // ctrl_status bit from ADC common core
 bit        ctrl_status_STATUS = 'h0; // ctrl_status bit from ADC common core
 bit        ctrl_status_STATUS_CRC = 'h0; // ctrl_status bit from ADC common core
 
-task adc_config_SIMPLE_test;
-  begin
+task adc_config_SIMPLE_test();
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // set static data setup in device's reg 0x21
     axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_SIMPLE); // read last config result
@@ -396,11 +390,9 @@ task adc_config_SIMPLE_test;
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h100); // set default
 
     adc_config_mode = 2'h0;
-  end
 endtask
 
-task adc_config_CRC_test;
-  begin
+task adc_config_CRC_test();
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // set CRC and static data setup in device's reg 0x21
     axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_CRC); // read last config result
@@ -423,11 +415,9 @@ task adc_config_CRC_test;
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h101); // set default
 
     adc_config_mode = 2'h1;
-  end
 endtask
 
-task adc_config_STATUS_test;
-  begin
+task adc_config_STATUS_test();
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002181)); // static data setup in device's reg 0x21
     axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
@@ -463,11 +453,9 @@ task adc_config_STATUS_test;
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h102); // set default
 
     adc_config_mode = 2'h2;
-  end
 endtask
 
-task adc_config_STATUS_CRC_test;
-  begin
+task adc_config_STATUS_CRC_test();
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_RSTN), `SET_ADC_COMMON_REG_RSTN_RSTN(1'b1)); //ADC common core out of reset
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), `SET_ADC_COMMON_REG_ADC_CONFIG_WR_ADC_CONFIG_WR(32'h00002185)); // static data and CRC setup in device's reg 0x21
     axi_read(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_ADC_CONFIG_WR), config_STATUS); // read last config result
@@ -503,15 +491,13 @@ task adc_config_STATUS_CRC_test;
     axi_write(`AXI_AD7606X_BA + GetAddrs(ADC_COMMON_REG_CNTRL_3), 'h103); // set default
 
     adc_config_mode = 2'h3;
-  end
 endtask
 
 //---------------------------------------------------------------------------
 // DB transmission test
 //---------------------------------------------------------------------------
 bit [31:0] capp_word;
-task db_transmission_test;
-  begin
+task db_transmission_test();
     #100 transfer_status = 1;
 
     // Generate cnvst_n pulse using AXI_PWM_GEN
@@ -527,7 +513,6 @@ task db_transmission_test;
     // Stop pwm gen
     axi_write (`AXI_PWMGEN_BA + GetAddrs(AXI_PWM_GEN_REG_RSTN), `SET_AXI_PWM_GEN_REG_RSTN_RESET(1));
     $display("[%t] axi_pwm_gen stopped.", $time);
-  end
 endtask
 
 endprogram

--- a/ad7616/tests/test_program_pi.sv
+++ b/ad7616/tests/test_program_pi.sv
@@ -69,28 +69,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -115,11 +112,11 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
   #100
 
-  data_acquisition_test;
+  data_acquisition_test();
 
   `INFO(("Test Done"));
 
@@ -170,12 +167,10 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-begin
+task sanity_test();
   axi_write (`AXI_AD7616_BA + GetAddrs(AXI_AD7616_REG_SCRATCH), `SET_AXI_AD7616_REG_SCRATCH_SCRATCH(32'hDEADBEEF));
   axi_read_v (`AXI_AD7616_BA + GetAddrs(AXI_AD7616_REG_SCRATCH), `SET_AXI_AD7616_REG_SCRATCH_SCRATCH(32'hDEADBEEF));
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -199,8 +194,7 @@ reg [31:0] rdata_reg;
 bit [31:0] captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
 
 
-task data_acquisition_test;
-  begin
+task data_acquisition_test();
     // Start spi clk generator
     axi_write (`AD7616_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
       `SET_AXI_CLKGEN_REG_RSTN_MMCM_RSTN(1) |
@@ -266,8 +260,6 @@ task data_acquisition_test;
     end else begin
       `INFO(("Data Acquisition Test PASSED"));
     end
-
-  end
 endtask
 
 endprogram

--- a/ad7616/tests/test_program_si.sv
+++ b/ad7616/tests/test_program_si.sv
@@ -110,28 +110,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -156,15 +153,15 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
   #100
 
-  fifo_spi_test;
+  fifo_spi_test();
 
   #100
 
-  offload_spi_test;
+  offload_spi_test();
 
   `INFO(("Test Done"));
 
@@ -176,22 +173,20 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-begin
+task sanity_test();
   axi_read_v (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_VERSION), PCORE_VERSION);
   axi_write (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   axi_read_v (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // SPI Engine generate transfer
 //---------------------------------------------------------------------------
 
-task generate_transfer_cmd;
-  input [7:0] sync_id;
-  begin
+task generate_transfer_cmd(
+   input [7:0] sync_id);
+
     // assert CSN
     axi_write (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), INST_CS_ON);
     // transfer data
@@ -201,7 +196,6 @@ task generate_transfer_cmd;
     // SYNC command to generate interrupt
     axi_write (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), (INST_SYNC | sync_id));
     $display("[%t] NOTE: Transfer generation finished.", $time);
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -414,9 +408,7 @@ end
 
 bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
 
-task offload_spi_test;
-  begin
-
+task offload_spi_test();
     // Configure pwm
     axi_write (`AD7616_PWM_GEN_BA + GetAddrs(AXI_PWM_GEN_REG_RSTN), `SET_AXI_PWM_GEN_REG_RSTN_RESET(1)); // PWM_GEN reset in regmap (ACTIVE HIGH)
     axi_write (`AD7616_PWM_GEN_BA + GetAddrs(AXI_PWM_GEN_REG_PULSE_X_PERIOD), `SET_AXI_PWM_GEN_REG_PULSE_X_PERIOD_PULSE_X_PERIOD('h64)); // set PWM period
@@ -446,7 +438,6 @@ task offload_spi_test;
     offload_status = 1;
 
     // Start the offload
-    #100
     axi_write (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(1));
     $display("[%t] Offload started.", $time);
 
@@ -469,8 +460,6 @@ task offload_spi_test;
     end else begin
       `INFO(("Offload Test PASSED"));
     end
-
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -479,9 +468,7 @@ endtask
 
 bit   [31:0]  sdi_fifo_data = 0;
 
-task fifo_spi_test;
-begin
-
+task fifo_spi_test();
   // Start spi clk generator
   axi_write (`AD7616_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
     `SET_AXI_CLKGEN_REG_RSTN_MMCM_RSTN(1) |
@@ -505,7 +492,6 @@ begin
   #100
   // Generate a FIFO transaction, write SDO first
   repeat (NUM_OF_WORDS) begin
-    #100
     axi_write (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SDO_FIFO), (16'hDEAD << (DATA_WIDTH - DATA_DLENGTH)));
   end
 
@@ -516,7 +502,6 @@ begin
   #100
 
   repeat (NUM_OF_WORDS) begin
-  #100
     axi_read (`SPI_AD7616_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SDI_FIFO_PEEK) , sdi_fifo_data);
   end
 
@@ -527,8 +512,6 @@ begin
     $display("sdi_fifo_data: %x; sdi_fifo_data_store %x", sdi_fifo_data, sdi_fifo_data_store);
     `INFO(("Fifo Read Test PASSED"));
   end
-
-end
 endtask
 
 endprogram

--- a/ad_quadmxfe1_ebz/tests/test_dma.sv
+++ b/ad_quadmxfe1_ebz/tests/test_dma.sv
@@ -303,7 +303,6 @@ program test_dma;
           `ERROR(("Address 0x%h Expected 0x%h found 0x%h",current_address,reference_word,captured_word));
         end
       end
-
     end
   endtask
 

--- a/adrv9001/tests/test_program.sv
+++ b/adrv9001/tests/test_program.sv
@@ -97,23 +97,21 @@ program test_program;
   // --------------------------
   // Wrapper function for AXI read verify
   // --------------------------
-  task axi_read_v();
-    input   [31:0]  raddr;
-    input   [31:0]  vdata;
-  begin
+  task axi_read_v(
+    input   [31:0]  raddr,
+    input   [31:0]  vdata);
+
     env.mng.RegReadVerify32(raddr,vdata);
-  end
   endtask
 
   // --------------------------
   // Wrapper function for AXI write
   // --------------------------
-  task axi_write;
-    input [31:0]  waddr;
-    input [31:0]  wdata;
-  begin
+  task axi_write(
+    input [31:0]  waddr,
+    input [31:0]  wdata);
+
     env.mng.RegWrite32(waddr,wdata);
-  end
   endtask
 
   integer rate;
@@ -162,7 +160,7 @@ program test_program;
 
     #1us;
 
-    sanity_test;
+    sanity_test();
 
     // R2T2 tests
     R1_MODE = 0;
@@ -175,10 +173,10 @@ program test_program;
       pn_test(`PN15);
     end
     if (DDS_DISABLE == 0) begin
-      dds_test;
+      dds_test();
     end
 
-    dma_test;
+    dma_test();
 
     // independent R1T1 tests
     R1_MODE = 1;
@@ -189,7 +187,7 @@ program test_program;
       axi_write (RX2_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
         `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_DATA_SEL(0));
     end
-    dma_test_ch2;
+    dma_test_ch2();
 
     // Test internal loopback DAC2->ADC2
     // Enable internal loopback
@@ -198,7 +196,7 @@ program test_program;
         `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_DATA_SEL(1));
       axi_write (RX2_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
         `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_DATA_SEL(1));
-      dma_test_ch2;
+      dma_test_ch2();
     end
 
     `INFO(("Test Done"));
@@ -208,9 +206,7 @@ program test_program;
   // --------------------------
   // Sanity test reg interface
   // --------------------------
-  task sanity_test;
-  begin
-
+  task sanity_test();
     //check ADC VERSION
     axi_read_v (RX1_COMMON + GetAddrs(COMMON_REG_VERSION),
                     `SET_COMMON_REG_VERSION_VERSION('h000a0300));
@@ -232,7 +228,6 @@ program test_program;
                                                (1 * 16) +
                                                (DDS_DISABLE * 64) +
                                                (IQCORRECTION_DISABLE * 1));
-  end
   endtask
 
   // --------------------------
@@ -242,7 +237,7 @@ program test_program;
                   bit rx2_en = 1,
                   bit tx1_en = 1,
                   bit tx2_en = 1);
-  begin
+
     // Configure Rx interface
     axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_CNTRL),
                (SDR_DDR_N << 16) |
@@ -278,20 +273,17 @@ program test_program;
     axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_RSTN), tx1_en << 1 | tx1_en << 0);
     axi_write (TX2_COMMON + GetAddrs(DAC_COMMON_REG_RSTN), tx2_en << 1 | tx2_en << 0);
 
-    gen_mssi_sync;
+    gen_mssi_sync();
 
     // pull out RX of reset
     axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_RSTN), rx1_en << 1 | rx1_en << 0);
     axi_write (RX2_COMMON + GetAddrs(ADC_COMMON_REG_RSTN), rx2_en << 1 | rx2_en << 0);
-
-  end
   endtask
 
   // --------------------------
   // Link teardown
   // --------------------------
-  task link_down;
-  begin
+  task link_down();
     // put RX in reset
     axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_RSTN),
               `SET_ADC_COMMON_REG_RSTN_RSTN(0));
@@ -303,15 +295,13 @@ program test_program;
     axi_write (TX2_COMMON + GetAddrs(DAC_COMMON_REG_RSTN),
               `SET_DAC_COMMON_REG_RSTN_RSTN(0));
     #1000;
-  end
   endtask
 
   // --------------------------
   // Test pattern test
   // --------------------------
-  task pn_test;
-    input [3:0] pattern;
-  begin
+  task pn_test(
+    input [3:0] pattern);
 
     reg [3:0] tx_pattern_map[0:3];
     reg [3:0] rx_pattern_map[0:3];
@@ -326,7 +316,7 @@ program test_program;
     rx_pattern_map[`NIBBLE_RAMP] = 10;
     rx_pattern_map[`FULL_RAMP] = 11;
 
-    link_setup;
+    link_setup();
     // enable test data for TX1
     axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
               `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(tx_pattern_map[pattern]));
@@ -380,22 +370,19 @@ program test_program;
     axi_read_v (RX1_COMMON + GetAddrs(ADC_COMMON_REG_STATUS),
                `SET_ADC_COMMON_REG_STATUS_STATUS('h1));
 
-    link_down;
-
-  end
+    link_down();
   endtask
 
   // --------------------------
   // DDS test procedure
   // --------------------------
-  task dds_test;
-  begin
+  task dds_test();
 
     //  -------------------------------------------------------
     //  Test DDS path
     //  -------------------------------------------------------
 
-    link_setup;
+    link_setup();
 
     // Select DDS as source
     axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
@@ -469,16 +456,13 @@ program test_program;
 
     #20000;
 
-    link_down;
-
-  end
+    link_down();
   endtask
 
    // --------------------------
   // DMA test procedure
   // --------------------------
-  task dma_test;
-  begin
+  task dma_test();
 
     //  -------------------------------------------------------
     //  Test DMA path
@@ -550,7 +534,7 @@ program test_program;
     axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_CNTRL_1),
       `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
 
-    link_setup;
+    link_setup();
 
     #20us;
 
@@ -572,15 +556,12 @@ program test_program;
       .step (1),
       .max_sample(2048)
     );
-
-  end
   endtask
 
   // --------------------------
   // DMA test procedure for Rx2/Tx2 independent pairs
   // --------------------------
-  task dma_test_ch2;
-  begin
+  task dma_test_ch2();
 
     //  -------------------------------------------------------
     //  Test DMA path
@@ -650,8 +631,6 @@ program test_program;
       .step (1),
       .max_sample(2048)
     );
-
-  end
   endtask
 
   // Check captured data against incremental pattern based on first sample
@@ -688,9 +667,7 @@ program test_program;
           `ERROR(("Address 0x%h Expected 0x%h found 0x%h",current_address,reference_word,captured_word));
         end
       end
-
     end
   endtask
 
 endprogram
-

--- a/adrv9009/tests/test_program.sv
+++ b/adrv9009/tests/test_program.sv
@@ -232,7 +232,6 @@ program test_program;
     `INFO(("  JESD LINK TEST DONE  "));
     `INFO(("======================="));
 
-
   end
 
   task tx_tpl_test(int use_dds);
@@ -380,7 +379,6 @@ program test_program;
 
     dut_rx_xcvr.down();
     ex_tx_xcvr.down();
-
   endtask
 
   task rx_os_tpl_test(int use_dds);
@@ -452,7 +450,6 @@ program test_program;
 
     ex_tx_os_xcvr.down();
     dut_rx_os_xcvr.down();
-
   endtask
 
   task check_captured_data(bit [31:0] address,

--- a/axi_tdd/tests/test_program.sv
+++ b/axi_tdd/tests/test_program.sv
@@ -44,8 +44,6 @@ import logger_pkg::*;
 import adi_regmap_pkg::*;
 import adi_regmap_tdd_gen_pkg::*;
 
-`define TDD      32'h7c42_0000
-
 program test_program;
 
   //instantiate the environment
@@ -274,7 +272,7 @@ program test_program;
     end
 
     // Check the pulse length using a loop on all available channels
-    check_pulse_length;
+    check_pulse_length();
 
 
     //*******//
@@ -315,7 +313,7 @@ program test_program;
     @(posedge running_state);
 
     // Check the pulse length using a loop on all available channels
-    check_pulse_length;
+    check_pulse_length();
 
 
     //*******//
@@ -393,7 +391,7 @@ program test_program;
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(1));
 
     // Trigger an external sync on the input pin
-    trigger_ext_event;
+    trigger_ext_event();
 
 
     //*********//
@@ -402,7 +400,7 @@ program test_program;
     @(posedge running_state);
 
     // Check the pulse length using a loop on all available channels
-    check_pulse_length;
+    check_pulse_length();
 
 
     //*******//
@@ -433,7 +431,7 @@ program test_program;
     @(posedge running_state);
 
     // Check the pulse length using a loop on all available channels
-    check_pulse_length;
+    check_pulse_length();
 
 
     //*******//
@@ -476,7 +474,7 @@ program test_program;
     // Since the initial software sync started the frame, the external sync will reset the tdd counter
     // Test this by issuing a parralel thread which counts and expects that the number of channel[0] sets per initial frame is 3
     fork
-      trigger_ext_event;
+      trigger_ext_event();
       repeat (3) @(posedge `TH.dut_tdd.inst.genblk1[0].i_channel.tdd_ch_set);
     join
 
@@ -494,7 +492,7 @@ program test_program;
     @(posedge `TH.dut_tdd.inst.tdd_endof_frame);
 
     // Check the pulse length using a loop on all available channels
-    check_pulse_length;
+    check_pulse_length();
 
     env.mng.RegWrite32(`TDD_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
                        `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(0));
@@ -521,7 +519,7 @@ program test_program;
                        `SET_TDDN_CNTRL_CONTROL_ENABLE(1));
 
     // Trigger an external sync on the input pin
-    trigger_ext_event;
+    trigger_ext_event();
 
     // Test a continuous burst
     ch_en = 32'b1;
@@ -570,32 +568,25 @@ program test_program;
   end
 
 
-  task start_clocks;
-
+  task start_clocks();
     `TH.`DEVICE_CLK.inst.IF.start_clock;
-
   endtask
 
 
-  task stop_clocks;
-
+  task stop_clocks();
     `TH.`DEVICE_CLK.inst.IF.stop_clock;
-
   endtask
 
 
-  task sys_reset;
-
+  task sys_reset();
     //asserts all the resets for 100 ns
     `TH.`SYS_RST.inst.IF.assert_reset;
     #100
     `TH.`SYS_RST.inst.IF.deassert_reset;
-
   endtask
 
 
-  task trigger_ext_event;
-
+  task trigger_ext_event();
     #20ns;
     `TB.sync_in =1'b1;
     #10ns;
@@ -604,12 +595,10 @@ program test_program;
     `TB.sync_in =1'b1;
     #20ns;
     `TB.sync_in =1'b0;
-
   endtask
 
 
-  task check_pulse_length;
-
+  task check_pulse_length();
     for (int i=0; i<=channel_count; i++) begin
       time t1=0, t2=0, expected_pulse_lengh;
 
@@ -632,12 +621,10 @@ program test_program;
         success_count++;
       end
     end
-
   endtask
 
 
   task channel_probe (input int i, output time t1, t2);
-
     t1 = $time;
     t2 = $time;
 
@@ -648,7 +635,6 @@ program test_program;
     if (!ch_pol[i]) @(negedge `TB.tdd_channel[i]);
     else            @(posedge `TB.tdd_channel[i]);
     t2 = $time;
-
   endtask
 
 endprogram

--- a/data_offload/tests/test_program.sv
+++ b/data_offload/tests/test_program.sv
@@ -95,15 +95,15 @@ module test_program();
     `TH.`PLDDR_RST.inst.IF.assert_reset;
     #1;
     
-    start_clocks;
-    sys_reset;
+    start_clocks();
+    sys_reset();
           
     #1
     env.start();
 
     #100
     `INFO(("Bring up IP from reset."));
-    systemBringUp;
+    systemBringUp();
 
     //do_set_transfer_length(`ADC_TRANSFER_LENGTH);
     do_set_transfer_length(`ADC_TRANSFER_LENGTH/64);
@@ -130,15 +130,14 @@ module test_program();
     #30000
     env.stop();
 
-    stop_clocks;
+    stop_clocks();
 
     `INFO(("Test bench done!"));
     $finish();
 
   end
 
-  task start_clocks;
-
+  task start_clocks();
     #1
     `TH.`SRC_CLK.inst.IF.start_clock;
     #1
@@ -147,20 +146,16 @@ module test_program();
     `TH.`SYS_CLK.inst.IF.start_clock;
     #1
     `TH.`PLDDR_CLK.inst.IF.start_clock;
-
   endtask
 
-  task stop_clocks;
-
+  task stop_clocks();
     `TH.`SRC_CLK.inst.IF.stop_clock;
     `TH.`DST_CLK.inst.IF.stop_clock;
     `TH.`SYS_CLK.inst.IF.stop_clock;
     `TH.`PLDDR_CLK.inst.IF.stop_clock;
-
   endtask
 
-  task sys_reset;
-
+  task sys_reset();
     `TH.`SRC_RST.inst.IF.assert_reset;
     `TH.`DST_RST.inst.IF.assert_reset;
     `TH.`SYS_RST.inst.IF.assert_reset;
@@ -171,11 +166,9 @@ module test_program();
     `TH.`DST_RST.inst.IF.deassert_reset;
     `TH.`SYS_RST.inst.IF.deassert_reset;
     `TH.`PLDDR_RST.inst.IF.deassert_reset;
-
   endtask
 
-  task systemBringUp;
-
+  task systemBringUp();
     // bring up the Data Offload instances from reset
 
     `INFO(("Bring up RX Data Offload"));
@@ -192,7 +185,6 @@ module test_program();
     env.mng.RegWrite32(`RX_DMA_BA + `DMAC_ADDR_CONTROL, 32'h1);
     `INFO(("Bring up TX DMAC"));
     env.mng.RegWrite32(`TX_DMA_BA + `DMAC_ADDR_CONTROL, 32'h1);
-
   endtask
 
   task do_set_transfer_length(int length);

--- a/data_offload_2/tests/test_program.sv
+++ b/data_offload_2/tests/test_program.sv
@@ -95,8 +95,8 @@ module test_program(
     env.scoreboard.set_oneshot(`OFFLOAD_ONESHOT);
     env.scoreboard.set_path_type(`OFFLOAD_PATH_TYPE);
 
-    start_clocks;
-    sys_reset;
+    start_clocks();
+    sys_reset();
 
     #1
     env.start();
@@ -110,7 +110,7 @@ module test_program(
 
     #100
     `INFO(("Bring up IP from reset."));
-    systemBringUp;
+    systemBringUp();
 
     env.src_axis_seq.start();
 
@@ -143,15 +143,14 @@ module test_program(
 
     env.stop();
 
-    stop_clocks;
+    stop_clocks();
 
     `INFO(("Test bench done!"));
     $finish();
 
   end
 
-  task start_clocks;
-
+  task start_clocks();
     #1
     `TH.`SRC_CLK.inst.IF.start_clock;
     #1
@@ -160,20 +159,16 @@ module test_program(
     `TH.`SYS_CLK.inst.IF.start_clock;
     #1
     `TH.`MEM_CLK.inst.IF.start_clock;
-
   endtask
 
-  task stop_clocks;
-
+  task stop_clocks();
     `TH.`SRC_CLK.inst.IF.stop_clock;
     `TH.`DST_CLK.inst.IF.stop_clock;
     `TH.`SYS_CLK.inst.IF.stop_clock;
     `TH.`MEM_CLK.inst.IF.stop_clock;
-
   endtask
 
-  task sys_reset;
-
+  task sys_reset();
     `TH.`SRC_RST.inst.IF.assert_reset;
     `TH.`DST_RST.inst.IF.assert_reset;
     `TH.`SYS_RST.inst.IF.assert_reset;
@@ -183,11 +178,9 @@ module test_program(
     `TH.`DST_RST.inst.IF.deassert_reset;
     `TH.`SYS_RST.inst.IF.deassert_reset;
     mem_rst_n = 1'b1;
-
   endtask
 
-  task systemBringUp;
-
+  task systemBringUp();
     // bring up the Data Offload instances from reset
     `INFO(("Bring up TX Data Offload"));
 
@@ -198,7 +191,6 @@ module test_program(
 `endif
 
     dut.set_resetn(1'b1);
-
   endtask
 
 endmodule

--- a/data_offload_2/tests/test_program_sync.sv
+++ b/data_offload_2/tests/test_program_sync.sv
@@ -85,15 +85,15 @@ module test_program_sync (
 
     env.scoreboard.set_oneshot(1);
 
-    start_clocks;
-    sys_reset;
+    start_clocks();
+    sys_reset();
 
     #1
     env.start();
 
     #100
     `INFO(("Bring up IP from reset."));
-    systemBringUp;
+    systemBringUp();
 
     env.src_axis_seq.start();
 
@@ -154,15 +154,14 @@ module test_program_sync (
 
     env.stop();
 
-    stop_clocks;
+    stop_clocks();
 
     `INFO(("Test bench done!"));
     $finish();
 
   end
 
-  task start_clocks;
-
+  task start_clocks();
     #1
     `TH.`SRC_CLK.inst.IF.start_clock;
     #1
@@ -171,16 +170,13 @@ module test_program_sync (
     `TH.`SYS_CLK.inst.IF.start_clock;
   endtask
 
-  task stop_clocks;
-
+  task stop_clocks();
     `TH.`SRC_CLK.inst.IF.stop_clock;
     `TH.`DST_CLK.inst.IF.stop_clock;
     `TH.`SYS_CLK.inst.IF.stop_clock;
-
   endtask
 
-  task sys_reset;
-
+  task sys_reset();
     `TH.`SRC_RST.inst.IF.assert_reset;
     `TH.`DST_RST.inst.IF.assert_reset;
     `TH.`SYS_RST.inst.IF.assert_reset;
@@ -189,11 +185,9 @@ module test_program_sync (
     `TH.`SRC_RST.inst.IF.deassert_reset;
     `TH.`DST_RST.inst.IF.deassert_reset;
     `TH.`SYS_RST.inst.IF.deassert_reset;
-
   endtask
 
-  task systemBringUp;
-
+  task systemBringUp();
     // bring up the Data Offload instances from reset
     `INFO(("Bring up TX Data Offload"));
 
@@ -203,7 +197,6 @@ module test_program_sync (
     // dut.set_transfer_length(`TRANSFER_LENGTH);
 
     dut.set_resetn(1'b1);
-
   endtask
 
 endmodule

--- a/dma_loopback/tests/test_program.sv
+++ b/dma_loopback/tests/test_program.sv
@@ -130,7 +130,6 @@ program test_program;
 
     m_dmac_api.wait_transfer_done(m_tid);
     s_dmac_api.wait_transfer_done(s_tid);
-
   endtask
 
 
@@ -158,25 +157,18 @@ program test_program;
   endtask
 
   task start_clocks;
-
     `TH.`DEVICE_CLK.inst.IF.start_clock;
-
   endtask
 
   task stop_clocks;
-
     `TH.`DEVICE_CLK.inst.IF.stop_clock;
-
   endtask
 
   task sys_reset;
-
     //asserts all the resets for 100 ns
     `TH.`SYS_RST.inst.IF.assert_reset;
     #100
     `TH.`SYS_RST.inst.IF.deassert_reset;
-
   endtask
-
 
 endprogram

--- a/i3c_controller/system_bd.tcl
+++ b/i3c_controller/system_bd.tcl
@@ -78,3 +78,7 @@ create_bd_port -dir O i3c_clk
 
 ad_connect i3c_irq i3c/irq
 ad_connect i3c_clk sys_clk_vip/clk_out
+
+set I3C_CONTROLLER 0x44A00000
+set_property offset $I3C_CONTROLLER [get_bd_addr_segs {mng_axi_vip/Master_AXI/host_interface}]
+adi_sim_add_define "I3C_CONTROLLER_BA=[format "%d" ${I3C_CONTROLLER}]"

--- a/i3c_controller/tests/test_program.sv
+++ b/i3c_controller/tests/test_program.sv
@@ -153,18 +153,15 @@ task axi_read_v(
     input   [31:0]  baddr,
     input   [13:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(baddr+{raddr,2'b00},vdata);
-end
-endtask
 
 task axi_read(
     input   [31:0]  baddr,
     input   [13:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(baddr+{raddr,2'b00},data);
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -174,9 +171,8 @@ task axi_write(
   input [31:0]  baddr,
   input [13:0]  waddr,
   input [31:0]  wdata);
-begin
+
   env.mng.RegWrite32(baddr+{waddr,2'b00},wdata);
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -195,7 +191,6 @@ assign offload_sdi_ready = 1'b1;
 // Write a DA to the SDA lane, for IBI request mock
 //---------------------------------------------------------------------------
 task write_ibi_da(input int da);
- begin
   i3c_dev_sda <= 1'b0;
   wait (`DUT_I3C_WORD.st == `CMDW_BCAST_7E_W0);
   for (int i = 6; i >= 0; i--) begin
@@ -204,22 +199,17 @@ task write_ibi_da(input int da);
   end
   @(negedge i3c_scl)
   i3c_dev_sda <= 1'bZ;
-end
 endtask
 
 //---------------------------------------------------------------------------
 // Information
 //---------------------------------------------------------------------------
 task print_cmdr (input int data);
-begin
   `INFO(("[%t] Got CMDR error %d, length %d, sync %d", $time, data[23:20], data[19:8], data[7:0]));
-end
 endtask
 
 task print_ibi(input int data);
-begin
   `INFO(("[%t] Got IBI DA %b, MDB %b, Sync %d.", $time, data[23:17], data[15:08], data[7:0]));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -272,7 +262,7 @@ initial begin
   env.start();
   env.sys_reset();
 
-  sanity_test;
+  sanity_test();
 
   // Enable I3C Controller
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_ENABLE, 0);
@@ -280,19 +270,19 @@ initial begin
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_OPS, {2'b01, 4'd0, 1'b0});
 
   // Must occur before any other task, since the written data is later used
-  dev_char_i3c_test;
+  dev_char_i3c_test();
 
-  daa_i3c_test;
+  daa_i3c_test();
 
-  ccc_i3c_test;
+  ccc_i3c_test();
 
-  priv_i3c_test;
+  priv_i3c_test();
 
-  priv_i2c_test;
+  priv_i2c_test();
 
-  offload_i3c_test;
+  offload_i3c_test();
 
-  ibi_i3c_test;
+  ibi_i3c_test();
 
   `INFO(("Test Done"));
 
@@ -325,15 +315,13 @@ end
 //---------------------------------------------------------------------------
 // Sanity test reg interface
 //---------------------------------------------------------------------------
-task sanity_test;
-begin
+task sanity_test();
   `INFO(("Sanity Started"));
   axi_read_v (I3C_CONTROLLER, `I3C_REGMAP_VERSION,       I3C_VERSION_CHECK);
   axi_read_v (I3C_CONTROLLER, `I3C_REGMAP_DEVICE_ID,     I3C_DEVICE_ID_CHECK);
   axi_write  (I3C_CONTROLLER, `I3C_REGMAP_SCRATCH,       I3C_SCRATCH_CHECK);
   axi_read_v (I3C_CONTROLLER, `I3C_REGMAP_SCRATCH,       I3C_SCRATCH_CHECK);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -343,7 +331,6 @@ bit   [31:0]  cmdr_fifo_data = 0;
 bit   [31:0]  sdi_fifo_data = 0;
 
 task ccc_i3c_test;
-begin
   `INFO(("CCC I3C Started"));
 
   auto_ack <= 1'b1;
@@ -429,14 +416,12 @@ begin
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_IRQ_PENDING, irq_pending);
 
   `INFO(("CCC I3C Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // Private transfer I3C Test
 //---------------------------------------------------------------------------
-task priv_i3c_test;
-begin
+task priv_i3c_test();
   `INFO(("Private Transfer I3C Started"));
 
   // Disable IBI
@@ -584,14 +569,12 @@ begin
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_IRQ_PENDING, irq_pending);
 
   `INFO(("Private Transfer I3C Ended"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // Private transfer I²C Test
 //---------------------------------------------------------------------------
-task priv_i2c_test;
-begin
+task priv_i2c_test();
   `INFO(("Private Transfer I2C Started"));
 
   // Unmask CMDR interrupt
@@ -681,7 +664,6 @@ begin
   end
 
   `INFO(("Private Transfer I2C Ended"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -689,8 +671,7 @@ endtask
 //---------------------------------------------------------------------------
 bit   [31:0]  ibi_fifo_data = 0;
 
-task ibi_i3c_test;
-begin
+task ibi_i3c_test();
   auto_ack <= 1'b0;
 
   `INFO(("IBI I3C Test Started"));
@@ -818,14 +799,12 @@ begin
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_IRQ_PENDING, irq_pending);
 
   `INFO(("IBI I3C Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // DAA I3C Test
 //---------------------------------------------------------------------------
-task daa_i3c_test;
-begin
+task daa_i3c_test();
   `INFO(("DAA I3C Started"));
 
   // Unmask the CMDR and DAA interrupt
@@ -892,7 +871,6 @@ begin
   axi_write (I3C_CONTROLLER, `I3C_REGMAP_IRQ_PENDING, irq_pending);
 
   `INFO(("DAA I3C Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -903,8 +881,8 @@ bit [3:0]  dev_char_1 = 4'b0010;
 bit [3:0]  dev_char_2 = 4'b0011;
 bit [3:0]  dev_char_3 = 4'b0011;
 bit [31:0] dev_char_data = 0;
-task dev_char_i3c_test;
-begin
+
+task dev_char_i3c_test();
   `INFO(("Device Characteristics I3C Test Started"));
   // Write DEV_CHAR of four devices
   axi_write(I3C_CONTROLLER, `I3C_REGMAP_DEV_CHAR, {DEVICE_DA1, 1'b1, 4'h0, dev_char_0});
@@ -926,14 +904,12 @@ begin
     `ERROR(("DEV_CHAR_0 FAILED"));
 
   `INFO(("Device Characteristics I3C Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // Offload I3C Test
 //---------------------------------------------------------------------------
-task offload_i3c_test;
-begin
+task offload_i3c_test();
   // Test #1, controller does offload transfer
 
   #10000ns
@@ -978,7 +954,6 @@ begin
   #10ns offload_trigger_l = 1'b0;
 
   `INFO(("Offload I3C Test Done"));
-end
 endtask
 
 endprogram

--- a/pulsar_adc_pmdz/tests/test_program.sv
+++ b/pulsar_adc_pmdz/tests/test_program.sv
@@ -107,28 +107,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -153,15 +150,15 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
   #100
 
-  fifo_spi_test;
+  fifo_spi_test();
 
   #100
 
-  offload_spi_test;
+  offload_spi_test();
   `INFO(("Test Done"));
 
   $finish;
@@ -173,21 +170,19 @@ end
 //---------------------------------------------------------------------------
 
 task sanity_test;
-begin
   axi_read_v (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_VERSION), PCORE_VERSION);
   axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   axi_read_v (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
 // SPI Engine generate transfer
 //---------------------------------------------------------------------------
 
-task generate_transfer_cmd;
-  input [7:0] sync_id;
-  begin
+task generate_transfer_cmd(
+  input [7:0] sync_id);
+
     // assert CSN
     axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), INST_CS_ON);
     // transfer data
@@ -197,7 +192,6 @@ task generate_transfer_cmd;
     // SYNC command to generate interrupt
     axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), (INST_SYNC | sync_id));
     $display("[%t] NOTE: Transfer generation finished.", $time);
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -406,9 +400,7 @@ end
 
 bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
 
-task offload_spi_test;
-  begin
-
+task offload_spi_test();
     //Configure DMA
     env.mng.RegWrite32(`PULSAR_ADC_DMA_BA + GetAddrs(DMAC_CONTROL), `SET_DMAC_CONTROL_ENABLE(1)); // Enable DMA
     env.mng.RegWrite32(`PULSAR_ADC_DMA_BA + GetAddrs(DMAC_FLAGS),
@@ -460,8 +452,6 @@ task offload_spi_test;
     end else begin
       `INFO(("Offload Test PASSED"));
     end
-
-  end
 endtask
 
 //---------------------------------------------------------------------------
@@ -470,9 +460,7 @@ endtask
 
 bit   [31:0]  sdi_fifo_data = 0;
 
-task fifo_spi_test;
-begin
-
+task fifo_spi_test();
   // Start spi clk generator
   axi_write (`PULSAR_ADC_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
     `SET_AXI_CLKGEN_REG_RSTN_MMCM_RSTN(1) |
@@ -522,8 +510,6 @@ begin
     $display("sdi_fifo_data: %x; sdi_fifo_data_store %x", sdi_fifo_data, sdi_fifo_data_store);
     `INFO(("Fifo Read Test PASSED"));
   end
-
-end
 endtask
 
 endprogram

--- a/pulsar_adc_pmdz/tests/test_sleep_delay.sv
+++ b/pulsar_adc_pmdz/tests/test_sleep_delay.sv
@@ -107,28 +107,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -153,7 +150,7 @@ initial begin
   `TH.`SYS_RST.inst.IF.deassert_reset;
   #100
 
-  sanity_test;
+  sanity_test();
 
   #100
 
@@ -171,13 +168,11 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-begin
+task sanity_test();
   axi_read_v (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_VERSION), PCORE_VERSION);
   axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   axi_read_v (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -429,9 +424,8 @@ bit [31:0] offload_captured_word_arr [(NUM_OF_TRANSFERS) -1 :0];
 bit [31:0] sleep_time;
 bit [31:0] expected_sleep_time;
 
-task sleep_delay_test;
-  input [7:0] sleep_param;
-begin
+task sleep_delay_test(
+  input [7:0] sleep_param);
 
   // Start spi clk generator
   axi_write (`PULSAR_ADC_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
@@ -473,7 +467,6 @@ begin
   end
   // Disable SPI Engine
   axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_ENABLE), 1);
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -486,10 +479,9 @@ bit [31:0] expected_cs_activate_time;
 bit [31:0] cs_deactivate_time;
 bit [31:0] expected_cs_deactivate_time;
 
-task cs_delay_test;
-  input [1:0] cs_activate_delay;
-  input [1:0] cs_deactivate_delay;
-begin
+task cs_delay_test(
+  input [1:0] cs_activate_delay,
+  input [1:0] cs_deactivate_delay);
 
     // Start spi clk generator
     axi_write (`PULSAR_ADC_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
@@ -539,7 +531,6 @@ begin
     expected_cs_deactivate_time = 2;
 
     // Start the offload
-    #100
     axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(1));
     $display("[%t] Offload started (no delay on CS change).", $time);
 
@@ -547,7 +538,6 @@ begin
 
     offload_status = 0;
     axi_write (`PULSAR_ADC_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(0));
-
 
     $display("[%t] Offload stopped (no delay on CS change).", $time);
 
@@ -632,7 +622,6 @@ begin
       `ERROR(("CS Delay Test FAILED: unexpected chip select deactivate instruction duration. Expected=%d, Got=%d",expected_cs_deactivate_time,cs_deactivate_time));
     end
     `INFO(("CS Delay Test PASSED"));
-
-  end
 endtask
+
 endprogram

--- a/spi_engine/tests/test_sleep_delay.sv
+++ b/spi_engine/tests/test_sleep_delay.sv
@@ -72,28 +72,25 @@ test_harness_env env;
 task axi_read_v(
     input   [31:0]  raddr,
     input   [31:0]  vdata);
-begin
+
   env.mng.RegReadVerify32(raddr,vdata);
-end
 endtask
 
 task axi_read(
     input   [31:0]  raddr,
     output  [31:0]  data);
-begin
+
   env.mng.RegRead32(raddr,data);
-end
 endtask
 
 // --------------------------
 // Wrapper function for AXI write
 // --------------------------
-task axi_write;
-  input [31:0]  waddr;
-  input [31:0]  wdata;
-begin
+task axi_write(
+  input [31:0]  waddr,
+  input [31:0]  wdata);
+
   env.mng.RegWrite32(waddr,wdata);
-end
 endtask
 
 // --------------------------
@@ -114,7 +111,7 @@ initial begin
 
   env.sys_reset();
 
-  sanity_test;
+  sanity_test();
 
   #100ns
 
@@ -132,13 +129,11 @@ end
 // Sanity test reg interface
 //---------------------------------------------------------------------------
 
-task sanity_test;
-begin
+task sanity_test();
   axi_read_v (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_VERSION), PCORE_VERSION);
   axi_write  (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   axi_read_v (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_SCRATCH), 32'hDEADBEEF);
   `INFO(("Sanity Test Done"));
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -390,9 +385,8 @@ bit [31:0] offload_captured_word_arr [(`NUM_OF_TRANSFERS) -1 :0];
 bit [31:0] sleep_time;
 bit [31:0] expected_sleep_time;
 
-task sleep_delay_test;
-  input [7:0] sleep_param;
-begin
+task sleep_delay_test(
+  input [7:0] sleep_param);
 
   // Start spi clk generator
   axi_write (`SPI_ENGINE_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
@@ -422,7 +416,6 @@ begin
 
   expected_sleep_time = 2+(sleep_param)*((`CLOCK_DIVIDER+1)*2);
   // Start the test
-  #100ns
   axi_write (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_CMD_FIFO), (`sleep(sleep_param)));
 
   #2000ns
@@ -434,7 +427,6 @@ begin
   end
   // Disable SPI Engine
   axi_write (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_ENABLE), 1);
-end
 endtask
 
 //---------------------------------------------------------------------------
@@ -447,10 +439,9 @@ bit [31:0] expected_cs_activate_time;
 bit [31:0] cs_deactivate_time;
 bit [31:0] expected_cs_deactivate_time;
 
-task cs_delay_test;
-  input [1:0] cs_activate_delay;
-  input [1:0] cs_deactivate_delay;
-begin
+task cs_delay_test(
+  input [1:0] cs_activate_delay,
+  input [1:0] cs_deactivate_delay);
 
     // Start spi clk generator
     axi_write (`SPI_ENGINE_AXI_CLKGEN_BA + GetAddrs(AXI_CLKGEN_REG_RSTN),
@@ -500,7 +491,6 @@ begin
     expected_cs_deactivate_time = 2;
 
     // Start the offload
-    #100ns
     axi_write (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(1));
     `INFOV(("Offload started (no delay on CS change)."), 6);
 
@@ -508,7 +498,6 @@ begin
 
     offload_status = 0;
     axi_write (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(0));
-
 
     `INFOV(("Offload stopped (no delay on CS change)."), 6);
 
@@ -559,7 +548,6 @@ begin
     expected_cs_deactivate_time = 2+2*cs_deactivate_delay*(1+`CLOCK_DIVIDER)*2;
 
     // Start the offload
-    #100ns
     axi_write (`SPI_ENGINE_SPI_REGMAP_BA + GetAddrs(AXI_SPI_ENGINE_OFFLOAD0_EN), `SET_AXI_SPI_ENGINE_OFFLOAD0_EN_OFFLOAD0_EN(1));
     `INFOV(("Offload started (with delay on CS change)."), 6);
 
@@ -597,7 +585,6 @@ begin
       `ERROR(("CS Delay Test FAILED: unexpected chip select deactivate instruction duration. Expected=%d, Got=%d",expected_cs_deactivate_time,cs_deactivate_time));
     end
     `INFO(("CS Delay Test PASSED"));
-
-  end
 endtask
+
 endprogram


### PR DESCRIPTION
Add parentheses to function calls to differentiate them from variables for readability.