### PR TITLE
adrv9009: Updated interconnects

### DIFF
--- a/adrv9009/system_bd.tcl
+++ b/adrv9009/system_bd.tcl
@@ -226,8 +226,8 @@ ad_connect rx_device_clk i_rx_jesd_exerciser/device_clk
 
 ad_connect ref_clk_ex i_rx_jesd_exerciser/ref_clk
 
-set_property -dict [list CONFIG.NUM_MI {18}] [get_bd_cells axi_cpu_interconnect]
-ad_connect i_rx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M17_AXI
+set_property -dict [list CONFIG.NUM_MI {3}] [get_bd_cells axi_cpu_interconnect_1]
+ad_connect i_rx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect_1/M02_AXI
 
 create_bd_port -dir O ex_rx_sync
 ad_connect ex_rx_sync i_rx_jesd_exerciser/rx_sync_0
@@ -246,8 +246,8 @@ ad_connect tx_device_clk i_tx_jesd_exerciser/device_clk
 
 ad_connect ref_clk_ex i_tx_jesd_exerciser/ref_clk
 
-set_property -dict [list CONFIG.NUM_MI {19}] [get_bd_cells axi_cpu_interconnect]
-ad_connect i_tx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M18_AXI
+set_property -dict [list CONFIG.NUM_MI {4}] [get_bd_cells axi_cpu_interconnect_1]
+ad_connect i_tx_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect_1/M03_AXI
 
 create_bd_port -dir I ex_tx_sync
 ad_connect ex_tx_sync i_tx_jesd_exerciser/tx_sync_0
@@ -275,8 +275,8 @@ ad_connect tx_os_device_clk i_tx_os_jesd_exerciser/device_clk
 
 ad_connect ref_clk_ex i_tx_os_jesd_exerciser/ref_clk
 
-set_property -dict [list CONFIG.NUM_MI {20}] [get_bd_cells axi_cpu_interconnect]
-ad_connect i_tx_os_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect/M19_AXI
+set_property -dict [list CONFIG.NUM_MI {5}] [get_bd_cells axi_cpu_interconnect_1]
+ad_connect i_tx_os_jesd_exerciser/S00_AXI_0 axi_cpu_interconnect_1/M04_AXI
 
 create_bd_port -dir I ex_tx_os_sync
 ad_connect ex_tx_os_sync i_tx_os_jesd_exerciser/tx_sync_0

--- a/common/test_harness/test_harness_system_bd.tcl
+++ b/common/test_harness/test_harness_system_bd.tcl
@@ -167,8 +167,8 @@ ad_cpu_interconnect 0x41200000 axi_intc
 ad_mem_hp0_interconnect sys_mem_clk ddr_axi_vip/S_AXI
 
 # connect mng_vip to ddr_vip
-set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect]
-ad_connect axi_cpu_interconnect/M01_AXI /axi_mem_interconnect/S00_AXI
+set_property -dict [list CONFIG.NUM_MI {2}] [get_bd_cells axi_cpu_interconnect_0]
+ad_connect axi_cpu_interconnect_0/M01_AXI /axi_mem_interconnect/S00_AXI
 
 global sys_mem_clk_index
 if { $use_smartconnect == 1} {
@@ -176,9 +176,9 @@ if { $use_smartconnect == 1} {
   set_property CONFIG.NUM_CLKS [expr $sys_mem_clk_index +1] [get_bd_cells axi_mem_interconnect]
   ad_connect sys_cpu_clk axi_mem_interconnect/ACLK$sys_mem_clk_index
 } else {
-  ad_connect sys_cpu_clk axi_cpu_interconnect/M01_ACLK
+  ad_connect sys_cpu_clk axi_cpu_interconnect_0/M01_ACLK
   ad_connect sys_cpu_clk axi_mem_interconnect/S00_ACLK
-  ad_connect sys_cpu_resetn axi_cpu_interconnect/M01_ARESETN
+  ad_connect sys_cpu_resetn axi_cpu_interconnect_0/M01_ARESETN
   ad_connect sys_cpu_resetn axi_mem_interconnect/S00_ARESETN
 }
 


### PR DESCRIPTION
- Updated test_harness naming to the new convention found in HDL repository
- Updated adrv9009 block design to connect to the 2nd interconnect

Use this branch together with [this hdl branch](https://github.com/analogdevicesinc/hdl/tree/interconnect_cascade). The system is now built properly, but the testbenches are still failing. 