### PR TITLE
testbenches/ip/util_axis_fifo: include test with random tkeep

### DIFF
--- a/library/vip/amd/axis/m_axis_sequencer.sv
+++ b/library/vip/amd/axis/m_axis_sequencer.sv
@@ -98,7 +98,6 @@ package m_axis_sequencer_pkg;
 
     protected descriptor_t descriptor_q [$];
 
-
     // new
     function new(
       input string name,
@@ -118,7 +117,6 @@ package m_axis_sequencer_pkg;
       this.queue_empty_sig = 1;
       this.keep_all = 1;
     endfunction: new
-
 
     // set vif proxy to drive outputs with 0 when inactive
     virtual task set_inactive_drive_output_0();
@@ -162,7 +160,6 @@ package m_axis_sequencer_pkg;
     virtual task packet_sent();
       this.fatal($sformatf("Base class was instantiated instead of the parameterized class!"));
     endtask: packet_sent
-
 
     // set disable policy
     function void set_stop_policy(input stop_policy_t stop_policy);
@@ -298,7 +295,6 @@ package m_axis_sequencer_pkg;
       ->>tkeep_stream_ev;
     endfunction: push_tkeep_for_stream
 
-
     // descriptor delay subroutine
     // - can be overridden in inherited classes for more specific delay generation
     protected task data_beat_delay_subroutine();
@@ -333,7 +329,6 @@ package m_axis_sequencer_pkg;
 
     protected axi4stream_mst_driver #(`AXIS_VIP_IF_PARAMS(AXIS)) driver;
 
-
     function new(
       input string name,
       input axi4stream_mst_driver #(`AXIS_VIP_IF_PARAMS(AXIS)) driver,
@@ -345,7 +340,6 @@ package m_axis_sequencer_pkg;
 
       this.driver.vif_proxy.set_no_insert_x_when_keep_low(1);
     endfunction: new
-
 
     // wait until data beat is sent
     virtual task beat_sent();

--- a/testbenches/ip/util_axis_fifo_asym/Makefile
+++ b/testbenches/ip/util_axis_fifo_asym/Makefile
@@ -18,7 +18,7 @@ LIB_DEPS += util_axis_fifo
 LIB_DEPS += util_axis_fifo_asym
 
 # default test program
-TP := test_program
+TP := $(notdir $(basename $(wildcard tests/*.sv)))
 
 # config files should have the following format
 #  cfg_<param1>_<param2>.tcl
@@ -27,7 +27,7 @@ CFG_FILES := $(notdir $(wildcard cfgs/cfg*.tcl))
 
 # List of tests and configuration combinations that has to be run
 # Format is:  <configuration>:<test name>
-TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(cfg):$(TP))
+TESTS := $(foreach cfg, $(basename $(CFG_FILES)), $(addprefix $(cfg):, $(TP)))
 
 include ../../../scripts/project-sim.mk
 

--- a/testbenches/ip/util_axis_fifo_asym/cfgs/cfg_tkeep.tcl
+++ b/testbenches/ip/util_axis_fifo_asym/cfgs/cfg_tkeep.tcl
@@ -1,0 +1,44 @@
+global ad_project_params
+
+set async_clk [expr int(rand()*2)]
+set ad_project_params(ASYNC_CLK) $async_clk
+
+set tkeep_en 1
+set ad_project_params(TKEEP_EN) $tkeep_en
+
+set tlast_en [expr int(rand()*2)]
+set ad_project_params(TLAST_EN) $tlast_en
+
+set random_width [expr int(8*pow(2, int(7.0*rand()+1)))]
+set INPUT_WIDTH $random_width
+set ad_project_params(INPUT_WIDTH) $INPUT_WIDTH
+
+set random_width [expr int(8*pow(2, int(7.0*rand()+1)))]
+set OUTPUT_WIDTH $random_width
+set ad_project_params(OUTPUT_WIDTH) $OUTPUT_WIDTH
+
+set reduced_fifo [expr int(rand()*2)]
+set ad_project_params(REDUCED_FIFO) $reduced_fifo
+
+if {$reduced_fifo} {
+    if {$INPUT_WIDTH > $OUTPUT_WIDTH} {
+        set RATIO $INPUT_WIDTH/$OUTPUT_WIDTH
+    } else {
+        set RATIO $OUTPUT_WIDTH/$INPUT_WIDTH
+    }
+} else {
+    set RATIO 1
+}
+
+set random_width [expr int(int(log($RATIO)/log(2))+4.0*rand()+1)]
+set ad_project_params(ADDRESS_WIDTH) $random_width
+
+set input_clk [expr int(rand()*9)+1]
+set ad_project_params(INPUT_CLK) $input_clk
+
+if {$async_clk} {
+    set output_clk [expr int(rand()*9)+1]
+    set ad_project_params(OUTPUT_CLK) $output_clk
+} else {
+    set ad_project_params(OUTPUT_CLK) $input_clk
+}

--- a/testbenches/ip/util_axis_fifo_asym/system_project.tcl
+++ b/testbenches/ip/util_axis_fifo_asym/system_project.tcl
@@ -23,6 +23,7 @@ source $ad_tb_dir/library/includes/sp_include_scoreboard.tcl
 adi_sim_project_files [list \
   "environment.sv" \
   "tests/test_program.sv" \
+  "tests/test_tkeep.sv" \
 ]
 
 #set a default test program

--- a/testbenches/ip/util_axis_fifo_asym/tests/test_tkeep.sv
+++ b/testbenches/ip/util_axis_fifo_asym/tests/test_tkeep.sv
@@ -92,7 +92,7 @@ program test_tkeep ();
 
     uaf_env.run();
 
-    send_data_wd = new("Util AXIS FIFO Watchdog", 50000, "Send data");
+    send_data_wd = new("Util AXIS FIFO Watchdog", 500000, "Send data");
 
     send_data_wd.start();
 
@@ -103,10 +103,9 @@ program test_tkeep ();
       send_data_wd.reset();
 
       if ((!`TKEEP_EN || !`TLAST_EN) && `INPUT_WIDTH < `OUTPUT_WIDTH) begin
-        `FATAL(("bad parameter case"));
         repeat($urandom_range(1,5)) begin
           sample_count = $urandom_range(1,128);
-          repeat(sample_count) begin
+          repeat(sample_count*`OUTPUT_WIDTH/8) begin
             uaf_env.input_axis_agent.sequencer.push_byte_for_stream($urandom_range(0,255));
             uaf_env.input_axis_agent.sequencer.push_tkeep_for_stream($urandom_range(0,1));
           end
@@ -123,8 +122,7 @@ program test_tkeep ();
         end
       end
 
-
-      #($urandom_range(1,10)*1us);
+      #($urandom_range(1,50)*1us);
 
       uaf_env.input_axis_agent.sequencer.clear_descriptor_queue();
       uaf_env.input_axis_agent.sequencer.wait_empty_descriptor_queue();

--- a/testbenches/ip/util_axis_fifo_asym/tests/test_tkeep.sv
+++ b/testbenches/ip/util_axis_fifo_asym/tests/test_tkeep.sv
@@ -1,0 +1,148 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright (C) 2024-2025 Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/main/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`include "utils.svh"
+`include "axis_definitions.svh"
+
+import logger_pkg::*;
+import test_harness_env_pkg::*;
+import environment_pkg::*;
+import watchdog_pkg::*;
+import m_axis_sequencer_pkg::*;
+
+import `PKGIFY(test_harness, mng_axi_vip)::*;
+import `PKGIFY(test_harness, ddr_axi_vip)::*;
+
+import `PKGIFY(test_harness, input_axis)::*;
+import `PKGIFY(test_harness, output_axis)::*;
+
+program test_tkeep ();
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  // declare the class instances
+  test_harness_env #(`AXI_VIP_PARAMS(test_harness, mng_axi_vip), `AXI_VIP_PARAMS(test_harness, ddr_axi_vip)) base_env;
+  util_axis_fifo_environment #(`AXIS_VIP_PARAMS(test_harness, input_axis), `AXIS_VIP_PARAMS(test_harness, output_axis), `INPUT_CLK, `OUTPUT_CLK) uaf_env;
+
+  watchdog send_data_wd;
+
+  int byte_count, sample_count;
+
+  initial begin
+
+    // create environment
+    base_env = new("Base Environment",
+                    `TH.`SYS_CLK.inst.IF,
+                    `TH.`DMA_CLK.inst.IF,
+                    `TH.`DDR_CLK.inst.IF,
+                    `TH.`SYS_RST.inst.IF,
+                    `TH.`MNG_AXI.inst.IF,
+                    `TH.`DDR_AXI.inst.IF);
+
+    uaf_env = new("Util AXIS FIFO Environment",
+                  `TH.`INPUT_CLK_VIP.inst.IF,
+                  `TH.`OUTPUT_CLK_VIP.inst.IF,
+                  `TH.`INPUT_AXIS.inst.IF,
+                  `TH.`OUTPUT_AXIS.inst.IF);
+
+    setLoggerVerbosity(ADI_VERBOSITY_NONE);
+
+    base_env.start();
+    uaf_env.start();
+
+    base_env.sys_reset();
+
+    uaf_env.configure();
+    uaf_env.input_axis_agent.sequencer.set_keep_some();
+    uaf_env.input_axis_agent.sequencer.set_data_gen_mode(DATA_GEN_MODE_TEST_DATA_TKEEP);
+    uaf_env.input_axis_agent.sequencer.set_descriptor_gen_mode(0);
+
+    uaf_env.run();
+
+    send_data_wd = new("Util AXIS FIFO Watchdog", 50000, "Send data");
+
+    send_data_wd.start();
+
+    uaf_env.input_axis_agent.sequencer.start();
+
+    // stimulus
+    repeat($urandom_range(5,10)) begin
+      send_data_wd.reset();
+
+      if ((!`TKEEP_EN || !`TLAST_EN) && `INPUT_WIDTH < `OUTPUT_WIDTH) begin
+        `FATAL(("bad parameter case"));
+        repeat($urandom_range(1,5)) begin
+          sample_count = $urandom_range(1,128);
+          repeat(sample_count) begin
+            uaf_env.input_axis_agent.sequencer.push_byte_for_stream($urandom_range(0,255));
+            uaf_env.input_axis_agent.sequencer.push_tkeep_for_stream($urandom_range(0,1));
+          end
+          uaf_env.input_axis_agent.sequencer.add_xfer_descriptor_sample_count(sample_count*`OUTPUT_WIDTH/`INPUT_WIDTH, `TLAST_EN, 0);
+        end
+      end else begin
+        repeat($urandom_range(1,5)) begin
+          byte_count = $urandom_range(1,1024);
+          repeat(byte_count) begin
+            uaf_env.input_axis_agent.sequencer.push_byte_for_stream($urandom_range(0,255));
+            uaf_env.input_axis_agent.sequencer.push_tkeep_for_stream($urandom_range(0,1));
+          end
+          uaf_env.input_axis_agent.sequencer.add_xfer_descriptor_byte_count(byte_count, `TLAST_EN, 0);
+        end
+      end
+
+
+      #($urandom_range(1,10)*1us);
+
+      uaf_env.input_axis_agent.sequencer.clear_descriptor_queue();
+      uaf_env.input_axis_agent.sequencer.wait_empty_descriptor_queue();
+
+      uaf_env.scoreboard_inst.wait_until_complete();
+
+    end
+
+    send_data_wd.stop();
+
+    #100ns;
+
+    uaf_env.stop();
+    base_env.stop();
+
+    `INFO(("Test bench done!"), ADI_VERBOSITY_NONE);
+    $finish();
+
+  end
+
+endprogram

--- a/testbenches/ip/util_axis_fifo_asym/waves/cfg_tkeep.wcfg
+++ b/testbenches/ip/util_axis_fifo_asym/waves/cfg_tkeep.wcfg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wave_config>
+   <wave_state>
+   </wave_state>
+   <db_ref_list>
+      <db_ref path="system_tb_behav.wdb" id="1">
+         <top_modules>
+            <top_module name="adi_axi_agent_pkg" />
+            <top_module name="adi_axi_monitor_pkg" />
+            <top_module name="adi_axis_agent_pkg" />
+            <top_module name="adi_axis_monitor_pkg" />
+            <top_module name="adi_common_pkg" />
+            <top_module name="adi_environment_pkg" />
+            <top_module name="adi_vip_pkg" />
+            <top_module name="attributes" />
+            <top_module name="axi4stream_vip_pkg" />
+            <top_module name="axi_vip_pkg" />
+            <top_module name="environment_pkg" />
+            <top_module name="glbl" />
+            <top_module name="ipif_pkg" />
+            <top_module name="logger_pkg" />
+            <top_module name="m_axi_sequencer_pkg" />
+            <top_module name="m_axis_sequencer_pkg" />
+            <top_module name="math_real" />
+            <top_module name="numeric_std" />
+            <top_module name="pub_sub_pkg" />
+            <top_module name="s_axi_sequencer_pkg" />
+            <top_module name="s_axis_sequencer_pkg" />
+            <top_module name="scoreboard_pkg" />
+            <top_module name="standard" />
+            <top_module name="std" />
+            <top_module name="std_logic_1164" />
+            <top_module name="std_logic_arith" />
+            <top_module name="std_logic_misc" />
+            <top_module name="std_logic_unsigned" />
+            <top_module name="system_tb" />
+            <top_module name="test_harness_env_pkg" />
+            <top_module name="textio" />
+            <top_module name="vital_primitives" />
+            <top_module name="vital_timing" />
+            <top_module name="vpkg" />
+            <top_module name="watchdog_pkg" />
+            <top_module name="xil_common_vip_pkg" />
+         </top_modules>
+      </db_ref>
+   </db_ref_list>
+   <zoom_setting>
+      <ZoomStartTime time="0.000 ns"></ZoomStartTime>
+      <ZoomEndTime time="5,430.001 ns"></ZoomEndTime>
+      <Cursor1Time time="605.501 ns"></Cursor1Time>
+   </zoom_setting>
+   <column_width_setting>
+      <NameColumnWidth column_width="95"></NameColumnWidth>
+      <ValueColumnWidth column_width="66"></ValueColumnWidth>
+   </column_width_setting>
+   <WVObjectSize size="2" />
+   <wvobject type="protoinst" fp_name="/system_tb/test_harness/util_axis_fifo_asym_DUT/s_axis">
+      <obj_property name="children_use_element_short_name">true</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ENUM_TRANSACTION</obj_property>
+      <obj_property name="EnumTransactionColorTable">fff,fff=blank</obj_property>
+      <obj_property name="UseCustomSignalColor">true</obj_property>
+      <obj_property name="CustomSignalColor">#00E600</obj_property>
+      <obj_property name="Render_Data">/system_tb/test_harness/util_axis_fifo_asym_DUT/s_axis.streamWaveData</obj_property>
+      <obj_property name="Number_Overlay">2</obj_property>
+      <obj_property name="Overlay_Object_0">/system_tb/test_harness/util_axis_fifo_asym_DUT/s_axis.linkStarve</obj_property>
+      <obj_property name="Overlay_Color_0">#99E600</obj_property>
+      <obj_property name="Overlay_Object_1">/system_tb/test_harness/util_axis_fifo_asym_DUT/s_axis.linkStall</obj_property>
+      <obj_property name="Overlay_Color_1">#E64C00</obj_property>
+      <obj_property name="Detail_Data">/system_tb/test_harness/util_axis_fifo_asym_DUT/s_axis.streamTooltipData</obj_property>
+      <obj_property name="ElementShortName">s_axis</obj_property>
+      <obj_property name="ObjectShortName">s_axis</obj_property>
+      <obj_property name="isExpanded"></obj_property>
+   </wvobject>
+   <wvobject type="protoinst" fp_name="/system_tb/test_harness/util_axis_fifo_asym_DUT/m_axis">
+      <obj_property name="children_use_element_short_name">true</obj_property>
+      <obj_property name="WaveformStyle">STYLE_ENUM_TRANSACTION</obj_property>
+      <obj_property name="EnumTransactionColorTable">fff,fff=blank</obj_property>
+      <obj_property name="UseCustomSignalColor">true</obj_property>
+      <obj_property name="CustomSignalColor">#00E600</obj_property>
+      <obj_property name="Render_Data">/system_tb/test_harness/util_axis_fifo_asym_DUT/m_axis.streamWaveData</obj_property>
+      <obj_property name="Number_Overlay">2</obj_property>
+      <obj_property name="Overlay_Object_0">/system_tb/test_harness/util_axis_fifo_asym_DUT/m_axis.linkStarve</obj_property>
+      <obj_property name="Overlay_Color_0">#99E600</obj_property>
+      <obj_property name="Overlay_Object_1">/system_tb/test_harness/util_axis_fifo_asym_DUT/m_axis.linkStall</obj_property>
+      <obj_property name="Overlay_Color_1">#E64C00</obj_property>
+      <obj_property name="Detail_Data">/system_tb/test_harness/util_axis_fifo_asym_DUT/m_axis.streamTooltipData</obj_property>
+      <obj_property name="ElementShortName">m_axis</obj_property>
+      <obj_property name="ObjectShortName">m_axis</obj_property>
+      <obj_property name="isExpanded"></obj_property>
+   </wvobject>
+</wave_config>


### PR DESCRIPTION
- Add support for user-defined tkeep on m_axis_sequencer,
- Add test_tkeep to util_axis_fifo, with random tkeep
- Add cfg_tkeep to util_axis_fifo, which forces TKEEP_EN=1

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] New test (change that adds new test program and/or testbench)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [ ] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
