### PR TITLE
scripts: fixup cygwin, use sh as subshell

### DIFF
--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -54,7 +54,7 @@ endef
 ifeq ($(OS), Windows_NT)
 CMD_PRE = cmd /C "
 CMD_POST = "
-RUN_SIM_PATH = $(shell cygpath -w $(ADI_HDL_DIR)/testbenches/scripts/run_sim.tcl) 
+RUN_SIM_PATH = $(shell cygpath -m $(ADI_HDL_DIR)/testbenches/scripts/run_sim.tcl)
 else
 CMD_PRE =
 CMD_POST =
@@ -85,7 +85,7 @@ define sim
 $(1) += $(addprefix runs/,$(addprefix $(1)/,$(2).log))
 $(addprefix runs/,$(addprefix $(1)/,$(2).log)): $(addprefix runs/,$(1)/system_project.log) $(addprefix tests/,$(2).sv) $(SV_DEPS) FORCE
 	$(RUN_PRE_OPT)$$(call simulate, \
-		$(CMD_PRE) flock runs/$(1)/.lock -c "$(M_VIVADO) $(RUN_SIM_PATH) -tclargs $(1) $(2) $(MODE) $(CMD_POST)", \
+		$(CMD_PRE) flock runs/$(1)/.lock sh -c "$(M_VIVADO) $(RUN_SIM_PATH) -tclargs $(1) $(2) $(MODE) $(CMD_POST)", \
 		$$@, \
 		Running $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
 		Run $(HL)$(strip $(2))$(NC) test on $(HL)$(strip $(1))$(NC) env, \
@@ -138,7 +138,7 @@ clean:
 $(HDL_LIBRARY_PATH)%/component.xml: TARGET:=xilinx
 FORCE:
 $(HDL_LIBRARY_PATH)%/component.xml: FORCE
-	flock $(dir $@).lock -c " \
+	flock $(dir $@).lock sh -c " \
 	$(MAKE) -C $(dir $@) $(TARGET); \
 	"; exit $$?
 FORCE:


### PR DESCRIPTION
Backslashes are not propagated by flock, so they do not reach Vivado.
Since Vivado tclsh supports unix-like paths, use them instead of escaping backslashes.
Also defines sh as the shell called by flock, since we want to ensure support to sh shell (related to https://github.com/analogdevicesinc/hdl/pull/1303).

The documentation for cygpath can be [read here](https://cygwin.com/cygwin-ug-net/cygpath.html),
where I chose "mixed mode" for the unix-like path, e.g.:
```
/cygdrive/c/Users/ --> C:/Users/
```

The flock behavior can be tested with:
```
~$ echo hello \\ backslash!
hello \ backslash!
~$ flock temp -c "echo hello \\ backslash!"
hello  backslash!
```

Vivado tclsh behavior can be tested with:
```
cd c:/Users
OK
cd c:\Users
couldn't change working directory to "c:Users": no such file or directory
cd c:\\Users
OK
```

Also tested on cygwin:
```
hdl/library$ make -j5 # successfully build all libs in parallel
hdl/projects/pulsar_adc_pmdz$ make # successfully synthesized the projects
```
For future work on altera and lattice, we should check if the shells supports regular slashes to streamline cross-platform compatibility.

Benchmarking WSL2 vs Cygwin (almost 5 times slower):
```
hdl/testbenches/i3c_controller$ time make
# WSL2:
real    2m16.014s
# Cygwin:
real    10m59.121s
```