### PR TITLE
scripts: make_tb_path: Error for unset ADI_*_DIR

### DIFF
--- a/scripts/make_tb_path.mk
+++ b/scripts/make_tb_path.mk
@@ -2,8 +2,14 @@
 ####################################################################################
 ####################################################################################
 
+ifeq ($(ADI_HDL_DIR),)
+$(error Environment variable ADI_HDL_DIR not set, please set it with the absolute path to the hdl repository.)
+endif
+
+ifeq ($(ADI_TB_DIR),)
+$(error Environment variable ADI_TB_DIR not set, please set it with the absolute path to the testbenches repository.)
+endif
+
 # Assumes this file is in <HDL>/testbenches/scripts/make_tb_path.mk
-ADI_HDL_DIR := ${ADI_HDL_DIR}
 HDL_LIBRARY_PATH := $(ADI_HDL_DIR)/library/
-ADI_TB_DIR := ${ADI_TB_DIR}
 TB_LIBRARY_PATH := $(ADI_TB_DIR)/library/


### PR DESCRIPTION


## PR Description

Add informative error for mandatory environment variable.
I would rather "hardcode" the depth on the entry Makefile (the one that we can obtain the current shell path),
and infer these variables for most users.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program