### PR TITLE
test_harness_env: Added simulation watchdog

### DIFF
--- a/library/utilities/test_harness_env.sv
+++ b/library/utilities/test_harness_env.sv
@@ -41,6 +41,7 @@ package test_harness_env_pkg;
   import logger_pkg::*;
   import adi_environment_pkg::*;
   import adi_axi_agent_pkg::*;
+  import watchdog_pkg::*;
 
 
   class test_harness_env #(int `AXI_VIP_PARAM_ORDER(mng), int `AXI_VIP_PARAM_ORDER(ddr)) extends adi_environment;
@@ -54,6 +55,8 @@ package test_harness_env_pkg;
     virtual interface clk_vip_if #(.C_CLK_CLOCK_PERIOD(2.5)) ddr_clk_vip_if;
 
     virtual interface rst_vip_if #(.C_ASYNCHRONOUS(1), .C_RST_POLARITY(1)) sys_rst_vip_if;
+
+    watchdog simulation_watchdog;
 
     //============================================================================
     // Constructor
@@ -72,6 +75,8 @@ package test_harness_env_pkg;
 
       super.new(name);
 
+      this.simulation_watchdog = new("Simulation watchdog", 10**6, "Simulation might be hanging!");
+
       this.sys_clk_vip_if = sys_clk_vip_if;
       this.dma_clk_vip_if = dma_clk_vip_if;
       this.ddr_clk_vip_if = ddr_clk_vip_if;
@@ -88,6 +93,8 @@ package test_harness_env_pkg;
     //   - Start the agents
     //============================================================================
     task start();
+      this.simulation_watchdog.start();
+
       this.mng.agent.start_master();
       this.ddr.agent.start_slave();
 
@@ -106,6 +113,8 @@ package test_harness_env_pkg;
       this.sys_clk_vip_if.stop_clock();
       this.dma_clk_vip_if.stop_clock();
       this.ddr_clk_vip_if.stop_clock();
+
+      this.simulation_watchdog.stop();
     endtask
 
     //============================================================================


### PR DESCRIPTION
## PR Description

Added simulation watchdog that restricts the runtime of all testbenches to 1 millisecond, preventing simulation hangs.
This value can be adjusted for each individual testbench to reduce the overhead.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [x] I have set the verbosity level to none for the test program
