### PR TITLE
 i3c_controller: Remove CLK_MOD, small write DAA task

### DIFF
--- a/docs/testbenches/ip_based/i3c_controller/index.rst
+++ b/docs/testbenches/ip_based/i3c_controller/index.rst
@@ -32,24 +32,13 @@ Block diagram
 Configuration parameters and modes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following parameter of this project that can be configured:
-
-- CLK_MOD: defines the I3C Controller Core clock cycles per bus bit.
+There are no parameters on this project.
 
 Configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following configuration files are available:
-
-+-----------------------+------------+
-| Configuration mode    | Parameters |
-|                       +------------+
-|                       | CLK_MOD    |
-+=======================+============+
-| cfg1                  | 0          |
-+-----------------------+------------+
-| cfg2                  | 1          |
-+-----------------------+------------+
+The testbench has an empty configuration file included in the file structure
+which allows the testbench to be built and run by default.
 
 Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/library/regmaps/adi_regmap_i3c_controller_pkg.sv
+++ b/library/regmaps/adi_regmap_i3c_controller_pkg.sv
@@ -42,8 +42,8 @@ package adi_regmap_i3c_controller_pkg;
 /* I3C Controller (i3c_controller_host_interface) */
 
   const reg_t i3c_controller_host_interface_VERSION = '{ 'h0000, "VERSION" , '{
-    "VERSION_MAJOR": '{ 31, 16, RO, 'h00 },
-    "VERSION_MINOR": '{ 15, 8, RO, 'h01 },
+    "VERSION_MAJOR": '{ 31, 16, RO, 'h01 },
+    "VERSION_MINOR": '{ 15, 8, RO, 'h00 },
     "VERSION_PATCH": '{ 7, 0, RO, 'h00 }}};
   `define SET_i3c_controller_host_interface_VERSION_VERSION_MAJOR(x) SetField(i3c_controller_host_interface_VERSION,"VERSION_MAJOR",x)
   `define GET_i3c_controller_host_interface_VERSION_VERSION_MAJOR(x) GetField(i3c_controller_host_interface_VERSION,"VERSION_MAJOR",x)

--- a/testbenches/ip/i3c_controller/Makefile
+++ b/testbenches/ip/i3c_controller/Makefile
@@ -10,8 +10,8 @@ include $(TB_LIBRARY_PATH)/includes/Makeinclude_common.mk
 include $(TB_LIBRARY_PATH)/includes/Makeinclude_i3c_controller.mk
 
 # Remaining test-bench dependencies except test programs
-ENV_DEPS += $(HDL_LIBRARY_PATH)/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.vh
-ENV_DEPS += $(HDL_LIBRARY_PATH)/i3c_controller/i3c_controller_core/i3c_controller_word.vh
+SV_DEPS += $(ADI_HDL_DIR)/library/i3c_controller/i3c_controller_host_interface/i3c_controller_regmap.vh
+SV_DEPS += $(ADI_HDL_DIR)/library/i3c_controller/i3c_controller_core/i3c_controller_word.vh
 
 LIB_DEPS += i3c_controller/i3c_controller_host_interface
 LIB_DEPS += i3c_controller/i3c_controller_core

--- a/testbenches/ip/i3c_controller/cfgs/cfg1.tcl
+++ b/testbenches/ip/i3c_controller/cfgs/cfg1.tcl
@@ -1,1 +1,1 @@
-set ad_project_params(CLK_MOD) 0
+# no parameters

--- a/testbenches/ip/i3c_controller/cfgs/cfg2.tcl
+++ b/testbenches/ip/i3c_controller/cfgs/cfg2.tcl
@@ -1,1 +1,0 @@
-set ad_project_params(CLK_MOD) 1

--- a/testbenches/ip/i3c_controller/system_bd.tcl
+++ b/testbenches/ip/i3c_controller/system_bd.tcl
@@ -1,6 +1,6 @@
 # ***************************************************************************
 # ***************************************************************************
-# Copyright (C) 2024 Analog Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
 #
 # In this HDL repository, there are many different and unique modules, consisting
 # of various HDL (Verilog or VHDL) components. The individual modules are
@@ -52,12 +52,11 @@ create_bd_port -dir I offload_trigger
 source $ad_hdl_dir/library/i3c_controller/scripts/i3c_controller_bd.tcl
 
 set async_clk 0
-set clk_mod $ad_project_params(CLK_MOD)
 set i2c_mod 1
 set offload 1
 set max_devs 16
 
-i3c_controller_create i3c $async_clk $clk_mod $i2c_mod $offload $max_devs
+i3c_controller_create i3c $async_clk $i2c_mod $offload $max_devs
 
 ad_connect i3c/m_i3c i3c
 ad_connect i3c/offload_sdi offload_sdi

--- a/testbenches/ip/i3c_controller/tests/test_program.sv
+++ b/testbenches/ip/i3c_controller/tests/test_program.sv
@@ -654,14 +654,13 @@ task priv_i2c_test();
   // Assert is in I²C mode
   if (`DUT_I3C_BIT_MOD.i2c_mode !== 1)
    `ERROR(("Not in I2C mode!"));
-  // Dummy LOW peripheral write + ACK continue
+  // Dummy HIGH peripheral write
   wait (`DUT_I3C_WORD.st == `CMDW_I2C_RX);
   set_auto_ack(0);
-  i3c_dev_sda <= 1'b0;
+  i3c_dev_sda <= 1'bZ;
   // Count n ACK-bit asserted low by the controller (sampling before
   // tri-state)
   repeat (I2C_CMD_2[15:8]) @(negedge `DUT_I3C_BIT_MOD.sdo);
-  i3c_dev_sda <= 1'bZ;
 
   wait (`DUT_I3C_BIT_MOD.nop == 0);
   wait (`DUT_I3C_BIT_MOD.nop == 1);

--- a/testbenches/ip/i3c_controller/tests/test_program.sv
+++ b/testbenches/ip/i3c_controller/tests/test_program.sv
@@ -362,8 +362,8 @@ task ccc_i3c_test;
   i3c_controller.set_cmd_fifo(I3C_CCC_CMD_RSTDAA); // CCC, length 0
   i3c_controller.set_cmd_fifo(I3C_CCC_RSTDAA);
   @(posedge i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[19:8] != 0)
     `FATAL(("CMD -> CMDR read length test FAILED"));
@@ -374,8 +374,8 @@ task ccc_i3c_test;
   i3c_controller.set_cmd_fifo(I3C_CCC_CMD_DISEC); // CCC, length tx 1
   i3c_controller.set_cmd_fifo(I3C_CCC_DISEC);
   @(posedge i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[19:8] != 1)
     `FATAL(("CMD -> CMDR write length test FAILED"));
@@ -385,8 +385,8 @@ task ccc_i3c_test;
   i3c_controller.set_cmd_fifo(I3C_CMD_GETPID_UDA); // CCC, length rx 6
   i3c_controller.set_cmd_fifo(I3C_CCC_GETPID);
   wait (i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[23:20] != 8)
     `FATAL(("#4: CMD -> CMDR UDA_ERROR assertion FAILED"));
@@ -404,8 +404,8 @@ task ccc_i3c_test;
   i3c_dev_sda <= 1'bZ;
   set_auto_ack(1);
   @(posedge i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[19:8] != 6)
     `FATAL(("CMD -> CMDR read length test FAILED"));
@@ -421,8 +421,8 @@ task ccc_i3c_test;
   i3c_dev_sda <= 1'bZ;
   set_auto_ack(1);
   @(posedge i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[19:8] != 1)
     `FATAL(("CMD -> CMDR read length test FAILED"));
@@ -436,8 +436,6 @@ task ccc_i3c_test;
     .sdo_almost_empty(1'b0),
     .cmdr_almost_full(1'b0),
     .cmd_almost_empty(1'b0));
-  // Clear all pending IRQs
-  i3c_controller.set_irq_pending(irq_pending);
 
   `INFO(("CCC I3C Test Done"), ADI_VERBOSITY_LOW);
 endtask
@@ -781,11 +779,11 @@ task ibi_i3c_test();
   write_ibi_da(DEVICE_DA1);
 
   @(posedge i3c_irq);
+  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
   i3c_controller.read_ibi_fifo(ibi_fifo_data);
   print_ibi(ibi_fifo_data);
   if (ibi_fifo_data[23:17] != DEVICE_DA1)
     `FATAL(("Wrong IBI DA"));
-  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
 
   // Test #2, peripheral does an IBI request by sending its DA during broadcast
   // address.
@@ -807,15 +805,15 @@ task ibi_i3c_test();
   // Enable ACK during the cmd transfer
   set_auto_ack(1);
   wait (i3c_irq);
+  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
   i3c_controller.read_ibi_fifo(ibi_fifo_data);
   print_ibi (ibi_fifo_data);
   if (ibi_fifo_data[23:17] != DEVICE_DA1)
     `FATAL(("Wrong IBI DA"));
-  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
 
   wait (i3c_irq); // cmdr_irq
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
   if (cmdr_fifo_data[19:8] != I3C_CMD_1[19:8])
     `FATAL(("CMD transfer after resolving IBI FAILED"));
@@ -872,11 +870,11 @@ task ibi_i3c_test();
   write_ibi_da(DEVICE_DA1+1);
 
   wait (i3c_irq);
+  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
   i3c_controller.read_ibi_fifo(ibi_fifo_data);
   print_ibi(ibi_fifo_data);
   if (ibi_fifo_data[23:17] != DEVICE_DA1+1)
     `FATAL(("Wrong IBI DA"));
-  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_IBI_PENDING);
 
   // Test #6, peripheral does IBI request by pulling SDA low, but
   // IBI is disabled while listening to them.
@@ -913,8 +911,6 @@ task ibi_i3c_test();
     .sdo_almost_empty(1'b0),
     .cmdr_almost_full(1'b0),
     .cmd_almost_empty(1'b0));
-  // Clear all pending IRQs
-  i3c_controller.set_irq_pending(irq_pending);
 
   `INFO(("IBI I3C Test Done"), ADI_VERBOSITY_LOW);
 endtask
@@ -956,30 +952,30 @@ task daa_i3c_test();
 
   write_daa(DEVICE_PID_BCR_DCR);
 
-  @(posedge i3c_irq);
+  wait (i3c_irq);
   `INFO(("GOT DAA IRQ"), ADI_VERBOSITY_LOW);
+  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_DAA_PENDING);
   // Assert 2x32-bit in SDI FIFO (PID+BCR+DCR)
   if (`DUT_I3C_REGMAP.i_sdi_fifo.m_axis_level != 2)
     `FATAL(("Wrong SDI FIFO level"));
   i3c_controller.read_sdi_fifo(sdi_fifo_data);
   i3c_controller.read_sdi_fifo(sdi_fifo_data);
-  // Assert that irq won't be cleared if SDO is empty
-  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_DAA_PENDING);
-  if (~`DUT_I3C_REGMAP.up_irq_pending[`I3C_REGMAP_IRQ_DAA_PENDING])
-    `FATAL(("DAA IRQ should not have been cleared"));
+  if (`DUT_I3C_REGMAP.up_irq_pending[`I3C_REGMAP_IRQ_DAA_PENDING])
+    `FATAL(("DAA IRQ should have been cleared"));
   `INFO(("Writing DA 1"), ADI_VERBOSITY_LOW);
   i3c_controller.write_sdo_fifo_data_4_byte(
     .data0({DEVICE_DA1, ~^DEVICE_DA1[6:0]}),
     .data1(8'h0),
     .data2(8'h0),
     .data3(8'h0));
-  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_DAA_PENDING);
 
   // Write DEV_CHAR_2 all Low for the second peripheral,
   // so BCR[2] is Low (used in the ibi_i3c_test).
   wait (`DUT_I3C_WORD.st == `CMDW_DAA_DEV_CHAR);
   dev_char_state <= 1'b0;
   @(posedge i3c_irq);
+  #10000ns
+  i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_DAA_PENDING);
   // Assert 2x32-bit in SDI FIFO (PID+BCR+DCR)
   if (`DUT_I3C_REGMAP.i_sdi_fifo.m_axis_level != 2)
     `FATAL(("Wrong SDI FIFO level"));
@@ -999,8 +995,8 @@ task daa_i3c_test();
   `WAIT (`DUT_I3C_WORD.st == `CMDW_BCAST_7E_W1, 100000);
   set_auto_ack(0);
   @(posedge i3c_irq);
-  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   i3c_controller.set_irq_pending(1'b1 << `I3C_REGMAP_IRQ_CMDR_PENDING);
+  i3c_controller.get_cmdr_fifo(cmdr_fifo_data);
   print_cmdr (cmdr_fifo_data);
 
   // Mask the DAA interrupt
@@ -1013,8 +1009,6 @@ task daa_i3c_test();
     .sdo_almost_empty(1'b0),
     .cmdr_almost_full(1'b0),
     .cmd_almost_empty(1'b0));
-  // Clear all pending IRQs
-  i3c_controller.set_irq_pending(irq_pending);
 
   `INFO(("DAA I3C Test Done"), ADI_VERBOSITY_LOW);
 endtask


### PR DESCRIPTION
## PR Description

Pair pr of https://github.com/analogdevicesinc/hdl/pull/1724
Removed from the I3C controller IP core.
Add write DAA mock task  To emulate a device writing the PID+BCR+DCR during the dynamic address assignment.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [x] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
