### PR TITLE
ad7616: Updated FPGA part number

### DIFF
--- a/testbenches/project/ad7616/system_project.tcl
+++ b/testbenches/project/ad7616/system_project.tcl
@@ -36,7 +36,7 @@ if {[expr {![info exists use_smartconnect]}]} {
 }
 
 # Create the project
-adi_sim_project_xilinx $project_name "xcvu9p-flga2104-2L-e"
+adi_sim_project_xilinx $project_name "xc7z020clg484-1"
 
 # Add test files to the project
 adi_sim_project_files [list \


### PR DESCRIPTION
Using the 7-series Xilinx FPGA part, since the original Ultrascale+ part has different properties and requirements for the MMCM clock generation and the AD7616 project implementation is only available for Zedboard. 
This fix is proposed since the latest update on the HDL for adding the FPGA_TECHNOLOGY for VCU boards affects the axi_clk_gen IP used in this project. Other projects are unaffected by this change. 