### PR TITLE
CI - skip tests for failed system builds

### DIFF
--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -47,7 +47,7 @@ echo \<testcase classname=\"$(FOLDER)_$(strip $(5))\" name=\"$(strip $(6))\" tim
 echo -n "$(strip $(4)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)]"; \
 if [[ $$RUN_SCRIPT == false ]]; then \
 	echo " $(RED)SKIPPED$(NC)"; \
-	echo \<skipped\/\> >> $$JUnitFile; \
+	echo \<skipped\> >> $$JUnitFile; \
 	echo "Test skipped because the system project didn't build successfully!" >> $$JUnitFile; \
 	echo \<\/skipped\> >> $$JUnitFile; \
 elif [ $$ERR = 0 ]; then \

--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -23,8 +23,8 @@ SHELL:=/bin/bash
 # $(6): test  name
 FOLDER=$(shell basename $(CURDIR))
 define simulate
+@echo "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."
 if [ -f $(CURDIR)/runs/$(strip $(5))/system_good.tmp ] || [ $(6) = BuildEnv ]; then \
-	echo "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."; \
 	START=$$(date +%s); \
 	$(strip $(1)) >> $(strip $(2)) 2>&1; \
 	(ERR=$$?; \
@@ -51,6 +51,9 @@ if [ -f $(CURDIR)/runs/$(strip $(5))/system_good.tmp ] || [ $(6) = BuildEnv ]; t
 	echo \<\/testcase\> >> $$JUnitFile; \
 	echo \<\/testsuite\> >> $$JUnitFile; \
 	exit $$ERR); \
+else \
+	echo -n "$(strip $(4)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)]"; \
+	echo " $(HL)SKIPPED$(NC)"; \
 fi;
 endef
 

--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -23,32 +23,35 @@ SHELL:=/bin/bash
 # $(6): test  name
 FOLDER=$(shell basename $(CURDIR))
 define simulate
-@echo "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."
-START=$$(date +%s); \
-$(strip $(1)) >> $(strip $(2)) 2>&1; \
-(ERR=$$?; \
-END=$$(date +%s); \
-DIFF=$$(( $$END - $$START )); \
-ERRS=`grep -v ^# $(2) | grep -w -i -e ^error -e ^fatal -e ^fatal_error -e "\[ERROR\]" -e "while\\ executing" -C 10 |  sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`; \
-if [[ $$ERRS > 0 ]] ; then ERR=1; fi;\
-JUnitFile='results/$(strip $(5))_$(strip $(6)).xml'; \
-echo \<testsuite\> > $$JUnitFile; \
-echo \<testcase classname=\"$(FOLDER)_$(strip $(5))\" name=\"$(strip $(6))\" time=\"$$DIFF\" \> >> $$JUnitFile; \
-echo -n "$(strip $(4)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)]"; \
-if [ $$ERR = 0 ]; then \
-	echo " $(GREEN)OK$(NC)"; \
-	echo \<passed\/\> >> $$JUnitFile; \
-else \
-	echo " $(RED)FAILED$(NC)"; \
-	echo "For details see $(HL)$(CURDIR)/$(strip $(2))$(NC)"; \
-	echo ""; \
-	echo \<failure\> >> $$JUnitFile; \
-	echo "$$ERRS" >>  $$JUnitFile; \
-	echo \<\/failure\> >> $$JUnitFile; \
-fi; \
-echo \<\/testcase\> >> $$JUnitFile; \
-echo \<\/testsuite\> >> $$JUnitFile; \
-exit $$ERR)
+if [ -f $(CURDIR)/runs/$(strip $(5))/system_good.tmp ] || [ $(6) = BuildEnv ]; then \
+	echo "$(strip $(3)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)] ..."; \
+	START=$$(date +%s); \
+	$(strip $(1)) >> $(strip $(2)) 2>&1; \
+	(ERR=$$?; \
+	END=$$(date +%s); \
+	DIFF=$$(( $$END - $$START )); \
+	ERRS=`grep -v ^# $(2) | grep -w -i -e ^error -e ^fatal -e ^fatal_error -e "\[ERROR\]" -e "while\\ executing" -C 10 |  sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`; \
+	if [[ $$ERRS > 0 ]] ; then ERR=1; fi;\
+	JUnitFile='results/$(strip $(5))_$(strip $(6)).xml'; \
+	echo \<testsuite\> > $$JUnitFile; \
+	echo \<testcase classname=\"$(FOLDER)_$(strip $(5))\" name=\"$(strip $(6))\" time=\"$$DIFF\" \> >> $$JUnitFile; \
+	echo -n "$(strip $(4)) [$(HL)$(CURDIR)/$(strip $(2))$(NC)]"; \
+	if [ $$ERR = 0 ]; then \
+		echo " $(GREEN)OK$(NC)"; \
+		echo \<passed\/\> >> $$JUnitFile; \
+		echo '' > $(CURDIR)/runs/$(strip $(5))/system_good.tmp; \
+	else \
+		echo " $(RED)FAILED$(NC)"; \
+		echo "For details see $(HL)$(CURDIR)/$(strip $(2))$(NC)"; \
+		echo ""; \
+		echo \<failure\> >> $$JUnitFile; \
+		echo "$$ERRS" >>  $$JUnitFile; \
+		echo \<\/failure\> >> $$JUnitFile; \
+	fi; \
+	echo \<\/testcase\> >> $$JUnitFile; \
+	echo \<\/testsuite\> >> $$JUnitFile; \
+	exit $$ERR); \
+fi;
 endef
 
 # For Cygwin, Vivado must be called from the Windows environment


### PR DESCRIPTION
CI skips tests for which the system build failed. 
In these cases the test program will not be started, instead it will state that the test program is skipped. This will also be shown in the CI history:
- System builds will be noted as `FAILED`
- Test programs that fail to pass the test but have successfully built systems will be noted as `FAILED`
- Test programs that don't have successfully built systems will be noted as `SKIPPED`
By default, running on local machine, once the system build fails, the test program is not started. 

How to check:
- Run all tests with the following make command: `make STOP_ON_ERROR=n`
Tested cases:
1) _ADRV9009_:
- Since the system build fails, this a good example
- Run the make script from above
2) _Scoreboard_:
- Create a copy of `cfg1` and name it `cfg2`
- Comment a parameter from `cfg1`; this will cause an error on build
- Run the make script from above