### PR TITLE
scripts: adi_sim: Default to noncoherent interface

### DIFF
--- a/scripts/adi_sim.tcl
+++ b/scripts/adi_sim.tcl
@@ -42,6 +42,9 @@ proc adi_sim_project_xilinx {project_name {part "xc7vx485tffg1157-1"}} {
 
   global sys_zynq
   set sys_zynq -1
+  if { ![info exists ad_project_params(CACHE_COHERENCY)] } {
+    set CACHE_COHERENCY false
+  }
   if { ![info exists ad_project_params(CUSTOM_HARNESS)] || !$ad_project_params(CUSTOM_HARNESS) } {
     source $ad_tb_dir/library/utilities/test_harness_system_bd.tcl
   }


### PR DESCRIPTION
## PR Description

Update the adi_sim script to default to non-coherent interfaces in testbenches.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
