### PR TITLE
SPI Engine: Fix echo_sclk in tests

### DIFF
--- a/testbenches/ip/spi_engine/tests/test_program.sv
+++ b/testbenches/ip/spi_engine/tests/test_program.sv
@@ -64,7 +64,7 @@ program test_program (
   inout [(`NUM_OF_CS - 1):0] spi_engine_spi_cs,
   inout spi_engine_spi_clk,
   `ifdef DEF_ECHO_SCLK
-    inout spi_engine_echo_sclk,
+    output reg spi_engine_echo_sclk,
   `endif
   inout [(`NUM_OF_SDI - 1):0] spi_engine_spi_sdi);
 
@@ -253,7 +253,11 @@ program test_program (
   // Echo SCLK generation - we need this only if ECHO_SCLK is enabled
   //---------------------------------------------------------------------------
   `ifdef DEF_ECHO_SCLK
-    assign #(`ECHO_SCLK_DELAY * 1ns) spi_engine_echo_sclk = spi_engine_spi_sclk;
+    initial begin
+      forever @(spi_engine_spi_sclk) begin
+        spi_engine_echo_sclk <= #(`ECHO_SCLK_DELAY * 1ns) spi_engine_spi_sclk;
+      end
+    end
   `endif
 
   //---------------------------------------------------------------------------

--- a/testbenches/ip/spi_engine/tests/test_sleep_delay.sv
+++ b/testbenches/ip/spi_engine/tests/test_sleep_delay.sv
@@ -62,7 +62,7 @@ program test_sleep_delay (
   inout [(`NUM_OF_CS - 1):0] spi_engine_spi_cs,
   inout spi_engine_spi_clk,
   `ifdef DEF_ECHO_SCLK
-    inout spi_engine_echo_sclk,
+    output reg spi_engine_echo_sclk,
   `endif
   inout [(`NUM_OF_SDI - 1):0] spi_engine_spi_sdi);
 
@@ -216,9 +216,12 @@ program test_sleep_delay (
   // Echo SCLK generation - we need this only if ECHO_SCLK is enabled
   //---------------------------------------------------------------------------
   `ifdef DEF_ECHO_SCLK
-    assign #(`ECHO_SCLK_DELAY * 1ns) spi_engine_echo_sclk = spi_engine_spi_sclk;
+    initial begin
+      forever @(spi_engine_spi_sclk) begin
+        spi_engine_echo_sclk <= #(`ECHO_SCLK_DELAY * 1ns) spi_engine_spi_sclk;
+      end
+    end
   `endif
-
   //---------------------------------------------------------------------------
   // Sleep and Chip Select Instruction time counter
   //---------------------------------------------------------------------------

--- a/testbenches/ip/spi_engine/tests/test_slowdata.sv
+++ b/testbenches/ip/spi_engine/tests/test_slowdata.sv
@@ -64,7 +64,7 @@ program test_slowdata (
   inout [(`NUM_OF_CS - 1):0] spi_engine_spi_cs,
   inout spi_engine_spi_clk,
   `ifdef DEF_ECHO_SCLK
-    inout spi_engine_echo_sclk,
+    output reg spi_engine_echo_sclk,
   `endif
   inout [(`NUM_OF_SDI - 1):0] spi_engine_spi_sdi);
 
@@ -364,9 +364,12 @@ program test_slowdata (
   // Echo SCLK generation - we need this only if ECHO_SCLK is enabled
   //---------------------------------------------------------------------------
   `ifdef DEF_ECHO_SCLK
-    assign #(`ECHO_SCLK_DELAY * 1ns) spi_engine_echo_sclk = spi_engine_spi_sclk;
+    initial begin
+      forever @(spi_engine_spi_sclk) begin
+        spi_engine_echo_sclk <= #(`ECHO_SCLK_DELAY * 1ns) spi_engine_spi_sclk;
+      end
+    end
   `endif
-
   //---------------------------------------------------------------------------
   // FIFO SPI Test
   //---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes failing cases where echo_sclk is used.

The tests were using inertial delays, meaning any delays larger than the sclk pulses would cause echo_sclk to be broken.
Additionally, fixed a bug in `spi_vip` where, for CPHA=0, the first bit in any transfers that didn't immediately follow a CS assertion would have the wrong delays applied.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [x] Update (change that modifies existing functionality)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
