### PR TITLE
Add testbench for Pluto

### DIFF
--- a/pluto/Makefile
+++ b/pluto/Makefile
@@ -1,0 +1,51 @@
+####################################################################################
+## Copyright (C) 2024 Analog Devices, Inc.
+####################################################################################
+
+# All test-bench dependencies except test programs
+SV_DEPS += ../common/sv/utils.svh
+SV_DEPS += ../common/sv/logger_pkg.sv
+SV_DEPS += ../common/sv/reg_accessor.sv
+SV_DEPS += ../common/sv/m_axis_sequencer.sv
+SV_DEPS += ../common/sv/s_axis_sequencer.sv
+SV_DEPS += ../common/sv/m_axi_sequencer.sv
+SV_DEPS += ../common/sv/s_axi_sequencer.sv
+SV_DEPS += ../common/sv/adi_regmap_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_dmac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_dac_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_adc_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_common_pkg.sv
+SV_DEPS += ../common/sv/adi_regmap_tdd_gen_pkg.sv
+SV_DEPS += ../common/sv/dmac_api.sv
+SV_DEPS += ../common/sv/dma_trans.sv
+SV_DEPS += ../common/sv/test_harness_env.sv
+SV_DEPS += system_tb.sv
+
+ENV_DEPS += system_project.tcl
+ENV_DEPS += system_bd.tcl
+ENV_DEPS +=../scripts/adi_sim.tcl
+ENV_DEPS +=../scripts/run_sim.tcl
+
+LIB_DEPS += axi_ad9361
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_tdd
+LIB_DEPS += util_pack/util_cpack2
+LIB_DEPS += util_pack/util_upack2
+
+# default test program
+TP := test_program
+
+# config files should have the following format
+#  cfg_<param1>_<param2>.tcl
+CFG_FILES := $(notdir $(wildcard cfgs/cfg*.tcl))
+#$(warning $(CFG_FILES))
+
+# List of tests and configuration combinations that has to be run
+# Format is:  <configuration>:<test name>
+TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(cfg):$(TP))
+#TESTS += cfg1_mm2mm_default:directed_test
+#TESTS += cfg1:test_program
+#TESTS += cfg2_fsync:test_program
+#TESTS += cfg2_fsync:test_frame_delay
+
+include ../scripts/project-sim.mk

--- a/pluto/README.md
+++ b/pluto/README.md
@@ -1,0 +1,27 @@
+Usage :
+
+Run all tests in batch mode:
+
+	make
+
+
+Run all tests in GUI mode:
+
+	make MODE=gui
+
+
+Run specific test on a specific configuration in gui mode:
+
+	make CFG=<name of cfg> TST=<name of test> MODE=gui
+
+
+Run all test from a configuration:
+
+	make <name of cfg>
+
+
+Where:
+
+ * <name of cfg> is a file from the cfgs directory without the tcl extension of format cfg\*
+ * <name of test> is a file from the tests directory without the tcl extension
+

--- a/pluto/cfgs/cfg1.tcl
+++ b/pluto/cfgs/cfg1.tcl
@@ -1,0 +1,7 @@
+global ad_project_params
+
+
+# Put project configs here 
+# e.g.
+# set ad_project_params(CMOS_LVDS_N) 1
+

--- a/pluto/system_bd.tcl
+++ b/pluto/system_bd.tcl
@@ -1,0 +1,111 @@
+# ***************************************************************************
+# ***************************************************************************
+# Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+#
+# In this HDL repository, there are many different and unique modules, consisting
+# of various HDL (Verilog or VHDL) components. The individual modules are
+# developed independently, and may be accompanied by separate and unique license
+# terms.
+#
+# The user should read each of these license terms, and understand the
+# freedoms and responsibilities that he or she has by using this source/core.
+#
+# This core is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.
+#
+# Redistribution and use of source or resulting binaries, with or without modification
+# of this file, are permitted under one of the following two license terms:
+#
+#   1. The GNU General Public License version 2 as published by the
+#      Free Software Foundation, which can be found in the top level directory
+#      of this repository (LICENSE_GPL2), and also online at:
+#      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+#
+# OR
+#
+#   2. An ADI specific BSD license, which can be found in the top level directory
+#      of this repository (LICENSE_ADIBSD), and also on-line at:
+#      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+#      This will allow to generate bit files and not release the source code,
+#      as long as it attaches to an ADI device.
+#
+# ***************************************************************************
+# ***************************************************************************
+
+source ../../scripts/adi_env.tcl
+
+global ad_project_params
+
+# Device clk
+ad_ip_instance clk_vip ssi_clk_vip [ list \
+  INTERFACE_MODE {MASTER} \
+  FREQ_HZ 250000000 \
+]
+adi_sim_add_define "SSI_CLK=ssi_clk_vip"
+create_bd_port -dir O ssi_clk_out
+ad_connect ssi_clk_out ssi_clk_vip/clk_out
+
+# Remove duplicated objects
+delete_bd_objs \
+  [get_bd_cells sys_concat_intc] \
+  [get_bd_cells sys_rstgen]
+
+ad_disconnect [get_bd_pins sys_clk_vip/clk_out] sys_cpu_clk
+
+# Block design under test
+source $ad_hdl_dir/projects/pluto/system_bd.tcl
+
+# Remove unnecessary objects
+delete_bd_objs \
+  [get_bd_intf_nets axi_ad9361_adc_dma_m_dest_axi] \
+  [get_bd_intf_nets axi_ad9361_dac_dma_m_src_axi] \
+  [get_bd_intf_nets S00_AXI_1] \
+  [get_bd_intf_nets sys_ps7_DDR] \
+  [get_bd_intf_nets sys_ps7_FIXED_IO] \
+  [get_bd_nets gpio_i_1] \
+  [get_bd_nets spi0_clk_i_1] \
+  [get_bd_nets spi0_csn_i_1] \
+  [get_bd_nets spi0_sdi_i_1] \
+  [get_bd_nets spi0_sdo_i_1] \
+  [get_bd_nets sys_200m_clk] \
+  [get_bd_nets sys_concat_intc_dout] \
+  [get_bd_nets sys_ps7_FCLK_RESET0_N] \
+  [get_bd_nets sys_ps7_GPIO_O] \
+  [get_bd_nets sys_ps7_GPIO_T] \
+  [get_bd_nets sys_ps7_SPI0_MOSI_O] \
+  [get_bd_nets sys_ps7_SPI0_SCLK_O] \
+  [get_bd_nets sys_ps7_SPI0_SS_O] \
+  [get_bd_nets sys_ps7_SPI0_SS1_O] \
+  [get_bd_nets sys_ps7_SPI0_SS2_O] \
+  [get_bd_cells sys_ps7]
+
+ad_connect sys_cpu_clk sys_clk_vip/clk_out
+ad_connect sys_cpu_clk mng_axi_vip/aclk
+ad_connect sys_cpu_clk axi_intc/s_axi_aclk
+ad_connect sys_cpu_clk axi_axi_interconnect/aclk
+ad_connect sys_cpu_clk axi_mem_interconnect/aclk1
+ad_connect sys_rst_vip/rst_out sys_rstgen/ext_reset_in
+ad_connect axi_intc/intr sys_concat_intc/dout
+ad_connect $sys_iodelay_clk axi_ad9361/delay_clk
+
+ad_mem_hp1_interconnect sys_cpu_clk axi_ad9361_adc_dma/m_dest_axi
+ad_mem_hp2_interconnect sys_cpu_clk axi_ad9361_dac_dma/m_src_axi
+
+ad_ip_parameter axi_ad9361 CONFIG.DELAY_REFCLK_FREQUENCY 400
+
+set RX_DMA 0x7C400000
+set_property offset $RX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361_adc_dma}]
+adi_sim_add_define "RX_DMA_BA=[format "%d" ${RX_DMA}]"
+
+set TX_DMA 0x7C420000
+set_property offset $TX_DMA [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361_dac_dma}]
+adi_sim_add_define "TX_DMA_BA=[format "%d" ${TX_DMA}]"
+
+set TDDN 0x7C440000
+set_property offset $TDDN [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_tdd_0}]
+adi_sim_add_define "TDDN_BA=[format "%d" ${TDDN}]"
+
+set AXI_AD9361 0x79020000
+set_property offset $AXI_AD9361 [get_bd_addr_segs {mng_axi_vip/Master_AXI/SEG_data_axi_ad9361}]
+adi_sim_add_define "AXI_AD9361_BA=[format "%d" ${AXI_AD9361}]"

--- a/pluto/system_project.tcl
+++ b/pluto/system_project.tcl
@@ -1,0 +1,46 @@
+source ../scripts/adi_sim.tcl
+source ../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+if {$argc < 1} {
+  puts "Expecting at least one argument that specifies the test configuration"
+  exit 1
+} else {
+  set cfg_file [lindex $argv 0]
+}
+
+# Read common config file
+source "cfgs/${cfg_file}"
+
+# Set the project name
+set project_name [file rootname $cfg_file]
+
+# Create the project
+adi_sim_project_xilinx $project_name "xc7z010clg400-1"
+
+# Add test files to the project
+adi_sim_project_files [list \
+ "../common/sv/utils.svh" \
+ "../common/sv/logger_pkg.sv" \
+ "../common/sv/reg_accessor.sv" \
+ "../common/sv/m_axis_sequencer.sv" \
+ "../common/sv/s_axis_sequencer.sv" \
+ "../common/sv/m_axi_sequencer.sv" \
+ "../common/sv/s_axi_sequencer.sv" \
+ "../common/sv/adi_regmap_pkg.sv" \
+ "../common/sv/adi_regmap_dmac_pkg.sv" \
+ "../common/sv/adi_regmap_dac_pkg.sv" \
+ "../common/sv/adi_regmap_adc_pkg.sv" \
+ "../common/sv/adi_regmap_common_pkg.sv" \
+ "../common/sv/adi_regmap_tdd_gen_pkg.sv" \
+ "../common/sv/dmac_api.sv" \
+ "../common/sv/dma_trans.sv" \
+ "../common/sv/test_harness_env.sv" \
+ "tests/test_program.sv" \
+ "system_tb.sv" \
+ ]
+
+#set a default test program
+adi_sim_add_define "TEST_PROGRAM=test_program"
+
+adi_sim_generate $project_name

--- a/pluto/system_tb.sv
+++ b/pluto/system_tb.sv
@@ -1,0 +1,70 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/1ps
+
+`include "utils.svh"
+
+module system_tb();
+
+  logic        burst = 1'b0;
+  logic        txdata;
+  logic [11:0] tx_data_out;
+
+  `TEST_PROGRAM test();
+
+  test_harness `TH (
+    .ssi_clk_out (ssi_clk),
+
+    .enable (enable),
+
+    .rx_clk_in (rx_clk_in),
+    .rx_data_in (tx_data_out),
+    .rx_frame_in (tx_frame_out),
+
+    .tx_clk_out (tx_clk_out),
+    .tx_data_out (tx_data_out),
+    .tx_frame_out (tx_frame_out),
+    .txnrx (txnrx),
+    .up_enable (1'b1),
+    .up_txnrx (1'b1),
+
+    .tdd_ext_sync(burst),
+    .txdata_o(txdata)
+  );
+
+  assign rx_clk_in = ssi_clk;
+
+endmodule

--- a/pluto/tests/test_program.sv
+++ b/pluto/tests/test_program.sv
@@ -1,0 +1,701 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsabilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+//
+//
+//
+`include "utils.svh"
+
+import test_harness_env_pkg::*;
+import axi_vip_pkg::*;
+import axi4stream_vip_pkg::*;
+import logger_pkg::*;
+import adi_regmap_pkg::*;
+import adi_regmap_dmac_pkg::*;
+import adi_regmap_dac_pkg::*;
+import adi_regmap_adc_pkg::*;
+import adi_regmap_common_pkg::*;
+import adi_regmap_tdd_gen_pkg::*;
+
+program test_program;
+
+  localparam CH0 = 8'h00;
+  localparam CH1 = 8'h40;
+  localparam CH2 = 8'h80;
+  localparam CH3 = 8'hC0;
+
+  localparam RX1_COMMON  = `AXI_AD9361_BA;
+  localparam RX1_CHANNEL = `AXI_AD9361_BA;
+  localparam TX1_COMMON  = `AXI_AD9361_BA + 'h4000;
+  localparam TX1_CHANNEL = `AXI_AD9361_BA + 'h4000;
+  localparam TDD1        = `AXI_AD9361_BA + 'h8000;
+
+  test_harness_env env;
+  bit [31:0] val = 32'h0;
+  int r1_mode, rate;
+
+  // --------------------------
+  // Wrapper function for AXI read
+  // --------------------------
+  task axi_read(
+    input   [31:0]  raddr,
+    output  [31:0]  rdata);
+
+    env.mng.RegRead32(raddr,rdata);
+  endtask
+
+  // --------------------------
+  // Wrapper function for AXI read verify
+  // --------------------------
+  task axi_read_v(
+    input   [31:0]  raddr,
+    input   [31:0]  vdata);
+
+    env.mng.RegReadVerify32(raddr,vdata);
+  endtask
+
+  // --------------------------
+  // Wrapper function for AXI write
+  // --------------------------
+  task axi_write(
+    input [31:0]  waddr,
+    input [31:0]  wdata);
+
+    env.mng.RegWrite32(waddr,wdata);
+  endtask
+
+  // --------------------------
+  // Main procedure
+  // --------------------------
+  initial begin
+
+    // Creating environment
+    env = new(`TH.`SYS_CLK.inst.IF,
+              `TH.`DMA_CLK.inst.IF,
+              `TH.`DDR_CLK.inst.IF,
+              `TH.`SYS_RST.inst.IF,
+              `TH.`MNG_AXI.inst.IF,
+              `TH.`DDR_AXI.inst.IF);
+
+    #2ps;
+
+    setLoggerVerbosity(6);
+    env.start();
+
+    // Set source synchronous interface clock frequency
+    `TH.`SSI_CLK.inst.IF.set_clk_frq(.user_frequency(61440000));
+    `TH.`SSI_CLK.inst.IF.start_clock;
+
+    // Initial system reset
+    env.sys_reset();
+
+    // This is required since the AD9361 interface always requires to receive
+    // something first before transmitting. This is not possible in loopback mode.
+    force `TH.axi_ad9361.inst.i_tx.dac_sync_enable = 1'b1;
+
+    sanity_test();
+
+    // 1R1T mode
+    r1_mode = 1;
+
+    pn_test();
+
+    dds_test();
+
+    dma_test();
+
+    // 2R2T mode
+    r1_mode = 0;
+
+    pn_test();
+
+    dds_test();
+
+    dma_test();
+
+    tdd_test();
+
+    `INFO(("Test Done"));
+
+  end
+
+  // --------------------------
+  // Sanity test reg interface
+  // --------------------------
+  task sanity_test();
+    // Check ADC VERSION
+    axi_read_v (RX1_COMMON + GetAddrs(COMMON_REG_VERSION),
+               `SET_COMMON_REG_VERSION_VERSION('h000a0300));
+    // Check DAC VERSION
+    axi_read_v (TX1_COMMON + GetAddrs(COMMON_REG_VERSION),
+               `SET_COMMON_REG_VERSION_VERSION('h00090262));
+  endtask
+
+  // --------------------------
+  // Setup link
+  // --------------------------
+  task link_setup();
+    // Set the DAC rate
+    rate = r1_mode ? 1 : 2;
+
+    // Configure RX interface
+    axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_CNTRL),
+              `SET_ADC_COMMON_REG_CNTRL_R1_MODE(r1_mode));
+
+    // Configure TX interface
+    axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_CNTRL_2),
+              `SET_DAC_COMMON_REG_CNTRL_2_R1_MODE(r1_mode));
+    axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_RATECNTRL),
+              `SET_DAC_COMMON_REG_RATECNTRL_RATE(rate-1));
+
+    // Pull out RX of reset
+    axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_RSTN),
+              `SET_ADC_COMMON_REG_RSTN_RSTN(1));
+    // Pull out TX of reset
+    axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_RSTN),
+              `SET_DAC_COMMON_REG_RSTN_RSTN(1));
+  endtask
+
+  // --------------------------
+  // Link teardown
+  // --------------------------
+  task link_down();
+    // Put RX in reset
+    axi_write (RX1_COMMON + GetAddrs(ADC_COMMON_REG_RSTN),
+              `SET_ADC_COMMON_REG_RSTN_RSTN(0));
+    // Put TX in reset
+    axi_write (TX1_COMMON + GetAddrs(DAC_COMMON_REG_RSTN),
+              `SET_DAC_COMMON_REG_RSTN_RSTN(0));
+    #1us;
+  endtask
+
+  // --------------------------
+  // Test pattern test
+  // --------------------------
+  task pn_test();
+    link_setup();
+
+    // Enable test data for TX
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(9));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(9));
+    if (r1_mode==0) begin
+      axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(9));
+      axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(9));
+    end
+
+    // Enable test data check for RX
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(9));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(9));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(9));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(9));
+    end
+
+    // SYNC DAC channels
+    axi_write (TX1_COMMON+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+              `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
+    // SYNC ADC channels
+    axi_write (RX1_COMMON+GetAddrs(ADC_COMMON_REG_CNTRL),
+              `SET_ADC_COMMON_REG_CNTRL_R1_MODE(r1_mode) |
+              `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
+
+    // Allow initial OOS to propagate
+    #15us;
+
+    // Clear PN OOS and PN ERR
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_STATUS),
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_ERR(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_OOS(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_OVER_RANGE(1));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_STATUS),
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_ERR(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_OOS(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_STATUS_OVER_RANGE(1));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_STATUS),
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_ERR(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_OOS(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_OVER_RANGE(1));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_STATUS),
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_ERR(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_PN_OOS(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_STATUS_OVER_RANGE(1));
+    end
+
+    #10us;
+
+    // Check PN OOS and PN ERR flags
+    axi_read_v (RX1_COMMON + GetAddrs(ADC_COMMON_REG_STATUS),
+               `SET_ADC_COMMON_REG_STATUS_STATUS('h1));
+
+    link_down();
+  endtask
+
+  // --------------------------
+  // DDS test procedure
+  // --------------------------
+  task dds_test();
+
+    //  -------------------------------------------------------
+    //  Test DDS path
+    //  -------------------------------------------------------
+
+    link_setup();
+
+    // Select DDS as source
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
+    if (r1_mode==0) begin
+      axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
+      axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(0));
+    end
+
+    // Enable normal data path for RX
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    end
+
+    // Configure tone amplitude and frequency
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h0fff));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h07ff));
+    if (r1_mode==0) begin
+      axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h03ff));
+      axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_1),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_1_DDS_SCALE_1(16'h01ff));
+    end
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0100));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0200));
+    if (r1_mode==0) begin
+      axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0400));
+      axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_2),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_2_DDS_INCR_1(16'h0800));
+    end
+
+    // Enable Rx channel, enable sign extension
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    end
+
+    // SYNC DAC channels
+    axi_write (TX1_COMMON+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+              `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
+    // SYNC ADC channels
+    axi_write (RX1_COMMON+GetAddrs(ADC_COMMON_REG_CNTRL),
+              `SET_ADC_COMMON_REG_CNTRL_R1_MODE(r1_mode) |
+              `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
+
+    #20us;
+
+    link_down();
+  endtask
+
+  // --------------------------
+  // DMA test procedure
+  // --------------------------
+  task dma_test();
+
+    //  -------------------------------------------------------
+    //  Test DMA path
+    //  -------------------------------------------------------
+
+    // Init test data
+    for (int i=0;i<2048*2 ;i=i+2) begin
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)<<4) << 16) | i<<4 ,15); // (<< 4) - 4 LSBs are dropped in the AXI_AD9361
+    end
+
+    // Configure TX DMA
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
+               `SET_DMAC_CONTROL_ENABLE(1));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
+               `SET_DMAC_X_LENGTH_X_LENGTH(32'h00000FFF));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
+               `SET_DMAC_FLAGS_CYCLIC(1));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+               `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA+32'h00000000));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    // Select DMA as source
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    if (r1_mode==0) begin
+      axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+      axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+                `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    end
+
+
+    // Enable normal data path for RX
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    end
+
+
+    // Enable Rx channel, enable sign extension
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    if (r1_mode==0) begin
+      axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+      axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+                `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    end
+
+    // SYNC DAC channels
+    axi_write (TX1_COMMON+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+              `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
+    // SYNC ADC channels
+    axi_write (RX1_COMMON+GetAddrs(ADC_COMMON_REG_CNTRL),
+              `SET_ADC_COMMON_REG_CNTRL_R1_MODE(r1_mode) |
+              `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
+
+    link_setup();
+
+    #20us;
+
+    // Configure RX DMA
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
+               `SET_DMAC_CONTROL_ENABLE(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
+               `SET_DMAC_FLAGS_TLAST(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
+               `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+               `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00002000));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    #10us;
+
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_CONTROL), 
+               `SET_DMAC_CONTROL_ENABLE(0)); 
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_CONTROL), 
+               `SET_DMAC_CONTROL_ENABLE(0)); 
+
+    check_captured_data(
+      .address (`DDR_BA+'h00002000),
+      .length (1024),
+      .step (1),
+      .max_sample(2048)
+    );
+
+    link_down();
+  endtask
+
+  // --------------------------
+  // TDD test procedure
+  // --------------------------
+  task tdd_test();
+
+    // Init test data
+    for (int i=0;i<2048*2 ;i=i+2) begin
+      env.ddr_axi_agent.mem_model.backdoor_memory_write_4byte(`DDR_BA+i*2,(((i+1)<<4) << 16) | i<<4 ,15); // (<< 4) - 4 LSBs are dropped in the AXI_AD9361
+    end
+
+    link_setup();
+
+    //  -------------------------------------------------------
+    //  Configure the TX/RX Channels
+    //  -------------------------------------------------------
+  
+    // Select DMA as source
+    axi_write (TX1_CHANNEL + CH0 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    axi_write (TX1_CHANNEL + CH1 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    axi_write (TX1_CHANNEL + CH2 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+    axi_write (TX1_CHANNEL + CH3 + GetAddrs(DAC_CHANNEL_REG_CHAN_CNTRL_7),
+              `SET_DAC_CHANNEL_REG_CHAN_CNTRL_7_DAC_DDS_SEL(2));
+
+    // Enable normal data path for RX
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+    axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL_3),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_3_ADC_PN_SEL(0));
+
+    // Enable Rx channel, enable sign extension
+    axi_write (RX1_CHANNEL + CH0 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    axi_write (RX1_CHANNEL + CH1 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    axi_write (RX1_CHANNEL + CH2 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+    axi_write (RX1_CHANNEL + CH3 + GetAddrs(ADC_CHANNEL_REG_CHAN_CNTRL),
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_ENABLE(1) |
+              `SET_ADC_CHANNEL_REG_CHAN_CNTRL_FORMAT_SIGNEXT(1));
+
+    // SYNC DAC channels
+    axi_write (TX1_COMMON+GetAddrs(DAC_COMMON_REG_CNTRL_1),
+              `SET_DAC_COMMON_REG_CNTRL_1_SYNC(1));
+    // SYNC ADC channels
+    axi_write (RX1_COMMON+GetAddrs(ADC_COMMON_REG_CNTRL),
+              `SET_ADC_COMMON_REG_CNTRL_SYNC(1));
+
+    //  -------------------------------------------------------
+    //  Configure the TX/RX DMA
+    //  -------------------------------------------------------
+
+    // Configure TX DMA
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_CONTROL),
+               `SET_DMAC_CONTROL_ENABLE(1));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
+               `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_FLAGS),
+               `SET_DMAC_FLAGS_CYCLIC(1) |
+               `SET_DMAC_FLAGS_TLAST(1));
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_SRC_ADDRESS),
+               `SET_DMAC_SRC_ADDRESS_SRC_ADDRESS(`DDR_BA+32'h00000000));
+
+    // Configure RX DMA
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_CONTROL),
+               `SET_DMAC_CONTROL_ENABLE(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_FLAGS),
+               `SET_DMAC_FLAGS_TLAST(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_IRQ_PENDING),
+               `SET_DMAC_IRQ_PENDING_TRANSFER_COMPLETED(1) |
+               `SET_DMAC_IRQ_PENDING_TRANSFER_QUEUED(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_IRQ_MASK),
+               `SET_DMAC_IRQ_MASK_TRANSFER_COMPLETED(0) |
+               `SET_DMAC_IRQ_MASK_TRANSFER_QUEUED(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_X_LENGTH),
+               `SET_DMAC_X_LENGTH_X_LENGTH(32'h000003FF));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_DEST_ADDRESS),
+               `SET_DMAC_DEST_ADDRESS_DEST_ADDRESS(`DDR_BA+32'h00002000));
+
+    //  -------------------------------------------------------
+    //  Configure the TDD for the phaser synchronization
+    //  -------------------------------------------------------
+
+    // Configure the TDD for the application
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_BURST_COUNT),
+               `SET_TDDN_CNTRL_BURST_COUNT_BURST_COUNT(32'h10));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_STARTUP_DELAY),
+               `SET_TDDN_CNTRL_STARTUP_DELAY_STARTUP_DELAY(32'h0F));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_FRAME_LENGTH),
+               `SET_TDDN_CNTRL_FRAME_LENGTH_FRAME_LENGTH(32'hFF));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH0_ON),
+               `SET_TDDN_CNTRL_CH0_ON_CH0_ON(32'h00));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH0_OFF),
+               `SET_TDDN_CNTRL_CH0_OFF_CH0_OFF(32'h10));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH1_ON),
+               `SET_TDDN_CNTRL_CH1_ON_CH1_ON(32'h20));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH1_OFF),
+               `SET_TDDN_CNTRL_CH1_OFF_CH1_OFF(32'h30));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH2_ON),
+               `SET_TDDN_CNTRL_CH2_ON_CH2_ON(32'h00));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CH2_OFF),
+               `SET_TDDN_CNTRL_CH2_OFF_CH2_OFF(32'h10));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CHANNEL_ENABLE),
+               `SET_TDDN_CNTRL_CHANNEL_ENABLE_CHANNEL_ENABLE(32'b111));
+
+    axi_write (`TDDN_BA+GetAddrs(TDDN_CNTRL_CONTROL),
+               `SET_TDDN_CNTRL_CONTROL_SYNC_EXT(1) |
+               `SET_TDDN_CNTRL_CONTROL_ENABLE(1));
+
+    // Submit the DMA transfer and wait for the TDD sync
+    axi_write (`TX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    // Send the external sync signal
+    trigger_ext_event();
+
+    // The first RX transfer is submitted between the first two TDD pulses
+    #2us;
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    check_cyclic_data();
+
+    link_down();
+  endtask
+
+  // Check captured data against incremental pattern based on first sample
+  // Pattern should be contiguous
+  task check_captured_data(
+    input bit [31:0] address,
+    input int length,
+    input int step,
+    input int max_sample);
+
+    bit [31:0] current_address;
+    bit [31:0] captured_word;
+    bit [31:0] reference_word;
+    bit [15:0] first;
+
+    for (int i=0;i<length/2;i=i+2) begin
+      current_address = address+(i*2);
+      captured_word = env.ddr_axi_agent.mem_model.backdoor_memory_read_4byte(current_address);
+      if (i==0) begin
+        first = captured_word[15:0];
+      end else begin
+        reference_word = (((first + (i+1)*step)%max_sample) << 16) | ((first + (i*step))%max_sample);
+
+        if (captured_word !== reference_word) begin
+          `ERROR(("Address 0x%h Expected 0x%h found 0x%h",current_address,reference_word,captured_word));
+        end
+      end
+    end
+  endtask
+
+  // Check the cyclic buffer integrity after each transmission
+  task check_cyclic_data();
+    // After each RX DMA end of transfer, check the captured data and issue a new transfer
+    @(posedge `TH.axi_ad9361_adc_dma.irq);
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_IRQ_PENDING),
+               `SET_DMAC_IRQ_PENDING_TRANSFER_COMPLETED(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    check_captured_data(
+      .address (`DDR_BA+'h00002000),
+      .length (1024),
+      .step (1),
+      .max_sample(512)
+    );
+
+    @(posedge `TH.axi_ad9361_adc_dma.irq);
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_IRQ_PENDING),
+               `SET_DMAC_IRQ_PENDING_TRANSFER_COMPLETED(1));
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_TRANSFER_SUBMIT),
+               `SET_DMAC_TRANSFER_SUBMIT_TRANSFER_SUBMIT(1));
+
+    check_captured_data(
+      .address (`DDR_BA+'h00002000),
+      .length (1024),
+      .step (1),
+      .max_sample(512)
+    );
+
+    @(posedge `TH.axi_ad9361_adc_dma.irq);
+    axi_write (`RX_DMA_BA+GetAddrs(DMAC_IRQ_PENDING),
+               `SET_DMAC_IRQ_PENDING_TRANSFER_COMPLETED(1));
+
+    check_captured_data(
+      .address (`DDR_BA+'h00002000),
+      .length (1024),
+      .step (1),
+      .max_sample(512)
+    );
+  endtask
+
+  // Trigger an external event
+  task trigger_ext_event();
+    #5ns;
+    `TB.burst =1'b1;
+    #50ns;
+    `TB.burst =1'b0;
+  endtask
+
+endprogram

--- a/pluto/waves/cfg1.wcfg
+++ b/pluto/waves/cfg1.wcfg
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wave_config>
+   <wave_state>
+   </wave_state>
+   <db_ref_list>
+      <db_ref path="system_tb_behav.wdb" id="1">
+         <top_modules>
+            <top_module name="adi_regmap_adc_pkg" />
+            <top_module name="adi_regmap_common_pkg" />
+            <top_module name="adi_regmap_dac_pkg" />
+            <top_module name="adi_regmap_dmac_pkg" />
+            <top_module name="adi_regmap_pkg" />
+            <top_module name="adi_regmap_tdd_gen_pkg" />
+            <top_module name="axi4stream_vip_pkg" />
+            <top_module name="axi_tdd_pkg" />
+            <top_module name="axi_vip_pkg" />
+            <top_module name="glbl" />
+            <top_module name="iic_pkg" />
+            <top_module name="ipif_pkg" />
+            <top_module name="lib_pkg" />
+            <top_module name="logger_pkg" />
+            <top_module name="m_axi_sequencer_pkg" />
+            <top_module name="reg_accessor_pkg" />
+            <top_module name="s_axi_sequencer_pkg" />
+            <top_module name="std" />
+            <top_module name="system_tb" />
+            <top_module name="test_harness_ddr_axi_vip_0_pkg" />
+            <top_module name="test_harness_env_pkg" />
+            <top_module name="test_harness_mng_axi_vip_0_pkg" />
+            <top_module name="vcomponents" />
+            <top_module name="vpkg" />
+            <top_module name="xil_common_vip_pkg" />
+         </top_modules>
+      </db_ref>
+   </db_ref_list>
+   <zoom_setting>
+      <ZoomStartTime time="0.000000 us"></ZoomStartTime>
+      <ZoomEndTime time="38.755209 us"></ZoomEndTime>
+      <Cursor1Time time="37.205000 us"></Cursor1Time>
+   </zoom_setting>
+   <column_width_setting>
+      <NameColumnWidth column_width="138"></NameColumnWidth>
+      <ValueColumnWidth column_width="66"></ValueColumnWidth>
+   </column_width_setting>
+   <WVObjectSize size="31" />
+   <wave_markers>
+      <marker label="" time="37450000000" />
+      <marker label="" time="35626000000" />
+   </wave_markers>
+   <wvobject fp_name="divider288" type="divider">
+      <obj_property name="label">AXI_AD9361 interface</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_enable_i0">
+      <obj_property name="ElementShortName">adc_enable_i0</obj_property>
+      <obj_property name="ObjectShortName">adc_enable_i0</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_valid_i0">
+      <obj_property name="ElementShortName">adc_valid_i0</obj_property>
+      <obj_property name="ObjectShortName">adc_valid_i0</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361/adc_data_i0">
+      <obj_property name="ElementShortName">adc_data_i0[15:0]</obj_property>
+      <obj_property name="ObjectShortName">adc_data_i0[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ANALOG</obj_property>
+      <obj_property name="CellHeight">100</obj_property>
+      <obj_property name="AnalogYRangeType">ANALOG_YRANGETYPE_FIXED</obj_property>
+      <obj_property name="AnalogYRangeMin">-512.000000</obj_property>
+      <obj_property name="AnalogYRRangeMax">512.000000</obj_property>
+      <obj_property name="AnalogInterpolation">ANALOG_INTERPOLATION_LINEAR</obj_property>
+      <obj_property name="AnalogOffscale">ANALOG_OFFSCALE_HIDE</obj_property>
+      <obj_property name="AnalogHorizLine">0.000000</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_enable_q0">
+      <obj_property name="ElementShortName">adc_enable_q0</obj_property>
+      <obj_property name="ObjectShortName">adc_enable_q0</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_valid_q0">
+      <obj_property name="ElementShortName">adc_valid_q0</obj_property>
+      <obj_property name="ObjectShortName">adc_valid_q0</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361/adc_data_q0">
+      <obj_property name="ElementShortName">adc_data_q0[15:0]</obj_property>
+      <obj_property name="ObjectShortName">adc_data_q0[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ANALOG</obj_property>
+      <obj_property name="CellHeight">100</obj_property>
+      <obj_property name="AnalogYRangeType">ANALOG_YRANGETYPE_FIXED</obj_property>
+      <obj_property name="AnalogYRangeMin">-512.000000</obj_property>
+      <obj_property name="AnalogYRRangeMax">512.000000</obj_property>
+      <obj_property name="AnalogInterpolation">ANALOG_INTERPOLATION_LINEAR</obj_property>
+      <obj_property name="AnalogOffscale">ANALOG_OFFSCALE_HIDE</obj_property>
+      <obj_property name="AnalogHorizLine">0.000000</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_enable_i1">
+      <obj_property name="ElementShortName">adc_enable_i1</obj_property>
+      <obj_property name="ObjectShortName">adc_enable_i1</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_valid_i1">
+      <obj_property name="ElementShortName">adc_valid_i1</obj_property>
+      <obj_property name="ObjectShortName">adc_valid_i1</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361/adc_data_i1">
+      <obj_property name="ElementShortName">adc_data_i1[15:0]</obj_property>
+      <obj_property name="ObjectShortName">adc_data_i1[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ANALOG</obj_property>
+      <obj_property name="CellHeight">100</obj_property>
+      <obj_property name="AnalogYRangeType">ANALOG_YRANGETYPE_FIXED</obj_property>
+      <obj_property name="AnalogYRangeMin">-512.000000</obj_property>
+      <obj_property name="AnalogYRRangeMax">512.000000</obj_property>
+      <obj_property name="AnalogInterpolation">ANALOG_INTERPOLATION_LINEAR</obj_property>
+      <obj_property name="AnalogOffscale">ANALOG_OFFSCALE_HIDE</obj_property>
+      <obj_property name="AnalogHorizLine">0.000000</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_enable_q1">
+      <obj_property name="ElementShortName">adc_enable_q1</obj_property>
+      <obj_property name="ObjectShortName">adc_enable_q1</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361/adc_valid_q1">
+      <obj_property name="ElementShortName">adc_valid_q1</obj_property>
+      <obj_property name="ObjectShortName">adc_valid_q1</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361/adc_data_q1">
+      <obj_property name="ElementShortName">adc_data_q1[15:0]</obj_property>
+      <obj_property name="ObjectShortName">adc_data_q1[15:0]</obj_property>
+      <obj_property name="Radix">SIGNEDDECRADIX</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ANALOG</obj_property>
+      <obj_property name="CellHeight">100</obj_property>
+      <obj_property name="AnalogYRangeType">ANALOG_YRANGETYPE_FIXED</obj_property>
+      <obj_property name="AnalogYRangeMin">-512.000000</obj_property>
+      <obj_property name="AnalogYRRangeMax">512.000000</obj_property>
+      <obj_property name="AnalogInterpolation">ANALOG_INTERPOLATION_LINEAR</obj_property>
+      <obj_property name="AnalogOffscale">ANALOG_OFFSCALE_HIDE</obj_property>
+      <obj_property name="AnalogHorizLine">0.000000</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider288" type="divider">
+      <obj_property name="label">DAC DMA</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_dac_dma/m_axis_ready">
+      <obj_property name="ElementShortName">m_axis_ready</obj_property>
+      <obj_property name="ObjectShortName">m_axis_ready</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_dac_dma/m_axis_valid">
+      <obj_property name="ElementShortName">m_axis_valid</obj_property>
+      <obj_property name="ObjectShortName">m_axis_valid</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361_dac_dma/m_axis_data">
+      <obj_property name="ElementShortName">m_axis_data[63:0]</obj_property>
+      <obj_property name="ObjectShortName">m_axis_data[63:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_dac_dma/m_axis_last">
+      <obj_property name="ElementShortName">m_axis_last</obj_property>
+      <obj_property name="ObjectShortName">m_axis_last</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider288" type="divider">
+      <obj_property name="label">ADC DMA</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_adc_dma/fifo_wr_en">
+      <obj_property name="ElementShortName">fifo_wr_en</obj_property>
+      <obj_property name="ObjectShortName">fifo_wr_en</obj_property>
+   </wvobject>
+   <wvobject type="array" fp_name="/system_tb/test_harness/axi_ad9361_adc_dma/fifo_wr_din">
+      <obj_property name="ElementShortName">fifo_wr_din[63:0]</obj_property>
+      <obj_property name="ObjectShortName">fifo_wr_din[63:0]</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_adc_dma/fifo_wr_sync">
+      <obj_property name="ElementShortName">fifo_wr_sync</obj_property>
+      <obj_property name="ObjectShortName">fifo_wr_sync</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_ad9361_adc_dma/fifo_wr_xfer_req">
+      <obj_property name="ElementShortName">fifo_wr_xfer_req</obj_property>
+      <obj_property name="ObjectShortName">fifo_wr_xfer_req</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider31" type="divider">
+      <obj_property name="label">TDD CH</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_channel_0[0]">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">[0]</obj_property>
+      <obj_property name="ObjectShortName">[0]</obj_property>
+      <obj_property name="label">CH0</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_channel_1[0]">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">[0]</obj_property>
+      <obj_property name="ObjectShortName">[0]</obj_property>
+      <obj_property name="label">CH1</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_channel_2[0]">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">[0]</obj_property>
+      <obj_property name="ObjectShortName">[0]</obj_property>
+      <obj_property name="label">CH2</obj_property>
+   </wvobject>
+   <wvobject fp_name="divider64" type="divider">
+      <obj_property name="label">CH Polarity</obj_property>
+      <obj_property name="DisplayName">label</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_core/inst/\genblk1[0].i_channel /ch_pol">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">ch_pol</obj_property>
+      <obj_property name="ObjectShortName">ch_pol</obj_property>
+      <obj_property name="label">CH0 POL</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_core/inst/\genblk1[1].i_channel /ch_pol">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">ch_pol</obj_property>
+      <obj_property name="ObjectShortName">ch_pol</obj_property>
+      <obj_property name="label">CH1 POL</obj_property>
+   </wvobject>
+   <wvobject type="logic" fp_name="/system_tb/test_harness/axi_tdd_0/tdd_core/inst/\genblk1[2].i_channel /ch_pol">
+      <obj_property name="DisplayName">label</obj_property>
+      <obj_property name="ElementShortName">ch_pol</obj_property>
+      <obj_property name="ObjectShortName">ch_pol</obj_property>
+      <obj_property name="label">CH2 POL</obj_property>
+   </wvobject>
+</wave_config>


### PR DESCRIPTION
This commit adds a new testbench for Pluto operating in both 1R1T and 2R2T modes, including the TDD setup and testing.