### PR TITLE
docs: Drop wavedrom, reorder requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@ author = 'Analog Devices, Inc.'
 
 extensions = [
     "sphinx.ext.todo",
-    "sphinxcontrib.wavedrom",
     "adi_doctools"
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-sphinx
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz
-sphinxcontrib.wavedrom
+sphinx


### PR DESCRIPTION
## PR Description

Sphinx-wavedrom [deps: cairocffi, CairoSVG] don't seem to be tested continuously, which leads to fatal bugs reaching production. The extension in particular has  two red flags:

* It renders on the client side, requiring wavedrom.js to be fetched from a different from a different domain, slowing down or even preventing the documentation if the domain is offline (cause of a previous problem).
* Even though it renders on the client side in our user case, it still import cairo renderer during build (the root cause of the current issue)

Drop it in favor of just committing the wavedrom source (commented out in the page or as a text file in the same path) and the rendered svg.

Also, reorder requirements to have adi_doctools as the first requirement.

You can check the checkboxes below by inserting a 'x' between square brackets
(without any other characters or spaces) or just check them after publishing the PR.

If there is a breaking change, specify dependent PRs in description and
try to push all related PRs at the same time.

Without this dependency, the CI now takes 18s instead of 29s

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program