### PR TITLE
pulsar: Remove leftover test_program

### DIFF
--- a/pulsar_adc_pmdz/system_project.tcl
+++ b/pulsar_adc_pmdz/system_project.tcl
@@ -40,7 +40,6 @@ adi_sim_project_files [list \
  "../common/sv/test_harness_env.sv" \
  "spi_engine.svh" \
  "tests/test_program.sv" \
- "tests/test_sleep_delay.sv"\
  "system_tb.sv" \
  ]
 


### PR DESCRIPTION
CI error: 
`ERROR: [Vivado 12-172] File or Directory 'tests/test_sleep_delay.sv' does not exist`

Removed the entry from system_project. 