### PR TITLE
.github: use doctools gh-pages actions, extend to pull_request

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-gh-pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: analogdevicesinc/doctools/gh-pages-rm-path@action
+      with:
+        path: pull/${{ github.event.number }}

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -37,56 +37,12 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     needs: [build-doc]
     permissions:
       contents: write
 
     steps:
-    - run: |
-        git config --global user.name "${{ github.event.head_commit.committer.name }}"
-        git config --global user.email "${{ github.event.head_commit.committer.email }}"
-
-    - uses: actions/checkout@v4
-    - name: Create gh-pages branch
-      run: >
-        git ls-remote --exit-code --heads origin refs/heads/gh-pages ||
-        (
-          git reset --hard ;
-          git clean -fdx ;
-          git checkout --orphan gh-pages ;
-          git reset --hard;
-          git commit -m "empty" --allow-empty ;
-          git push origin gh-pages:gh-pages
-        )
-
-    - uses: actions/checkout@v4
-      with:
-        ref: 'gh-pages'
-        lfs: 'false'
-
-    - name: Empty gh-pages
-      run: |
-        git rm -r . --quiet || true
-
-    - uses: actions/download-artifact@v4
+    - uses: analogdevicesinc/doctools/gh-pages-deploy@action
       with:
         name: html
 
-    - name: Patch doc build
-      run: |
-        rm -r _sources
-        touch .nojekyll
-
-    - name: Commit gh-pages
-      run: |
-        author=$(git log -1 --pretty=format:'%an')
-        email=$(git log -1 --pretty=format:'%ae')
-        commit=$(git rev-parse --short HEAD)
-
-        git add . >> /dev/null
-        git commit -m "deploy: ${GITHUB_SHA}" --allow-empty
-
-    - name: Push to gh-pages
-      run: >-
-        git push origin gh-pages:gh-pages


### PR DESCRIPTION
## PR Description

Use the Doctools share GitHub Actions to simplify docs deployment, and adding support for deploying temporary pull_request docs, without having to have the intricate ci context logic handled here.
<img width="900" height="191" alt="image" src="https://github.com/user-attachments/assets/cb2dcc15-7e96-46da-8529-7270b5add931" />


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
