### PR TITLE
testbenches/ip/spi_engine: update for new spi_engine_create parameter

### DIFF
--- a/testbenches/ip/spi_engine/spi_engine_test_bd.tcl
+++ b/testbenches/ip/spi_engine/spi_engine_test_bd.tcl
@@ -7,6 +7,7 @@ source $ad_hdl_dir/library/spi_engine/scripts/spi_engine.tcl
 
 set data_width              $ad_project_params(DATA_WIDTH)
 set async_spi_clk           $ad_project_params(ASYNC_SPI_CLK)
+set offload_en              1; # offload capability is needed for the testbenches
 set num_cs                  $ad_project_params(NUM_OF_CS)
 set num_sdi                 $ad_project_params(NUM_OF_SDI)
 set num_sdo                 $ad_project_params(NUM_OF_SDO)
@@ -24,8 +25,9 @@ create_bd_intf_port -mode Monitor -vlnv analog.com:interface:spi_engine_rtl:1.0 
 
 set hier_spi_engine spi_engine
 
-spi_engine_create $hier_spi_engine  $data_width $async_spi_clk $num_cs $num_sdi  \
-                                    $num_sdo $sdi_delay $echo_sclk $sdo_streaming \
+spi_engine_create $hier_spi_engine  $data_width $async_spi_clk $offload_en \
+                                    $num_cs $num_sdi $num_sdo $sdi_delay \
+                                    $echo_sclk $sdo_streaming \
                                     $cmd_mem_addr_width $data_mem_addr_width \
                                     $sdi_fifo_addr_width $sdo_fifo_addr_width \
                                     $sync_fifo_addr_width $cmd_fifo_addr_width


### PR DESCRIPTION
## PR Description

A recent HDL PR (https://github.com/analogdevicesinc/hdl/pull/1978) introduced an extra parameter to spi_engine_create, which selects whether the SPI Engine will be instanced with Offload capabilities.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Update (change that modifies existing functionality)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [ ] I have followed the code style guidelines
- [ ] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
