### PR TITLE
.gitignore: fix ignoring all .lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,4 @@ _build
 .qsys_edit
 .github/CODEOWNERS
 .github/PULL_REQUEST_TEMPLATE.md
-common/**/.lock
-common/**/interfaces/*.sv
+*.lock


### PR DESCRIPTION
now it correctly ignores .lock files from libraries