### PR TITLE
Doc quickfixes

### DIFF
--- a/docs/testbenches/common/more_information.rst
+++ b/docs/testbenches/common/more_information.rst
@@ -1,4 +1,4 @@
 More information
 -------------------------------------------------------------------------------
 
-To be done.
+-  :ref:`ADI Testbenches User guide <user_guide>`

--- a/docs/testbenches/ip_based/index.rst
+++ b/docs/testbenches/ip_based/index.rst
@@ -9,5 +9,3 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   template/index
-

--- a/docs/testbenches/ip_based/template/index.rst
+++ b/docs/testbenches/ip_based/template/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _ip_based_template:
 
 IP based test bench template

--- a/docs/testbenches/project_based/index.rst
+++ b/docs/testbenches/project_based/index.rst
@@ -9,5 +9,3 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   template/index
-

--- a/docs/testbenches/project_based/template/index.rst
+++ b/docs/testbenches/project_based/template/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _project_based_template:
 
 Project based test bench template


### PR DESCRIPTION
Update the "More information" file to send the user to the "User guide" section.
Hide the ip-based and project-based template files from the toctree.