### PR TITLE
initial POC for cocotb framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 runs/
 results/
+sim_build*/
 *.log
 *.pb
 ipcache

--- a/cocotb/README.md
+++ b/cocotb/README.md
@@ -1,0 +1,31 @@
+# cocotb Verification Framework
+
+Simulator-agnostic cocotb testbenches for ADI IP unit verification.
+
+## Layout
+
+```
+cocotb/
+├── framework/              # Reusable across ALL IPs
+│   ├── paths.py            # repo path anchors (REPO_ROOT, COCOTB_DIR)
+│   ├── axi_stream.py       # valid/ready stream driver & monitor
+│   ├── backpressure.py     # random *ready toggling strategies
+│   ├── reset.py            # random reset injection + reset-value checks
+│   ├── scoreboard.py       # expected-vs-actual comparison
+│   ├── random_ctx.py       # single-seed reproducible randomness
+│   ├── sweep/              # multi-config build→run→report harness (any IP/sim)
+│   │   ├── layout.py       # SweepLayout: build/run/coverage dir addressing + flags
+│   │   ├── dispatch.py     # parallel job runner with process-group teardown
+│   │   ├── results.py      # cocotb JUnit XML parse + TEST ANALYSIS reporting
+│   │   └── coverage.py     # merge per-run Verilator coverage into one dataset
+│   └── spi/                # SPI-specific (reusable for any SPI IP)
+│       ├── instructions.py # 16-bit SPI Engine command encoder
+│       ├── bus_monitor.py  # passive SPI bus watcher (SDO/SCLK/CS)
+│       └── slave_model.py  # SPI slave BFM (drives SDI)
+└── requirements.txt
+```
+
+Per-IP tests live under `../testbenches/ip/<ip>/<module>/`, each with its own
+README covering how to run and sweep that module. An IP's `runner.py` supplies
+only the DUT-specific parts — sources, toplevel, test modules, generics, per-run
+env — and drives the `framework.sweep` helpers for everything else.

--- a/cocotb/framework/__init__.py
+++ b/cocotb/framework/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable cocotb verification framework (simulator-agnostic).
+
+Components here are IP-independent and intended for reuse across all ADI IP
+unit testbenches (spi_engine, axi_dmac, ...). SPI-specific helpers live in the
+``spi`` subpackage.
+"""

--- a/cocotb/framework/axi_stream.py
+++ b/cocotb/framework/axi_stream.py
@@ -1,0 +1,165 @@
+"""AXI-Stream driver and monitor (manager/subordinate handshake helpers).
+
+Generic over signal names so the same classes drive the CMD stream, the SDO
+data stream, and monitor the SDI/SYNC streams on the spi_engine_execution DUT.
+
+The DUT exposes several lightweight valid/ready stream interfaces:
+
+  * CMD:  ``cmd_valid`` / ``cmd_ready`` / ``cmd``            (driven, manager)
+  * SDO:  ``sdo_data_valid`` / ``sdo_data_ready`` / ``sdo_data`` (driven)
+  * SDI:  ``sdi_data_valid`` / ``sdi_data_ready`` / ``sdi_data`` (monitored)
+  * SYNC: ``sync_valid`` / ``sync_ready`` / ``sync``         (monitored)
+
+These are not strictly AXI-Stream (no TLAST/TKEEP) but follow the same
+valid/ready semantics, so a single pair of helpers covers them all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import cocotb
+from cocotb.triggers import RisingEdge, ReadOnly
+from cocotb.utils import get_sim_time
+
+
+def _resolve(dut, name):
+    """Return the handle for ``name`` on ``dut`` or raise a clear error."""
+    if not hasattr(dut, name):
+        raise AttributeError(f"DUT has no signal '{name}'")
+    return getattr(dut, name)
+
+
+def _as_int(handle):
+    """Read a handle as int, tolerating X/Z (returns -1 if unresolvable)."""
+    val = handle.value
+    try:
+        return int(val)
+    except ValueError:
+        return -1
+
+
+@dataclass
+class StreamTransaction:
+    """One observed/sent beat on a valid/ready stream."""
+
+    data: int
+    timestamp: int  # simulation time in ns at the accepting clock edge
+
+
+class AXIStreamDriver:
+    """Drives a valid/data stream, respecting downstream ready (manager side).
+
+    Parameters
+    ----------
+    clk        : the clock handle the stream is synchronous to
+    valid      : the *valid handle this driver asserts
+    ready      : the *ready handle this driver samples
+    data       : the *data handle this driver writes
+    rng        : optional ``random.Random`` for inter-word gap jitter
+    """
+
+    def __init__(self, clk, valid, ready, data, *, rng=None, name="axis"):
+        self.clk = clk
+        self.valid = valid
+        self.ready = ready
+        self.data = data
+        self.rng = rng
+        self.name = name
+        self.valid.value = 0
+
+    @classmethod
+    def from_dut(cls, dut, prefix, *, ready_signal=None, data_signal=None,
+                 clk=None, **kwargs):
+        """Build a driver from a DUT and a signal-name ``prefix``.
+
+        e.g. prefix='cmd' -> cmd_valid/cmd_ready/cmd ; prefix='sdo_data' ->
+        sdo_data_valid/sdo_data_ready/sdo_data.
+        """
+        clk = clk if clk is not None else _resolve(dut, "clk")
+        valid = _resolve(dut, f"{prefix}_valid")
+        ready = _resolve(dut, ready_signal or f"{prefix}_ready")
+        data = _resolve(dut, data_signal or prefix)
+        return cls(clk, valid, ready, data, name=prefix, **kwargs)
+
+    async def send(self, value, *, gap=0):
+        """Send a single word; block until accepted (valid && ready).
+
+        ``gap`` idle cycles (valid deasserted) are inserted *before* the beat.
+        """
+        for _ in range(gap):
+            self.valid.value = 0
+            await RisingEdge(self.clk)
+        self.data.value = int(value)
+        self.valid.value = 1
+        # Wait for a rising edge where ready was sampled high.
+        while True:
+            await ReadOnly()
+            if self.ready.value == 1:
+                await RisingEdge(self.clk)
+                break
+            await RisingEdge(self.clk)
+        self.valid.value = 0
+
+    async def send_queue(self, values, *, min_gap=0, max_gap=0):
+        """Send a sequence of words with random inter-word gaps in range."""
+        for v in values:
+            if max_gap > 0 and self.rng is not None:
+                gap = self.rng.randint(min_gap, max_gap)
+            else:
+                gap = min_gap
+            await self.send(v, gap=gap)
+
+
+class AXIStreamMonitor:
+    """Passively records accepted beats (valid && ready) on a stream.
+
+    Runs as a background coroutine started via :meth:`start`. Captured
+    transactions land in :attr:`received` (a list of :class:`StreamTransaction`).
+    """
+
+    def __init__(self, clk, valid, ready, data, *, name="axis", callback=None):
+        self.clk = clk
+        self.valid = valid
+        self.ready = ready
+        self.data = data
+        self.name = name
+        self.callback = callback
+        self.received: list[StreamTransaction] = []
+        self._task = None
+
+    @classmethod
+    def from_dut(cls, dut, prefix, *, ready_signal=None, data_signal=None,
+                 clk=None, **kwargs):
+        clk = clk if clk is not None else _resolve(dut, "clk")
+        valid = _resolve(dut, f"{prefix}_valid")
+        ready = _resolve(dut, ready_signal or f"{prefix}_ready")
+        data = _resolve(dut, data_signal or prefix)
+        return cls(clk, valid, ready, data, name=prefix, **kwargs)
+
+    def start(self):
+        if self._task is None:
+            self._task = cocotb.start_soon(self._run())
+        return self._task
+
+    def stop(self):
+        if self._task is not None:
+            self._task.kill()
+            self._task = None
+
+    async def _run(self):
+        while True:
+            await RisingEdge(self.clk)
+            await ReadOnly()
+            if self.valid.value == 1 and self.ready.value == 1:
+                txn = StreamTransaction(
+                    data=_as_int(self.data),
+                    timestamp=int(get_sim_time("ns")),
+                )
+                self.received.append(txn)
+                if self.callback is not None:
+                    self.callback(txn)
+
+    @property
+    def values(self):
+        return [t.data for t in self.received]

--- a/cocotb/framework/backpressure.py
+++ b/cocotb/framework/backpressure.py
@@ -1,0 +1,69 @@
+"""Random *ready toggling to exercise flow control / backpressure.
+
+A :class:`RandomBackpressure` coroutine drives a single ``ready`` handle with a
+chosen pattern. All randomness comes from an injected ``random.Random`` so runs
+are reproducible from the master seed (see :mod:`framework.random_ctx`).
+
+Applied to the consumer-side ready signals of spi_engine_execution:
+``sdi_data_ready`` and ``sync_ready``. (``sdo_data_ready`` and ``cmd_ready`` are
+DUT *outputs*; backpressure on those streams is applied by gating the driver's
+valid instead — see ``AXIStreamDriver`` gaps.)
+"""
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import RisingEdge
+
+
+class RandomBackpressure:
+    def __init__(self, clk, ready, rng, *, name="bp"):
+        self.clk = clk
+        self.ready = ready
+        self.rng = rng
+        self.name = name
+        self._task = None
+        self.ready.value = 1
+
+    # ---- strategies (each is a long-running coroutine) ------------------
+    async def _uniform(self, duty_cycle):
+        while True:
+            self.ready.value = 1 if self.rng.random() < duty_cycle else 0
+            await RisingEdge(self.clk)
+
+    async def _burst(self, min_on, max_on, min_off, max_off):
+        while True:
+            on = self.rng.randint(min_on, max_on)
+            for _ in range(on):
+                self.ready.value = 1
+                await RisingEdge(self.clk)
+            off = self.rng.randint(min_off, max_off)
+            for _ in range(off):
+                self.ready.value = 0
+                await RisingEdge(self.clk)
+
+    async def _always(self):
+        self.ready.value = 1
+        while True:
+            await RisingEdge(self.clk)
+
+    # ---- control --------------------------------------------------------
+    def start_uniform(self, duty_cycle=0.5):
+        return self._start(self._uniform(duty_cycle))
+
+    def start_burst(self, min_on=1, max_on=4, min_off=1, max_off=4):
+        return self._start(self._burst(min_on, max_on, min_off, max_off))
+
+    def start_always_ready(self):
+        return self._start(self._always())
+
+    def _start(self, coro):
+        self.stop()
+        self._task = cocotb.start_soon(coro)
+        return self._task
+
+    def stop(self, *, final_value=1):
+        if self._task is not None:
+            self._task.kill()
+            self._task = None
+        self.ready.value = final_value

--- a/cocotb/framework/paths.py
+++ b/cocotb/framework/paths.py
@@ -1,0 +1,16 @@
+"""Repository path anchors, resolved once from this file's location.
+
+The cocotb framework lives at ``<repo>/cocotb/framework``, so every anchor here
+is derived from ``__file__`` — IP runners never hand-roll ``../../..`` chains,
+and there is a single source of truth for where the repo root is.
+
+    from framework.paths import REPO_ROOT, COCOTB_DIR
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FRAMEWORK_DIR = Path(__file__).resolve().parent   # <repo>/cocotb/framework
+COCOTB_DIR = FRAMEWORK_DIR.parent                 # <repo>/cocotb
+REPO_ROOT = COCOTB_DIR.parent                     # <repo>

--- a/cocotb/framework/random_ctx.py
+++ b/cocotb/framework/random_ctx.py
@@ -1,0 +1,57 @@
+"""Central seeded randomness for fully reproducible runs.
+
+Every stochastic decision in a testbench (backpressure toggles, reset timing,
+random stimulus) must derive from a single seed so that a failing run can be
+replayed bit-for-bit. The seed is read from ``RANDOM_SEED`` when present, else
+generated and *logged*.
+
+Usage::
+
+    rc = RandomContext.from_env(dut._log)
+    bp_rng = rc.derive("sdo_backpressure")
+    rc.log_seed()
+
+Derived generators are independent ``random.Random`` instances seeded from the
+master seed plus a stable label hash, so adding a new consumer does not perturb
+the streams of existing ones.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import zlib
+
+
+class RandomContext:
+    def __init__(self, seed: int, logger=None):
+        self.seed = int(seed) & 0xFFFFFFFF
+        self.logger = logger
+        self.master = random.Random(self.seed)
+        self._derived: dict[str, random.Random] = {}
+
+    @classmethod
+    def from_env(cls, logger=None, var="RANDOM_SEED"):
+        raw = os.environ.get(var)
+        if raw is not None and raw != "":
+            seed = int(raw, 0)
+        else:
+            seed = random.SystemRandom().randrange(2 ** 32)
+        return cls(seed, logger=logger)
+
+    def derive(self, label: str) -> random.Random:
+        """Return a stable, independent RNG for a named consumer."""
+        if label not in self._derived:
+            mixed = (self.seed ^ zlib.crc32(label.encode())) & 0xFFFFFFFF
+            self._derived[label] = random.Random(mixed)
+        return self._derived[label]
+
+    def log_seed(self):
+        msg = (f"RANDOM SEED = {self.seed}  "
+               f"(replay with SEED = {self.seed} in runner.py)")
+        if self.logger is not None:
+            self.logger.info("=" * 60)
+            self.logger.info(msg)
+            self.logger.info("=" * 60)
+        else:
+            print(msg)

--- a/cocotb/framework/reset.py
+++ b/cocotb/framework/reset.py
@@ -1,0 +1,95 @@
+"""Random reset injection and reset-value checking.
+
+:class:`RandomResetInjector` asserts ``resetn`` at random points to verify the
+DUT recovers cleanly, then checks the documented reset values once reset
+deasserts. :func:`apply_reset` is the simple deterministic helper used by most
+tests for the initial bring-up.
+
+Documented reset values for spi_engine_execution (active-low resetn):
+    cs        = all ones  ((1<<NUM_OF_CS)-1)
+    sclk      = cpol      (DEFAULT_SPI_CFG[1] after reset)
+    idle      = 1         (=> cmd_ready == 1)
+    sdo_t     = 1
+    sync_valid= 0
+"""
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+
+async def apply_reset(dut, *, cycles_before=5, hold=5):
+    """Deterministic active-low reset pulse; leaves resetn high on return."""
+    dut.resetn.value = 1
+    await ClockCycles(dut.clk, cycles_before)
+    dut.resetn.value = 0
+    await ClockCycles(dut.clk, hold)
+    dut.resetn.value = 1
+    await RisingEdge(dut.clk)
+
+
+def check_reset_values(dut, params, *, scoreboard=None, index=-1):
+    """Check DUT outputs against documented reset values. Returns list of errs."""
+    cpol = (params["DEFAULT_SPI_CFG"] >> 1) & 1
+    expected_cs = (1 << params["NUM_OF_CS"]) - 1
+    checks = [
+        ("cs", int(dut.cs.value), expected_cs),
+        ("sync_valid", int(dut.sync_valid.value), 0),
+        ("cmd_ready", int(dut.cmd_ready.value), 1),
+        ("sdo_t", int(dut.sdo_t.value), 1),
+        ("sclk", int(dut.sclk.value), cpol),
+    ]
+    errs = []
+    for name, actual, expected in checks:
+        if scoreboard is not None:
+            scoreboard.compare(index, f"reset.{name}", expected, actual)
+        if actual != expected:
+            errs.append(f"{name}={actual} expected {expected}")
+    return errs
+
+
+class RandomResetInjector:
+    """Periodically asserts reset at random intervals during a test.
+
+    Parameters
+    ----------
+    dut, rng     : DUT handle and a seeded random.Random
+    min_interval, max_interval : clock cycles between resets
+    hold         : cycles to hold reset low
+    on_reset     : optional callback invoked after each reset deasserts
+    """
+
+    def __init__(self, dut, rng, *, min_interval=50, max_interval=200,
+                 hold=3, on_reset=None, name="reset_inj"):
+        self.dut = dut
+        self.rng = rng
+        self.min_interval = min_interval
+        self.max_interval = max_interval
+        self.hold = hold
+        self.on_reset = on_reset
+        self.name = name
+        self.count = 0
+        self._task = None
+
+    def start(self):
+        if self._task is None:
+            self._task = cocotb.start_soon(self._run())
+        return self._task
+
+    def stop(self):
+        if self._task is not None:
+            self._task.kill()
+            self._task = None
+
+    async def _run(self):
+        while True:
+            wait = self.rng.randint(self.min_interval, self.max_interval)
+            await ClockCycles(self.dut.clk, wait)
+            self.dut.resetn.value = 0
+            await ClockCycles(self.dut.clk, self.hold)
+            self.dut.resetn.value = 1
+            await RisingEdge(self.dut.clk)
+            self.count += 1
+            if self.on_reset is not None:
+                self.on_reset(self.count)

--- a/cocotb/framework/scoreboard.py
+++ b/cocotb/framework/scoreboard.py
@@ -1,0 +1,94 @@
+"""Expected-vs-actual comparison with rich mismatch reporting.
+
+The golden model enqueues *expected* items; monitors enqueue *actual* items.
+The scoreboard compares them in order and accumulates failures, so a single
+test can report every mismatch instead of dying on the first one.
+
+Two comparison styles are provided:
+
+  * exact data comparison (``add_expected`` / ``add_actual`` queues)
+  * timing comparison with a tolerance window (``check_timing``) for the
+    cycle-count checks in the hybrid golden model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Mismatch:
+    index: int
+    field: str
+    expected: object
+    actual: object
+    note: str = ""
+
+    def __str__(self):
+        s = (f"[#{self.index}] {self.field}: "
+             f"expected={self._fmt(self.expected)} actual={self._fmt(self.actual)}")
+        if self.note:
+            s += f"  ({self.note})"
+        return s
+
+    @staticmethod
+    def _fmt(v):
+        return f"0x{v:x}" if isinstance(v, int) and v >= 0 else repr(v)
+
+
+class Scoreboard:
+    def __init__(self, name="scoreboard", logger=None):
+        self.name = name
+        self.logger = logger
+        self.mismatches: list[Mismatch] = []
+        self.compared = 0
+
+    # ---- order-preserving item comparison -------------------------------
+    def compare(self, index, field, expected, actual, *, note=""):
+        """Compare one field; record a mismatch if unequal. Returns bool ok."""
+        self.compared += 1
+        if expected != actual:
+            m = Mismatch(index, field, expected, actual, note)
+            self.mismatches.append(m)
+            if self.logger:
+                self.logger.error(f"{self.name} MISMATCH {m}")
+            return False
+        return True
+
+    def compare_within(self, index, field, expected, actual, tol, *, note=""):
+        """Compare a numeric field allowing |expected-actual| <= tol."""
+        self.compared += 1
+        if abs(int(expected) - int(actual)) > tol:
+            m = Mismatch(index, field, expected, actual,
+                         note=(note + f" tol=±{tol}").strip())
+            self.mismatches.append(m)
+            if self.logger:
+                self.logger.error(f"{self.name} MISMATCH {m}")
+            return False
+        return True
+
+    def compare_sequences(self, expected, actual, *, field="data"):
+        """Compare two ordered sequences element-by-element (and length)."""
+        if len(expected) != len(actual):
+            m = Mismatch(-1, f"{field}.length", len(expected), len(actual),
+                         "sequence length differs")
+            self.mismatches.append(m)
+            if self.logger:
+                self.logger.error(f"{self.name} MISMATCH {m}")
+        for i, (e, a) in enumerate(zip(expected, actual)):
+            self.compare(i, field, e, a)
+
+    # ---- result ----------------------------------------------------------
+    @property
+    def passed(self):
+        return not self.mismatches
+
+    def assert_no_errors(self):
+        if self.mismatches:
+            lines = "\n  ".join(str(m) for m in self.mismatches)
+            raise AssertionError(
+                f"{self.name}: {len(self.mismatches)} mismatch(es) "
+                f"out of {self.compared} comparisons:\n  {lines}")
+        if self.logger:
+            self.logger.info(
+                f"{self.name}: all {self.compared} comparisons passed")

--- a/cocotb/framework/spi/__init__.py
+++ b/cocotb/framework/spi/__init__.py
@@ -1,0 +1,1 @@
+"""SPI-specific verification components (reusable for any SPI IP)."""

--- a/cocotb/framework/spi/bus_monitor.py
+++ b/cocotb/framework/spi/bus_monitor.py
@@ -1,0 +1,242 @@
+"""Passive SPI bus watcher.
+
+Observes the SPI side of the DUT (SCLK / SDO / CS / SDI) and reconstructs the
+words shifted out on SDO, sampling on the active SCLK edge implied by CPOL/CPHA.
+Purely observational — it never drives a signal.
+
+SPI mode -> sampling edge convention (mode = {CPOL, CPHA}):
+
+  * CPHA=0: data sampled on the *leading* SCLK edge
+  * CPHA=1: data sampled on the *trailing* SCLK edge
+
+  with leading edge = rising when CPOL=0, falling when CPOL=1.
+
+The DUT drives ``sdo`` one bit at a time, MSB first, and clocks ``word_length``
+bits per word. Because the execution module registers sclk/sdo together, the
+monitor follows the *output* SCLK rather than reconstructing it from the core
+clock, which keeps it correct across prescaler settings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import cocotb
+from cocotb.triggers import Edge, RisingEdge, FallingEdge
+from cocotb.utils import get_sim_time
+
+
+@dataclass
+class SPIWord:
+    sdo: int            # MOSI word on lane 0 (back-compat single-lane view)
+    sdi_lanes: list     # captured SDI bit-stream per lane (ints), index = lane
+    word_length: int
+    timestamp: int
+    sdo_lanes: list = None  # captured SDO bit-stream per lane (ints), index = lane
+
+
+def _bit(handle, idx=None):
+    try:
+        v = handle.value
+        if idx is None:
+            return int(v)
+        return (int(v) >> idx) & 1
+    except ValueError:
+        return -1
+
+
+class SPIBusMonitor:
+    """Reconstructs SDO words by sampling on the active SCLK edge.
+
+    Parameters
+    ----------
+    dut          : DUT handle (uses dut.sclk, dut.sdo, dut.cs, dut.sdi)
+    cpol, cpha   : SPI mode for choosing the sampling edge
+    word_length  : bits per word (can be updated between transfers via attr)
+    num_sdio     : number of SDIO lanes
+    """
+
+    def __init__(self, dut, *, cpol=0, cpha=0, word_length=8, num_sdio=1,
+                 sdo_lane_mask=None, sdi_lane_mask=None,
+                 gate_signal=None, name="spi_mon"):
+        self.dut = dut
+        self.log = dut._log
+        self.clk = dut.clk
+        self.sclk = dut.sclk
+        self.sdo = dut.sdo
+        self.cs = dut.cs
+        self.sdi = dut.sdi
+        # Warn-once guard so an X/Z coercion is flagged but does not flood the
+        # log on every sampling edge of a persistently-unresolved signal.
+        self._warned_x = set()
+        # Optional activity gate: when provided, SCLK edges are only counted
+        # while this signal is high. ``transfer_active`` precisely brackets the
+        # bit-valid window and avoids phantom edges from CPOL idle settling.
+        self.gate = gate_signal
+        self.cpol = cpol
+        self.cpha = cpha
+        self.word_length = word_length
+        self.num_sdio = num_sdio
+        # Lane masks select which physical lanes carry data. Default: all lanes.
+        all_lanes = (1 << num_sdio) - 1
+        self.sdo_lane_mask = all_lanes if sdo_lane_mask is None else sdo_lane_mask
+        self.sdi_lane_mask = all_lanes if sdi_lane_mask is None else sdi_lane_mask
+        self.name = name
+        self.words: list[SPIWord] = []
+        self._task = None
+
+    def configure(self, *, cpol=None, cpha=None, word_length=None,
+                  sdo_lane_mask=None, sdi_lane_mask=None):
+        if cpol is not None:
+            self.cpol = cpol
+        if cpha is not None:
+            self.cpha = cpha
+        if word_length is not None:
+            self.word_length = word_length
+        if sdo_lane_mask is not None:
+            self.sdo_lane_mask = sdo_lane_mask
+        if sdi_lane_mask is not None:
+            self.sdi_lane_mask = sdi_lane_mask
+
+    def _warn_x(self, what):
+        """Warn once per (signal, lane) that an X/Z read was coerced to 0."""
+        if what not in self._warned_x:
+            self._warned_x.add(what)
+            self.log.warning(
+                f"{self.name}: {what} read X/Z during an active transfer; "
+                f"coercing to 0 (further occurrences suppressed)")
+
+    def _active_lanes(self, mask):
+        """Physical lane indices set in ``mask``, ascending (= shift order)."""
+        return [l for l in range(self.num_sdio) if (mask >> l) & 1]
+
+    def start(self):
+        if self._task is None:
+            self._task = cocotb.start_soon(self._run())
+        return self._task
+
+    def stop(self):
+        if self._task is not None:
+            self._task.kill()
+            self._task = None
+
+    def flush(self):
+        """Discard any partially-accumulated word and restart sampling.
+
+        Call after an injected DUT reset so bits captured before the reset do
+        not bleed into the next word.
+        """
+        was_running = self._task is not None
+        self.stop()
+        if was_running:
+            self.start()
+
+    def _sample_edge_is_rising(self):
+        # leading edge rises when CPOL=0; CPHA=1 samples on the trailing edge.
+        leading_is_rising = (self.cpol == 0)
+        if self.cpha == 0:
+            return leading_is_rising
+        return not leading_is_rising
+
+    def _active(self):
+        """True if a transfer is in progress (gate high, or no gate set)."""
+        if self.gate is None:
+            return True
+        try:
+            return int(self.gate.value) == 1
+        except ValueError:
+            return False
+
+    async def _run(self):
+        # Clock-synchronous sampling: on every *core* clock edge all registered
+        # DUT outputs (sclk, sdo) are settled, so we detect SCLK edges by
+        # comparing successive samples. Awaiting RisingEdge(sclk) directly races
+        # with the co-registered sdo update (both are clocked in the same always
+        # block) and can latch the previous bit — this avoids that delta race.
+        bits_sdo = [0] * self.num_sdio
+        bits_sdi = [0] * self.num_sdio
+        count = 0
+        prev_sclk = _bit(self.sclk)
+        if prev_sclk < 0:
+            prev_sclk = self.cpol
+        while True:
+            await RisingEdge(self.clk)
+            cur_sclk = _bit(self.sclk)
+            if cur_sclk < 0:
+                continue
+            rising = (prev_sclk == 0 and cur_sclk == 1)
+            falling = (prev_sclk == 1 and cur_sclk == 0)
+            prev_sclk = cur_sclk
+
+            is_sample_edge = rising if self._sample_edge_is_rising() else falling
+            if not is_sample_edge:
+                continue
+
+            # A new word only *starts* while the gate is active, rejecting
+            # phantom edges from CPOL idle settling between transfers; a word
+            # already in progress always finishes.
+            if count == 0 and not self._active():
+                continue
+
+            # Latch the word length at the *start* of each word so a length
+            # change between transfers does not truncate the accumulator.
+            if count == 0:
+                wl = self.word_length
+                mask = (1 << wl) - 1
+            # Capture every physical lane on both SDO and SDI. Single-bit
+            # signals (num_sdio==1) are read whole; vectors are indexed per lane.
+            for lane in range(self.num_sdio):
+                so = _bit(self.sdo, lane if self.num_sdio > 1 else None)
+                if so < 0:
+                    self._warn_x(f"sdo[{lane}]" if self.num_sdio > 1 else "sdo")
+                    so = 0
+                bits_sdo[lane] = ((bits_sdo[lane] << 1) | so) & mask
+                si = _bit(self.sdi, lane if self.num_sdio > 1 else None)
+                if si < 0:
+                    self._warn_x(f"sdi[{lane}]" if self.num_sdio > 1 else "sdi")
+                    si = 0
+                bits_sdi[lane] = ((bits_sdi[lane] << 1) | si) & mask
+            count += 1
+
+            if count == wl:
+                self.words.append(SPIWord(
+                    sdo=bits_sdo[0],
+                    sdi_lanes=list(bits_sdi),
+                    sdo_lanes=list(bits_sdo),
+                    word_length=wl,
+                    timestamp=int(get_sim_time("ns")),
+                ))
+                bits_sdo = [0] * self.num_sdio
+                bits_sdi = [0] * self.num_sdio
+                count = 0
+
+    @property
+    def sdo_words(self):
+        """Captured SDO words flattened period-major, active-lane-minor.
+
+        For each captured SPI period, emit one word per *active* SDO lane in
+        ascending lane order — matching the golden model's round-robin layout.
+        At a single active lane this is just one word per period (the previous
+        single-lane behaviour).
+        """
+        lanes = self._active_lanes(self.sdo_lane_mask)
+        if self.num_sdio == 1 or not lanes:
+            return [w.sdo for w in self.words]
+        out = []
+        for w in self.words:
+            src = w.sdo_lanes if w.sdo_lanes is not None else [w.sdo]
+            for l in lanes:
+                out.append(src[l] if l < len(src) else 0)
+        return out
+
+    @property
+    def sdi_words(self):
+        """Captured SDI words flattened period-major, active-lane-minor."""
+        lanes = self._active_lanes(self.sdi_lane_mask)
+        if self.num_sdio == 1 or not lanes:
+            return [w.sdi_lanes[0] for w in self.words]
+        out = []
+        for w in self.words:
+            for l in lanes:
+                out.append(w.sdi_lanes[l] if l < len(w.sdi_lanes) else 0)
+        return out

--- a/cocotb/framework/spi/instructions.py
+++ b/cocotb/framework/spi/instructions.py
@@ -1,0 +1,139 @@
+"""SPI Engine 16-bit command encoding.
+
+Mirrors the command decoder in ``spi_engine_execution.v``::
+
+    inst = cmd[14:12]
+
+    CMD_TRANSFER   = 3'b000
+    CMD_CHIPSELECT = 3'b001
+    CMD_WRITE      = 3'b010   (configuration register write)
+    CMD_MISC       = 3'b011   (sync / sleep)
+    CMD_CS_INV     = 3'b100
+
+These encoders are the single source of truth shared by the stimulus and the
+golden model, so a mis-encoded instruction can never silently agree with itself.
+"""
+
+from __future__ import annotations
+
+# Instruction opcodes (cmd[14:12])
+CMD_TRANSFER = 0b000
+CMD_CHIPSELECT = 0b001
+CMD_WRITE = 0b010
+CMD_MISC = 0b011
+CMD_CS_INV = 0b100
+
+# MISC sub-op (cmd[8])
+MISC_SYNC = 0
+MISC_SLEEP = 1
+
+# Configuration register addresses (cmd[10:8] for CMD_WRITE)
+REG_CLK_DIV = 0b000
+REG_CONFIG = 0b001
+REG_WORD_LENGTH = 0b010
+REG_SDI_LANE_CONFIG = 0b011
+REG_SDO_LANE_CONFIG = 0b100
+
+
+def _u(value, bits):
+    if not (0 <= value < (1 << bits)):
+        raise ValueError(f"value {value} does not fit in {bits} bits")
+    return value
+
+
+def _inst(op):
+    return op << 12
+
+
+def transfer(n_minus_1, *, write=True, read=False):
+    """Transfer instruction.
+
+    ``n_minus_1`` is the raw cmd[7:0] field; the engine transfers
+    ``n_minus_1 + 1`` words (last_transfer = transfer_counter == cmd[7:0]).
+    """
+    cmd = _inst(CMD_TRANSFER)
+    cmd |= (1 << 8) if write else 0
+    cmd |= (1 << 9) if read else 0
+    cmd |= _u(n_minus_1, 8)
+    return cmd
+
+
+def chipselect(cs_bits, *, delay=0):
+    """Chip-select instruction. ``cs_bits`` drives cmd[NUM_OF_CS-1:0];
+    ``delay`` is cmd[9:8] (0 => early-exit, no CS delay)."""
+    cmd = _inst(CMD_CHIPSELECT)
+    cmd |= _u(delay, 2) << 8
+    cmd |= _u(cs_bits, 8)
+    return cmd
+
+
+def write_reg(reg, value):
+    cmd = _inst(CMD_WRITE)
+    cmd |= _u(reg, 3) << 8
+    cmd |= _u(value, 8)
+    return cmd
+
+
+def config_clk_div(clk_div):
+    return write_reg(REG_CLK_DIV, clk_div)
+
+
+def config_spi_mode(*, cpha=0, cpol=0, three_wire=0, sdo_idle_state=0):
+    val = (cpha & 1) | ((cpol & 1) << 1) | ((three_wire & 1) << 2) \
+        | ((sdo_idle_state & 1) << 3)
+    return write_reg(REG_CONFIG, val)
+
+
+def config_word_length(word_length):
+    return write_reg(REG_WORD_LENGTH, word_length)
+
+
+def config_sdi_lane_mask(mask):
+    return write_reg(REG_SDI_LANE_CONFIG, mask)
+
+
+def config_sdo_lane_mask(mask):
+    return write_reg(REG_SDO_LANE_CONFIG, mask)
+
+
+def sync(sync_id):
+    cmd = _inst(CMD_MISC)
+    cmd |= MISC_SYNC << 8
+    cmd |= _u(sync_id, 8)
+    return cmd
+
+
+def sleep(duration):
+    cmd = _inst(CMD_MISC)
+    cmd |= MISC_SLEEP << 8
+    cmd |= _u(duration, 8)
+    return cmd
+
+
+def cs_invert(mask):
+    cmd = _inst(CMD_CS_INV)
+    cmd |= _u(mask, 8)
+    return cmd
+
+
+def decode(cmd):
+    """Human-readable decode for logging/debug."""
+    inst = (cmd >> 12) & 0b111
+    if inst == CMD_TRANSFER:
+        return (f"TRANSFER n={cmd & 0xFF} "
+                f"w={(cmd >> 8) & 1} r={(cmd >> 9) & 1}")
+    if inst == CMD_CHIPSELECT:
+        return f"CHIPSELECT cs=0x{cmd & 0xFF:02x} delay={(cmd >> 8) & 3}"
+    if inst == CMD_WRITE:
+        reg = (cmd >> 8) & 0b111
+        names = {REG_CLK_DIV: "CLK_DIV", REG_CONFIG: "CONFIG",
+                 REG_WORD_LENGTH: "WORD_LENGTH",
+                 REG_SDI_LANE_CONFIG: "SDI_LANE", REG_SDO_LANE_CONFIG: "SDO_LANE"}
+        return f"WRITE {names.get(reg, reg)}=0x{cmd & 0xFF:02x}"
+    if inst == CMD_MISC:
+        sub = (cmd >> 8) & 1
+        return (f"SLEEP {cmd & 0xFF}" if sub == MISC_SLEEP
+                else f"SYNC id={cmd & 0xFF}")
+    if inst == CMD_CS_INV:
+        return f"CS_INV mask=0x{cmd & 0xFF:02x}"
+    return f"UNKNOWN 0x{cmd:04x}"

--- a/cocotb/framework/spi/slave_model.py
+++ b/cocotb/framework/spi/slave_model.py
@@ -1,0 +1,190 @@
+"""SPI slave bus-functional model: drives SDI (MISO) in response to the bus.
+
+Shifts response words out on SDI, MSB-first. Response data can be a fixed queue,
+random, or an echo of the observed SDO.
+
+Two driving strategies are supported:
+
+  * **SCLK-edge** (default): advance the bit on the SCLK edge *opposite* the
+    master's sampling edge, so data is stable when the DUT latches it. This is
+    fully black-box but assumes one SDI bit per visible SCLK period — which the
+    DUT violates during a backpressure stall, where it parks transfer_active low
+    yet still toggles SCLK a couple of phantom edges before resuming.
+
+  * **strobe** (recommended for this DUT): advance the bit on the DUT's actual
+    SDI sample strobe ``trigger_rx_s`` in the shiftreg submodule. The DUT shifts
+    SDI on exactly this strobe, so following it keeps the slave in perfect
+    lock-step across stalls and word boundaries. This is a white-box hook, which
+    is appropriate for a unit testbench of this very module.
+"""
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import RisingEdge, FallingEdge, Edge
+
+
+class SPISlaveModel:
+    MODE_QUEUE = "queue"
+    MODE_RANDOM = "random"
+    MODE_ECHO = "echo"
+
+    def __init__(self, dut, *, cpol=0, cpha=0, word_length=8, num_sdio=1,
+                 mode="queue", responses=None, rng=None, gate_signal=None,
+                 sample_strobe=None, name="spi_slave"):
+        self.dut = dut
+        self.clk = dut.clk
+        self.sclk = dut.sclk
+        self.sdo = dut.sdo
+        self.sdi = dut.sdi
+        self.cs = dut.cs
+        # Activity gate (transfer_active): bits only advance while a transfer is
+        # in progress, so stalls/word boundaries cannot desync the slave.
+        self.gate = gate_signal
+        # Optional DUT SDI sample strobe (trigger_rx_s). When provided, the slave
+        # advances on this strobe instead of counting SCLK edges — robust under
+        # backpressure. The bit presented before the *first* strobe is the MSB.
+        self.sample_strobe = sample_strobe
+        self.cpol = cpol
+        self.cpha = cpha
+        self.word_length = word_length
+        self.num_sdio = num_sdio
+        self.mode = mode
+        self.rng = rng
+        self.name = name
+        # Single flat response queue, consumed period-major / active-lane-minor:
+        # for L active lanes, the first L words populate period 0 (lane order
+        # ascending), the next L populate period 1, etc. At L=1 this is just one
+        # word per period — identical to the original single-lane queue.
+        self._responses = list(responses or [])
+        # Active SDI lanes (default: all). Words map only onto these lanes;
+        # inactive lanes are driven to 0.
+        all_lanes = (1 << num_sdio) - 1
+        self.sdi_lane_mask = all_lanes
+        self._task = None
+        self.sdi.value = 0
+
+    def _active_lanes(self):
+        return [l for l in range(self.num_sdio)
+                if (self.sdi_lane_mask >> l) & 1]
+
+    def configure(self, *, cpol=None, cpha=None, word_length=None,
+                  sdi_lane_mask=None):
+        if cpol is not None:
+            self.cpol = cpol
+        if cpha is not None:
+            self.cpha = cpha
+        if word_length is not None:
+            self.word_length = word_length
+        if sdi_lane_mask is not None:
+            self.sdi_lane_mask = sdi_lane_mask
+
+    def load(self, responses):
+        self._responses = list(responses)
+
+    def start(self):
+        if self._task is None:
+            self._task = cocotb.start_soon(self._run())
+        return self._task
+
+    def stop(self):
+        if self._task is not None:
+            self._task.kill()
+            self._task = None
+        self.sdi.value = 0
+
+    def _sample_edge_is_rising(self):
+        leading_is_rising = (self.cpol == 0)
+        if self.cpha == 0:
+            return leading_is_rising
+        return not leading_is_rising
+
+    def _next_word(self):
+        """Pop the next response word for a single lane."""
+        if self.mode == self.MODE_RANDOM and self.rng is not None:
+            return self.rng.randrange(1 << self.word_length)
+        if self.mode == self.MODE_ECHO:
+            return None  # echo handled inline from observed SDO
+        if self._responses:
+            return self._responses.pop(0)
+        return 0
+
+    def _next_period_words(self):
+        """Return {physical_lane: word} for one SPI period across active lanes.
+
+        Consumes the response queue in ascending active-lane order, so the flat
+        queue is laid out period-major / lane-minor (see __init__).
+        """
+        words = {}
+        for lane in self._active_lanes():
+            w = self._next_word()
+            words[lane] = 0 if w is None else w
+        return words
+
+    def _drive_lanes(self, lane_words, bit_idx):
+        """Present bit ``bit_idx`` (MSB-first) of each lane's word on sdi[]."""
+        if self.num_sdio > 1:
+            lanes = 0
+            for lane, value in lane_words.items():
+                bit = (value >> (self.word_length - 1 - bit_idx)) & 1
+                lanes |= (bit << lane)
+            self.sdi.value = lanes
+        else:
+            # Single lane: lane 0 word (or 0 if inactive/empty).
+            value = lane_words.get(0, 0)
+            bit = (value >> (self.word_length - 1 - bit_idx)) & 1
+            self.sdi.value = bit
+
+    def _active(self):
+        if self.gate is None:
+            return True
+        try:
+            return int(self.gate.value) == 1
+        except ValueError:
+            return False
+
+    async def _run(self):
+        if self.sample_strobe is not None:
+            await self._run_strobe()
+        else:
+            await self._run_sclk_edge()
+
+    async def _run_sclk_edge(self):
+        # Edge-driven slave: present a bit, then advance on the master's "change"
+        # edge (the edge opposite its sampling edge) so the next bit is stable
+        # before the DUT samples. Awaiting the SCLK edge directly (rather than
+        # polling the core clock) reacts within the same delta, which matters at
+        # clk_div=0 where SCLK toggles every core clock and a one-cycle BFM lag
+        # would shift the data by a full half-period.
+        while True:
+            lane_words = self._next_period_words()
+            for bit_idx in range(self.word_length):
+                self._drive_lanes(lane_words, bit_idx)
+                if not self._sample_edge_is_rising():
+                    await RisingEdge(self.sclk)
+                else:
+                    await FallingEdge(self.sclk)
+
+    async def _run_strobe(self):
+        # Strobe-driven slave: present the MSB, then on each DUT SDI sample strobe
+        # (trigger_rx_s) advance to the next bit. Because the DUT shifts SDI on
+        # exactly this strobe, the slave stays in lock-step regardless of stalls,
+        # word boundaries or backpressure. We update SDI on the core clock edge
+        # *after* the strobe so the new bit is stable before the next strobe.
+        lane_words = self._next_period_words()
+        bit_idx = 0
+        self._drive_lanes(lane_words, bit_idx)
+        while True:
+            await RisingEdge(self.clk)
+            try:
+                strobe = int(self.sample_strobe.value)
+            except ValueError:
+                continue
+            if strobe != 1:
+                continue
+            # DUT just latched the currently-presented bit; advance.
+            bit_idx += 1
+            if bit_idx >= self.word_length:
+                lane_words = self._next_period_words()
+                bit_idx = 0
+            self._drive_lanes(lane_words, bit_idx)

--- a/cocotb/framework/sweep/__init__.py
+++ b/cocotb/framework/sweep/__init__.py
@@ -1,0 +1,31 @@
+"""Multi-config build -> run -> report sweep harness (IP- and sim-agnostic).
+
+The reusable machinery behind an IP runner: how build/run dirs are addressed
+(:class:`SweepLayout`), how jobs are dispatched in parallel with clean teardown
+(:func:`dispatch`), how cocotb results are parsed and reported
+(:mod:`~framework.sweep.results`), and how Verilator coverage is merged
+(:func:`merge_and_report_coverage`).
+
+An IP runner supplies only the DUT-specific parts — its sources, toplevel, test
+modules, generics, and per-run env — and drives these helpers.
+"""
+
+from framework.sweep.coverage import merge_and_report_coverage
+from framework.sweep.dispatch import dispatch
+from framework.sweep.layout import SweepLayout
+from framework.sweep.results import (
+    parse_results,
+    print_analysis,
+    print_execution_counts,
+    print_tests_with_runs,
+)
+
+__all__ = [
+    "SweepLayout",
+    "dispatch",
+    "parse_results",
+    "print_analysis",
+    "print_execution_counts",
+    "print_tests_with_runs",
+    "merge_and_report_coverage",
+]

--- a/cocotb/framework/sweep/coverage.py
+++ b/cocotb/framework/sweep/coverage.py
@@ -1,0 +1,44 @@
+"""Merge per-run Verilator coverage into one dataset and print how to view it.
+
+Merging across configs is deliberate: each generic combo reaches different RTL
+(e.g. the 4-CS or 4-lane paths), so the union over the whole sweep is the
+meaningful coverage number. Verilator-specific but IP-agnostic; skips cleanly
+if the tools or ``.dat`` files are missing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def merge_and_report_coverage(runs_root: Path, coverage_dir: Path) -> None:
+    """Merge every ``<runs_root>/*/coverage.dat`` and print viewing instructions.
+
+    Collects each run's ``coverage.dat`` under ``runs_root``, merges them into
+    ``coverage_dir/merged.dat`` with ``verilator_coverage``, and prints the
+    commands to annotate/export the result. No-op with a note if there is
+    nothing to merge or the tool is absent.
+    """
+    dats = sorted(runs_root.glob("*/coverage.dat"))
+    if not dats:
+        print("coverage: no coverage.dat collected (Verilator only) — skipping.",
+              file=sys.stderr)
+        return
+    if not shutil.which("verilator_coverage"):
+        print("coverage: verilator_coverage not on PATH; per-run .dat files are "
+              f"under {runs_root} — merge them manually.", file=sys.stderr)
+        return
+
+    coverage_dir.mkdir(parents=True, exist_ok=True)
+    merged = coverage_dir / "merged.dat"
+    subprocess.run(["verilator_coverage", "--write", str(merged), *map(str, dats)],
+                   check=True)
+    print(f"\ncoverage: merged {len(dats)} run(s) -> {merged}")
+    print("view it with:")
+    print(f"  verilator_coverage --annotate cov_annotated --annotate-min 1 {merged}")
+    print("  grep -rn '^%' cov_annotated/          # never-hit lines")
+    print(f"  verilator_coverage --write-info coverage.info {merged}")
+    print("  genhtml coverage.info -o cov_html     # -> cov_html/index.html (needs lcov)")

--- a/cocotb/framework/sweep/dispatch.py
+++ b/cocotb/framework/sweep/dispatch.py
@@ -1,0 +1,57 @@
+"""Parallel job dispatch with clean process-group teardown.
+
+:func:`dispatch` runs a function over a list of jobs, yielding results as they
+finish, and guarantees that on any exit — Ctrl+C, ``break``, exception — the
+worker processes and the simulator children they spawn are all killed by process
+group so nothing leaks. It is simulator- and IP-agnostic: give it a callable and
+a list of argument tuples.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import suppress
+
+
+def _new_process_group() -> None:
+    # Worker becomes its own group leader so we can signal it AND the simulator
+    # child it spawns with one killpg — nothing survives an interrupt.
+    os.setpgrp()
+
+
+def _kill_pool(ex: ProcessPoolExecutor) -> None:
+    for proc in ex._processes.values():
+        with suppress(ProcessLookupError, PermissionError):
+            os.killpg(proc.pid, signal.SIGKILL)
+
+
+def dispatch(fn, jobs, *, max_jobs, label=None):
+    """Yield ``fn(*job)`` results as they finish; parallel when ``max_jobs`` > 1.
+
+    A generator so callers can show progress live. On any exit — Ctrl+C, break,
+    exception — the workers and the simulator children they spawned are killed
+    by process group, so nothing leaks. shutdown(wait=False) because a hung sim
+    must not block teardown. ``label(job)`` names the in-flight jobs on interrupt.
+    """
+    if max_jobs <= 1:
+        for job in jobs:
+            yield fn(*job)
+        return
+    ex = ProcessPoolExecutor(max_workers=max_jobs, initializer=_new_process_group)
+    pending = {}  # future -> job, dropped as each result is yielded
+    try:
+        for job in jobs:
+            pending[ex.submit(fn, *job)] = job
+        for fut in as_completed(list(pending)):
+            del pending[fut]
+            yield fut.result()
+    finally:
+        if label:
+            for fut, job in pending.items():
+                if fut.running():
+                    print(f"Aborting {label(job)}...", file=sys.stderr)
+        _kill_pool(ex)
+        ex.shutdown(wait=False, cancel_futures=True)

--- a/cocotb/framework/sweep/layout.py
+++ b/cocotb/framework/sweep/layout.py
@@ -1,0 +1,70 @@
+"""Directory layout and build flags for a multi-config simulation sweep.
+
+``build_dir_for``/``run_dir_for``/``build_args`` in an IP runner all read the
+same handful of values (simulator, dir roots, coverage/waves toggles). Bundling
+them into one :class:`SweepLayout` keeps those addressing rules in one place and
+spares every runner from threading the same six arguments around.
+
+Two addressing schemes, deliberately different:
+  * build dirs are *content-addressed* — same (sim, config-name, instrumentation)
+    maps to the same dir, so an unchanged config reuses its binary and configs
+    with differing generics never collide on a stale one;
+  * run dirs are *identity-addressed* — unique per (config-name, seed), so no two
+    runs write the same results/coverage file. This is what makes parallel and
+    multi-agent runs safe.
+
+``name`` is any DUT-generic string the caller uses to identify a config (e.g.
+``"dw8_cs1_sd1"``); this module never interprets it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SweepLayout:
+    """Where a sweep's build/run/coverage artifacts live, and how it compiles.
+
+    Parameters
+    ----------
+    sim         : simulator name ("verilator" | "icarus")
+    build_root  : parent of all per-config build dirs
+    runs_root   : parent of all per-run dirs
+    coverage_dir: destination for the merged coverage dataset
+    coverage    : compile with Verilator line coverage instrumentation
+    waves       : dump waveforms per run
+    verilator_build_args / icarus_build_args : extra per-sim compile flags
+        (generics and ``--coverage`` are added elsewhere / automatically)
+    """
+    sim: str
+    build_root: Path
+    runs_root: Path
+    coverage_dir: Path
+    coverage: bool = False
+    waves: bool = False
+    verilator_build_args: tuple[str, ...] = ()
+    icarus_build_args: tuple[str, ...] = ()
+
+    @property
+    def instr(self) -> str:
+        """Instrumentation suffix so instrumented builds don't reuse plain ones."""
+        return ("_cov" if self.coverage else "") + ("_wave" if self.waves else "")
+
+    def build_dir(self, name: str) -> Path:
+        """Content-addressed: same (sim, name, instrumentation) -> same binary."""
+        return self.build_root / f"{self.sim}_{name}{self.instr}"
+
+    def run_dir(self, name: str, seed: int) -> Path:
+        """Identity-addressed: unique per run, so parallel workers never clash."""
+        return self.runs_root / f"{name}_seed{seed}"
+
+    def build_args(self) -> list[str]:
+        """Per-sim compile flags, adding ``--coverage`` when instrumenting."""
+        args = list(self.verilator_build_args if self.sim == "verilator"
+                    else self.icarus_build_args)
+        if self.coverage and self.sim == "verilator":
+            # Compile-time instrumentation; the run binary rejects --coverage.
+            args.append("--coverage")
+        return args

--- a/cocotb/framework/sweep/results.py
+++ b/cocotb/framework/sweep/results.py
@@ -1,0 +1,61 @@
+"""Parse cocotb JUnit XML and print the sweep's TEST ANALYSIS block.
+
+All IP-agnostic: a test is identified only by its name, a run only by its tag.
+:func:`parse_results` turns one results file into ``(name, ran, failed)`` rows;
+the ``print_*`` helpers render the cross-run tally the runner accumulates.
+"""
+
+from __future__ import annotations
+from collections import defaultdict
+
+import xml.etree.ElementTree as ET
+
+
+def parse_results(xml_path) -> list[tuple[str, bool, bool]]:
+    """Return [(name, ran, failed)] from a cocotb JUnit XML.
+
+    cocotb emits one <testcase> per test with no aggregate counts, so tally them
+    here: skipped tests carry a <skipped/> child, failed ones a <failure/>.
+    """
+    rows = []
+    for tc in ET.parse(xml_path).getroot().iter("testcase"):
+        skipped = tc.find("skipped") is not None
+        failed = tc.find("failure") is not None
+        rows.append((tc.get("name"), not skipped, failed))
+    return rows
+
+
+def print_execution_counts(counts: dict[str, int]) -> None:
+    """Per-test run tally, most-run first; flag tests skipped in every run."""
+    if not counts:
+        return
+    print("EXECUTION COUNTS")
+    for name, n in sorted(counts.items(), key=lambda kv: kv[1], reverse=True):
+        flag = "   NEVER EXECUTED" if n == 0 else ""
+        print(f"  {name:<48} {n}{flag}")
+
+
+def print_tests_with_runs(title: str, tests: dict[str, list[str]]) -> None:
+    """Print 'test on runs:' blocks — used for both FAILURES and SKIPPED TESTS."""
+    if not tests:
+        return
+    print(f"\n{title}")
+    for name in sorted(tests):
+        print(f"  {name} on runs:")
+        # group each tag by its run prefix, collecting the seeds
+        seeds_by_run = defaultdict(list)
+        for tag in tests[name]:
+            run, seed = tag.split("_seed")
+            seeds_by_run[run].append(int(seed))
+        for run in sorted(seeds_by_run):
+            seeds = sorted(seeds_by_run[run])
+            print(f"    {run} on seeds {seeds}")
+
+
+def print_analysis(counts, failures, skips, runs_root) -> None:
+    """The TEST ANALYSIS block: counts, then which tests failed/skipped where."""
+    print("\n" + "=" * 17 + " TEST ANALYSIS " + "=" * 17)
+    print_execution_counts(counts)
+    print_tests_with_runs("FAILURES", failures)
+    print_tests_with_runs("SKIPPED TESTS", skips)
+    print(f"\nPer-run logs and results under: {runs_root}")

--- a/cocotb/requirements.txt
+++ b/cocotb/requirements.txt
@@ -1,0 +1,16 @@
+# cocotb verification framework — Python dependencies
+#
+# cocotb 2.0's --timing support requires Verilator >= 5.0 (the distro 4.x will
+# not work); Verilator itself is installed separately (see env.sh / README).
+#
+# Recreate the venv with:
+#   python3 -m venv .venv && . .venv/bin/activate
+#   pip install -r requirements.txt
+
+cocotb==2.0.1
+cocotb-bus==0.3.0
+
+# Pulled in transitively (pinned for reproducibility):
+#   find_libpython==0.5.1   (cocotb)
+#   packaging==26.2         (cocotb)
+#   scapy==2.7.0            (cocotb-bus)

--- a/testbenches/ip/spi_engine/execution/README.md
+++ b/testbenches/ip/spi_engine/execution/README.md
@@ -1,0 +1,192 @@
+# SPI Engine — `execution` unit testbench
+
+**Important notice:** this is a POC / experiment for IP/Unit testing using CocoTB.
+This branch/PR might suffer drastic changes in a short window of time.
+Consider it experimental and unstable.
+
+A cocotb testbench that drives the DUT with the real 16-bit SPI Engine command
+stream and checks every SPI-bus and SDI-return transaction against an
+independent Python golden model.
+
+Layered:
+- reusable, IP-agnostic framework (`cocotb/framework/`)
+- reusable SPI layer (`cocotb/framework/spi/`)
+- DUT-specific tier (harness + golden model + `test_*.py`)
+
+
+# Running the TB
+## Initial setup
+
+Prerequisites:
+- Python venv with dependencies
+- Verilator ≥ 5.0 (cocotb 2.0 `--timing`; distro 4.x won't work)
+- Optional: Icarus Verilog ≥ 11 (event-sim cross-check)
+- Optional: `lcov` package for HTML coverage report
+
+One-time install:
+
+```bash
+# 1. Verilator from source, to a local prefix:
+cd PATH_TO_INSTALL_VERILATOR
+git clone https://github.com/verilator/verilator && cd verilator
+git checkout v5.026
+autoconf && ./configure --prefix=$HOME/.local/verilator && make -j"$(nproc)" && make install
+
+# 2. Python venv + deps, at the testbenches_repo/ root (holds cocotb/ and testbenches/):
+cd PATH_TO_STORE_VENV
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r cocotb/requirements.txt        # cocotb 2.0.1, cocotb-bus
+
+# 3. Optional tools:
+sudo apt install iverilog lcov                 # Icarus sim + genhtml for coverage
+```
+
+Add helper function to your `~/.bash_aliases`
+
+```bash
+# ~/.bash_aliases
+function activate_cocotb() {
+    local venv_path=<PATH_TO_VENV>
+    local verilator_path=<PATH_TO_VERILATOR>
+    export PATH="$verilator_path/bin:$PATH"
+    export VERILATOR_ROOT="$verilator_path/share/verilator"
+    source "$venv_path/bin/activate"
+    echo "cocotb:    $(python -c 'import cocotb; print(cocotb.__version__)' 2>/dev/null || echo MISSING)"
+    echo "verilator: $(verilator --version 2>/dev/null || echo MISSING)"
+}
+```
+
+## Running tests
+
+`runner.py` is the single entry point — it owns the build (sources, generics,
+compile flags), the config sweep, seeds, parallelism, and result aggregation.
+It takes no arguments. The full routine per shell:
+
+```bash
+activate_cocotb
+export ADI_HDL_DIR=/path/to/hdl
+cd testbenches/ip/spi_engine/execution   # from the testbenches_repo root
+python3 runner.py
+```
+
+It builds every config once (cached, so re-runs skip unchanged builds), runs the
+suite across configs × seeds in parallel, and prints a live `RUN RESULTS` list
+followed by a `TEST ANALYSIS` (execution counts, and which tests failed/skipped
+on which runs).
+Per-run logs and results land under `sim_build/runs/<RUN_ID>/`.
+
+### Run Configurations / Run a single Config / Reproduce one run
+
+Everything a user changes lives in the `CONFIGURATION` block at the top of
+`runner.py` (the sweep, seed count, `SIM`, `MAX_JOBS`, coverage, etc. — each
+commented in place; skim it).
+
+Comment out the default `CONFIGS` list and add your own single entry, then
+optionally pin `SEED` (to a value the summary logged) and `TESTCASE`:
+
+```python
+CONFIGS = [Config(data_width=32, num_of_sdio=4, default_clk_div=2)]
+SEED = 1587325506
+TESTCASE = "test_sdi_handshake_stability"
+```
+
+Leave `SEED`/`TESTCASE` as `None` for the normal random sweep over the full suite.
+Set `MAX_JOBS = 1` for a serial run with live simulator output (debugging);
+set `RUN_ID` to keep concurrent runs (e.g. separate agents) in separate dirs.
+
+### Simulator choice (`SIM`)
+
+The two supported simulators trade off differently:
+
+- **Icarus** compiles the SystemVerilog faster (lighter elaboration).
+- **Verilator** executes the simulation faster — higher simulated ns per second of
+  wall-clock time
+
+So Icarus wins for a quick one-off, while Verilator wins for long runs and the
+multi-seed sweep, where run time dominates the one-time compile cost.
+
+- Changing defaults to 8 parallel jobs + 10 random seeds:
+  - full-suite wall-clock time on Icarus: 0m47s (of which 0.0s compiling)
+  - full-suite wall-clock time on Verilator: 1m03s (of which 29.5s compiling)
+
+## Checking code coverage (verilator only)
+
+Coverage is Verilator-only (no effect under `SIM=icarus`).
+
+Set `COVERAGE = True` in `runner.py` and run it. Each run writes its own
+`coverage.dat`; the runner merges them into `sim_build/coverage/<RUN_ID>/merged.dat`
+— the union of RTL reached across all generics (the 4-CS and 4-lane paths only
+some configs hit). The script prints the view commands at the end; the two ways
+to read `merged.dat`:
+
+```bash
+DAT=sim_build/coverage/run/merged.dat
+
+# annotated source (no extra tools): '%'-prefixed lines are under threshold
+verilator_coverage --annotate cov_annotated --annotate-min 1 $DAT
+grep -rn "^%" cov_annotated/
+
+# HTML report (needs lcov): browsable per-file line coverage at cov_html/index.html
+verilator_coverage --write-info coverage.info $DAT
+genhtml coverage.info -o cov_html
+```
+
+`genhtml` reads absolute RTL paths from `coverage.info`, so run it on the same
+machine as the sim (the `hdl_repo` sources must exist at those paths).
+
+# TB Philosophy
+
+## The problem
+
+- RTL predates TB, as such LLMs tend to represent the RTL literally in the TB
+- If RTL has a bug, the bug is modeled into the TB and thus isn't caught
+- Literal representation of the RTL ties implementation to TB, changing one breaks the other
+
+## Proposed solution
+
+Propose a requirement driven clean room framework. Lets break this down...
+
+### Requirements
+
+- Atomic text description of each behaviour the IP should have
+  - atomic: each behaviour is small and can be simply represented
+    - implementation: one always block/assignment per requirement
+    - testbench: one testcase per requirement
+- What/Why/How methodology: helps humans and LLMs understand the codebase
+  - Requirements describe the What/Why
+  - RTL explains the How
+- Easy bidirectional traceability (greppable comments in RTL/TB)
+  - Better navigation between documentation, implementation and verification (V-model)
+
+### Clean room
+
+- RTL predates the testbench and often predates the docs and SW drivers
+  - Hard to acquire RTL independent ground truth to produce TB/Test cases
+- As such, use an LLM session to derive behavioural (black box) requirements of the IP
+  - As independent from implementation as possible
+  - HDL docs and SW Drivers can corroborate to the requirements
+- From the requirements, a new LLM session produces the behavioural implementation-independent testcases
+
+### Framework
+
+- A set of guidelines were produced to guide the LLM sessions and
+allow this procedure to be easily replicated for other IPs.
+
+Proposed flow:
+
+1. Using the [requirements guideline](./doc/guideline_for_writing_requirements.md)
+have LLM produce requirements from docs, SW drivers and RTL
+2. Human validation of requirements
+3. With requirements, ask LLM to draft TB architecture and organization
+4. Human validation of TB/TC architecture
+5. Using the [testcase guideline](./doc/guideline_for_writing_testcases.md)
+and the proposed architecture, have LLM produce the TB/testcases
+6. Human validation of the testbench
+
+### LLM Friendlyness
+
+- Mixture of natural language description (requirements) with code (RTL) help
+LLMs understand and implement tasks
+- Atomic greppable requirements result in smaller context windows
+- Test cases that target specific requirements allow LLMs to validate their
+work and loop

--- a/testbenches/ip/spi_engine/execution/doc/bug_log.md
+++ b/testbenches/ip/spi_engine/execution/doc/bug_log.md
@@ -1,0 +1,57 @@
+# Data unstable under held valid - SDI handshake unstable under sub-word ready-stall at clk_div=0 (FLAG EXEC-F1)
+- code revision: hdl_repo 8ae99f4c (main branch, Wed Jun 24)
+- Requirement: EXEC-FLOW-05 - `sdi_data` must stay stable while `sdi_data_valid` is asserted and unaccepted (valid/ready handshake stability).
+- Test: `test_flow_control.py::test_sdi_handshake_stability` (fails on current RTL; second home of EXEC-FLOW-05).
+- Symptom: at `clk_div=0`, if the consumer stalls (`sdi_data_ready` low) for less than a word period, a new word is fully shifted in and overwrites the previous one before it is accepted - `sdi_data` changes under an unaccepted valid, corrupting/dropping the stalled word. With `clk_div=2` and bounded stalls: zero violations, correct data.
+- Root cause: (spi_engine_execution_shiftreg.v) the SDI datapath has no hold on the captured word - at `clk_div=0` a full word shifts in every word period, so the engine effectively requires `sdi_data_ready` to be granted within one word period. There is no backpressure guarantee that the downstream consumer honors that.
+- Decision needed: treat as a documented operating constraint (downstream SDI FIFO must accept within a word period, i.e. model realistic backpressure) or add a hold/skid so the captured word survives an arbitrary stall at `clk_div=0`.
+- Run Command: `WAVES=1 COCOTB_TESTCASE=test_sdi_handshake_stability make` (waveform in the run's `sim_build/<NNN>_<timestamp>/dump.fst`)
+- Wave signals:
+  - dut::sdi_data
+  - dut::sdi_data_valid
+  - dut::sdi_data_ready
+  - dut::transfer_active
+  - dut::shiftreg::trigger_rx_s
+  - dut::shiftreg::trigger_rx_d
+  - dut::shiftreg::sdi_data_latch
+
+# Register not cleared by reset - Sticky sdo_data_ready survives reset (FLAG EXEC-F10)
+- code revision: hdl_repo 8ae99f4c (main branch, Wed Jun 24)
+- Requirement: EXEC-SDO-04 - the engine must not request SDO data (`sdo_data_ready`) with no write instruction in flight; a reset must return the SDO request handshake to idle.
+- Test: `test_flow_control.py::test_sdo_ready_cleared_by_reset` (fails on current RTL; second home of EXEC-SDO-04).
+- Symptom: in FIFO mode (`s_offload_active=0`), `sdo_data_ready` asserts with no command pending and no valid write instruction - but only after a prior transfer, and the state survives an intervening `resetn` pulse.
+- Root cause: (spi_engine_execution.v) `exec_transfer_cmd_reg` is set inside `if (exec_cmd)` and has NO reset branch, so it stays 1 across reset. It feeds the shiftreg as `exec_cmd`, and the prefetch gate `sdo_data_ready_int = (...) && (s_offload_active || (exec_cmd & index_ready))` then asserts `sdo_data_ready` post-reset with no transfer in flight - an AXI-stream/protocol violation (state not cleared by reset).
+- Decision needed: reset SHOULD clear `exec_transfer_cmd_reg` (RTL fix), or a post-reset non-transfer command is a required power-on step (document the sequence).
+- Run Command: `WAVES=1 COCOTB_TESTCASE=test_sdo_ready_cleared_by_reset make` (waveform in the run's `sim_build/<NNN>_<timestamp>/dump.fst`)
+- Wave signals:
+  - dut::resetn
+  - dut::s_offload_active
+  - dut::sdo_data_valid
+  - dut::sdo_data_ready
+  - dut::exec_transfer_cmd_reg
+  - dut::shiftreg::exec_cmd
+  - dut::shiftreg::index_ready
+  - dut::shiftreg::sdo_data_ready_int
+
+# Missing lane-mask gate - Offload prefetch ignores the SDO lane mask
+- code revision: hdl_repo 8ae99f4c (main branch, Wed Jun 24)
+- Requirement: EXEC-OFF-02 - offload prefetch requires ALL SDO lanes active; with a sub-mask (some lanes inactive) the engine must wait for the write instruction instead of prefetching.
+- Test (white-box): `test_offload.py::test_offload_prefetch_requires_all_lanes` (fails hard on current RTL; skipped at `NUM_OF_SDIO<2`) - proves `sdo_data_ready` prefetch fires under a sub-mask.
+- Test (black-box): `test_offload.py::test_offload_submask_no_stream_corruption` (fails hard on current RTL; skipped at `NUM_OF_SDIO<3`) - proves the prefetch actually **corrupts the SDO bus data**: same command/data/mask, the offload-mode SPI-bus SDO words differ from FIFO mode (stream slides by one, wrong lane mapping). Sweeps every observable sub-mask **and** the timing phase (offset from lane-mask re-pulse to data arrival), because the corruption is phase-dependent - a single phase can miss it.
+- Symptom: with `s_offload_active=1` and a sub-mask leaving some lanes inactive, the engine prefetches an SDO word during the lane-mask scan window (before the lane map is built), instead of waiting for the write instruction. The early-consumed word is mapped with a stale `lane_lookup[]`/`last_active_idx`, so the whole SDO stream shifts by one and lands on the wrong lanes - observed black-box on the SPI bus at `NUM_OF_SDIO>=3` (e.g. sub-mask `0b101`: FIFO `[186,76,28,73,...]` vs offload `[28,76,73,183,...]`). At `NUM_OF_SDIO<=2` the sub-mask leaves at most one active lane (identity map), so the corruption is not observable. **Phase-dependent:** whether it corrupts depends on which cycle of the ~`NUM_OF_SDIO`-cycle lane-scan rebuild consumes the prefetched word. Some (mask, phase) points are clean - e.g. mask `0b011` corrupts at phases 1..N but is clean at phase 0 - so the test must sweep the phase, not pin one.
+- Impact: this is an internal ordering fault of the execution module, independent of the offload IP - it accepts an SDO word before its own lane map is ready. Given SDO data valid during the scan, it produces wrong data on the wire under a legal offload+sub-mask configuration.
+- Root cause: (spi_engine_execution_shiftreg.v) the prefetch gate `sdo_data_ready_int = (...) && (s_offload_active || (exec_cmd & index_ready))` lets `s_offload_active` bypass `index_ready` (= assembler `lane_cfg_ready`, "lane-mask scan complete"). No lane-mask/scan-done term guards the offload branch.
+- Suggested fix: require `index_ready` in the offload branch too, e.g. `... && index_ready && (s_offload_active || exec_cmd)`. Efficiency toll is negligible: `index_ready` only deasserts for ~NUM_OF_SDIO cycles per lane-mask change (not per word/transfer), so steady-state throughput is unchanged.
+- Decision needed: add the scan-done (and/or all-lanes) gate to the RTL, or correct `spi_engine_execution.rst` if the requirement is not intended.
+- Run Command (white-box): `PARAM_NUM_OF_SDIO=2 WAVES=1 COCOTB_TESTCASE=test_offload_prefetch_requires_all_lanes make`
+- Run Command (black-box): `PARAM_NUM_OF_SDIO=3 WAVES=1 COCOTB_TESTCASE=test_offload_submask_no_stream_corruption make` (needs NUM_OF_SDIO>=3; waveform in the run's `sim_build/<NNN>_<timestamp>/dump.fst`)
+- Wave signals:
+  - dut::s_offload_active
+  - dut::sdo_data_valid
+  - dut::sdo_data_ready
+  - dut::sdo_lane_mask
+  - dut::sdo   (SPI-bus output - where the corruption is observable)
+  - dut::shiftreg::exec_cmd
+  - dut::shiftreg::index_ready
+  - dut::shiftreg::sdo_data_ready_int
+  - dut::shiftreg::sdo_data_assemble::lane_cfg_ready

--- a/testbenches/ip/spi_engine/execution/doc/guideline_for_writing_requirements.md
+++ b/testbenches/ip/spi_engine/execution/doc/guideline_for_writing_requirements.md
@@ -1,0 +1,265 @@
+# Specification & Requirements Authoring Guideline
+
+## 1. Purpose
+
+This guideline defines **how to write behavioral requirements** for existing ADI FPGA IPs whose RTL already exists.
+
+Unlike a traditional V-model, this project follows an **inverted V-model**:
+
+```
+Existing RTL
+↓
+Behavioral Requirements
+↓
+Golden Model
+↓
+Verification Environment
+```
+
+The objective is **not** to paraphrase the RTL. The objective is to reconstruct the intended behavior at the module boundary so that the golden model becomes an independent behavioral representation of the design.
+
+Because the RTL and documentation originate from the same engineering team, we **cannot achieve author independence**, but we **can achieve representational independence** by expressing behavior at a higher abstraction level.
+
+## 2. Guiding Principles
+
+Requirements should satisfy the **What / Why / How** separation.
+
+- **Requirement:** defines **what** the IP must do.
+- **Rationale:** briefly explains **why** the behavior exists.
+- **Design/RTL:** define **how** the behavior is implemented.
+
+Requirements should:
+
+- describe **externally observable behavior**;
+- remain valid if the RTL is refactored;
+- be suitable for direct verification;
+- enable simple bidirectional traceability.
+
+## 3. Writing Rules
+
+Every requirement MUST:
+
+- have a unique, stable ID;
+- describe **one behavior** (atomic);
+- use RFC-2119 keywords: **MUST**, **MUST NOT**, **SHOULD** and **MAY**;
+- describe **what**, not **how**;
+- describe behavior observable at the module boundary;
+- state applicable conditions explicitly;
+- define measurable behavior whenever timing or quantities are involved, expressed as a **closed-form relation to inputs** (e.g. `SCLK period = (div+1)·2 core clocks`) rather than a cycle-by-cycle trace;
+- use defined project terminology;
+- include a brief rationale;
+- remain stable under equivalent RTL refactoring.
+
+A requirement MAY also specify its verification method, one of:
+
+- **`SIMULATION`** — the default; checked by a directed test, parameter sweep, or waveform assertion.
+- **`FORMAL`** — reserved for small, highly-reused primitives (e.g. CDC synchronizers) where exhaustive proof is tractable.
+- **`HARDWARE`** — used sparingly, only for behavior that cannot be observed in simulation or whose simulation would be prohibitively long.
+
+Most requirements are `SIMULATION`; `FORMAL`/`HARDWARE` are the deliberate exception, which keeps the effort budget honest.
+
+The recommended wording is:
+
+> **When** `<condition>`, the IP **MUST** `<observable behavior>` **within** `<limit>`.
+
+This template is guidance rather than mandatory grammar.
+
+**Requirement format.** Each requirement is a short labeled block:
+
+```
+#### <ID>
+- Description: <condition> → <observable action> [within <limit>], using only boundary signals.
+- Rationale: the *why* (Description is the *what*; the RTL is the *how*).
+- Provenance: where it came from — see §7.
+```
+
+Keep the block self-contained and free of inlined analysis: everything needed to write
+the test belongs in the Description.
+
+## 3.1 Document Structure
+
+A spec document is laid out as:
+
+1. **Module boundary** — an opening chapter listing every boundary signal and build
+   parameter in a table. This is the controlled vocabulary (§9): a requirement may name
+   nothing else.
+2. **Requirement blocks**, grouped into sections by function (reset, command stream,
+   each instruction, …), each in the format above.
+
+Non-requirement material (flags §8, provenance analysis, RTL notes) lives in separate
+documents (§10) so the spec stays small enough to grep and load one requirement at a
+time.
+
+## 4. Good Requirements
+
+Good requirements are:
+
+- atomic;
+- unambiguous;
+- testable;
+- implementation-independent;
+- device/protocol-facing.
+
+For example:
+
+❌
+
+> The execution FSM enters WAIT_IO after asserting `cmd_valid_d1`.
+
+✔
+
+> When outbound data is unavailable, the IP MUST delay the SPI transfer until the data becomes available.
+
+The same rewrite applied to more cases from the current RTL-derived draft:
+
+| Implementation-level (avoid) | Behavioral requirement (prefer) |
+|------------------------------|--------------------------------|
+| "`cs_activate` is asserted for one cycle to reset the SDI shift registers." | "When a chip-select is asserted, any residual receive state from a prior transaction is cleared before the new transaction captures data." |
+| "`sdo_t_int = ~sdo_enabled` during transfer; `sdo_t`=1 otherwise." | "SDO is actively driven only during a write transfer; at all other times it is tri-stated." |
+| "Sleep uses `sleep_counter` compared against `cmd_d1_time`." | "A sleep instruction stalls command execution for `2+(t+1)·(div+1)·2` core clocks, then resumes." |
+
+## 5. Requirement Code Smells
+
+During review, ask:
+
+- Can one test fail while another behavior still passes?
+  - → Split the requirement.
+
+- Would changing the RTL architecture require rewriting this requirement?
+  - → It probably describes the implementation.
+
+- Could two engineers interpret this differently?
+  - → It is ambiguous.
+
+- Could a verification engineer write a test from this requirement alone?
+  - → If not, it is incomplete.
+
+- Does it contain words such as *correctly*, *normally*, *efficiently*, *appropriately* or *quickly*?
+  - → Replace them with measurable behavior.
+
+These heuristics are often more valuable than rigid grammar rules.
+
+## 6. Source Hierarchy
+
+Behavior should be derived from sources in the following order:
+
+1. ADI `.rst` documentation.
+2. Linux / no-OS drivers.
+3. SPI protocol and external device datasheets.
+4. RTL (only when previous sources are silent).
+
+The RTL is **never** the preferred specification source.
+
+If a behavior is derived solely from the RTL, it MUST be identified as **RTL-CHARACTERIZED** rather than documented intent.
+
+## 7. Requirement Provenance
+
+Provenance answers one question: **where did this requirement come from?** Give the
+reader enough to locate the source — a tag plus, where useful, the specific file /
+driver / datasheet section. One source per requirement:
+
+| Tag               | Source                                                        |
+| ----------------- | ------------------------------------------------------------- |
+| DOCUMENTED        | ADI documentation (`.rst`).                                   |
+| EXTERNAL          | SPI protocol or device datasheet.                             |
+| RTL-CHARACTERIZED | Observable only in the RTL — a regression lock, not intent.   |
+
+Only an `EXTERNAL` mismatch is a genuine bug; a `RTL-CHARACTERIZED` mismatch just means
+the model drifted from the RTL.
+
+Optional qualifiers, kept terse:
+
+- `DOCUMENTED (non-independent)` — the doc merely restates the RTL (same team wrote both).
+- `(drivers)` / `(Linux)` / `(no-OS)` — a reference driver depends on this behavior.
+
+Combine tags when several sources apply (e.g. `EXTERNAL + DOCUMENTED`).
+
+## 8. Suspicious Behavior
+
+The value of requirement authoring is not transcription—it is engineering judgment.
+
+Flag behaviors that are:
+
+- undocumented;
+- inconsistent with documentation;
+- inconsistent with protocol or datasheets;
+- inconsistent with software usage;
+- likely implementation accidents;
+- correct but unusually fragile.
+
+Do **not** silently rewrite suspicious behavior into the "expected" behavior.
+
+Instead record:
+
+```
+Observed behavior
+↓
+Why it is suspicious
+↓
+Authority that can resolve it
+↓
+Proposed intended behavior (optional)
+```
+
+## 9. Scope
+
+Specify only behavior observable at **this module's boundary**.
+
+Define that boundary once, up front, as an explicit table of the signals (and build
+parameters) a requirement is allowed to name — a **controlled vocabulary**. A
+requirement that reaches for a term outside this table is almost certainly describing
+the implementation, not the behavior.
+
+Out-of-scope behavior should reference the responsible module instead of restating its requirements.
+
+State any parameter/configuration domain over which the requirement applies.
+
+Explicitly identify known coverage holes. The absence of a requirement is a coverage
+gap, never implied coverage.
+
+## 10. Traceability
+
+Requirements are maintained in Markdown.
+
+The behavioral spec and any RTL-implementation notes MUST be kept in **separate documents**. An RTL-derived, signal-level description is a useful implementation reference but is **not** the spec and MUST NOT be the golden model's source — mixing the two reintroduces the circular dependency this guideline exists to prevent.
+
+The same applies to all non-requirement material: flags (§8), provenance analysis, and
+driver evidence each live in their own document. The spec holds only requirements and
+the boundary vocabulary, keeping it small enough to grep and load one requirement at a
+time.
+
+Avoid cross-document links between these companions. A link chain turns one edit into a
+maintenance cascade. Prefer stable IDs a `grep` resolves over hard-coded pointers.
+
+IDs are **append-only**: never renumber or reuse an ID. Retire a requirement by marking
+it deprecated in place; only ever append new IDs.
+
+RTL and verification contain lightweight trace comments referencing requirement IDs. A
+`REQ:` trace tag MUST name fully-expanded individual IDs, not a grouped shorthand (e.g.
+`FOO-01/02`), so a plain `grep` reconciles spec ↔ RTL ↔ verification exactly.
+
+Trace comments should be placed **as close as possible** to the implementation or verification logic that satisfies the requirement.
+
+A requirement should normally require:
+
+- one RTL trace;
+- one verification trace.
+
+If many trace comments are required, review whether the requirement should be decomposed into smaller, more atomic requirements.
+
+# 11. Definition of Done
+
+A requirement is complete when all of the following are true:
+
+- [ ] Unique ID.
+- [ ] One observable behavior.
+- [ ] Uses RFC-2119 terminology.
+- [ ] Describes *what*, not *how*.
+- [ ] Stable under RTL refactoring.
+- [ ] Explicit conditions.
+- [ ] Measurable and testable; timing as a closed-form relation to inputs, not a cycle trace.
+- [ ] Brief rationale (describes why).
+- [ ] Verification method identified (optional).
+- [ ] Provenance tagged.
+- [ ] Applicable parameter/configuration domain stated.
+- [ ] Any uncertainty recorded as a `FLAG`.

--- a/testbenches/ip/spi_engine/execution/doc/guideline_for_writing_testcases.md
+++ b/testbenches/ip/spi_engine/execution/doc/guideline_for_writing_testcases.md
@@ -1,0 +1,309 @@
+# Testbench Elaboration Guideline (for LLM implementers)
+
+**Audience:** an LLM (or engineer) turning behavioral requirements into test cases.
+**Purpose:** define *how* a requirement-driven, clean-room testbench MUST be composed,
+with a short *why* per rule. Normative guideline, not a tutorial. IP-agnostic: it
+applies to any IP whose requirements were authored per the requirement-writing
+guideline.
+
+Keywords **MUST**, **MUST NOT**, **SHOULD** follow RFC-2119.
+
+---
+
+## 0. Philosophy
+
+The RTL predates the testbench, so an LLM asked to test it tends to mirror the RTL —
+which bakes the RTL's bugs into the check and ties the two together so neither can
+change alone. The clean-room answer:
+
+- **Requirements are the ground truth**, not the RTL. Behavioral, black-box
+  requirements are derived first (separate guideline); the TB is written from *them*.
+- **What / Why / How:** requirements state the *what* and *why*; the RTL is the *how*.
+  The TB checks the *what* at the boundary — never the *how*.
+- **Atomic → one test per requirement.** A small requirement maps to one focused test,
+  keeping context windows small and letting an LLM validate its own work and loop.
+- **Bidirectional traceability:** greppable `REQ:` tags link requirement ↔ test (↔ RTL),
+  so coverage closure is a `grep`, not a reading exercise.
+
+The rest of this document makes these concrete.
+
+---
+
+## 1. Foundational principle — two independent implementations
+
+- **1.1 — MUST** treat every test as *two independent implementations of a requirement,
+  compared at the boundary*: the RTL vs a golden model, reconciled by a scoreboard.
+  *Why:* a single implementation checked against itself proves nothing.
+- **1.2 — MUST** write the golden model from the **requirements**, never by transcribing
+  RTL logic. *Why:* a model that mirrors the RTL inherits its bugs and the comparison
+  becomes circular.
+- **1.3 — MUST** assert pass/fail only on **observable boundary signals** (the ports and
+  streams named in the requirements' boundary vocabulary). *Why:* internal state is not
+  the contract; checking it re-couples the TB to the RTL and breaks on legal refactors.
+- **1.4 — MUST NOT** reference internal DUT signals (counters, pipeline regs, FSM state)
+  in any **pass/fail assertion**. *Why:* same as 1.3.
+- **1.5 — MAY** read internal signals for **debug/logging** and for **stimulus/sampling
+  timing** where a pure black-box view would be ambiguous (e.g. gating a monitor so it
+  stays in lock-step under backpressure). *Why:* generating *correct* stimulus is not
+  the same as *asserting* on internals; the pass/fail check still lives on boundary
+  signals.
+- **1.6 — MUST**, whenever 1.5 is used, confine the access to the single coupling layer
+  (§4.1, never in `test_*`) and comment *why* the black-box view is insufficient.
+  *Why:* keeps white-box coupling in one file, so a signal rename breaks one place and
+  is flagged for review on refactor.
+- **1.7 — MUST** write **real** tests that drive the DUT and assert on its actual output.
+  A test **MUST NOT** be a placeholder or stub — no `assert True`/`assert False`, no
+  hard-coded pass, no assertion on a value the test itself just computed without involving
+  the DUT. Every test MUST be able to fail for a real behavioral reason. *Why:* a mock
+  test reports green while verifying nothing — worse than no test, because it hides the
+  gap. If a behavior cannot be driven yet, leave it untested and record the hole (§6.4,
+  §11.3), do not fake it.
+
+---
+
+## 2. Tiered structure — dependencies point inward
+
+Place new code in the correct tier:
+
+- **2.1 — MUST** keep the **generic tier** protocol- and DUT-agnostic: stream
+  driver/monitor, backpressure, reset, scoreboard, RNG. *Why:* reused by every IP.
+- **2.2 — MUST** keep the **protocol tier** protocol-aware but DUT-agnostic: the
+  encoding codec, passive bus monitor, protocol BFM. It MUST NOT hard-code this DUT's
+  parameters or pinout. *Why:* reused across all IPs of that protocol.
+- **2.3 — MUST** confine everything specific to this DUT to the **DUT tier**: harness,
+  golden model, tests. *Why:* isolates DUT knowledge to one place.
+- **2.4 — MUST NOT** import an outer tier from an inner one. Dependencies point only
+  inward. *Why:* an inward-pointing import graph is what makes inner tiers reusable.
+- **2.5 — MUST** add new reusable capability to the innermost tier where it is still
+  general. *Why:* prevents DUT-specific leakage into shared code.
+
+---
+
+## 3. The encoding is a shared contract
+
+- **3.1 — MUST** encode commands/transactions — in **both** stimulus and golden model —
+  through a single shared codec. *Why:* if both share one encoder, a mis-encoded input
+  cannot silently agree with itself.
+- **3.2 — MUST NOT** hand-assemble raw command/register words inline in a test.
+  *Why:* bypasses the contract and drifts from the RTL decoder.
+- **3.3 — MUST** update the codec (and only the codec) when the encoding changes, then
+  re-run the suite. *Why:* one source of truth for the encoding.
+
+---
+
+## 4. Single coupling point & one-way parameters
+
+- **4.1 — MUST** make one harness the *only* place that maps transactions ↔ DUT signals.
+  Tests speak transactions; the framework speaks signals; the harness translates.
+  *Why:* a pinout change touches exactly one file.
+- **4.2 — MUST** flow parameters one way only: build config → env → **both** RTL generics
+  **and** the golden model. *Why:* keeps model and silicon in lockstep; a value set in
+  one place only would desync them.
+- **4.3 — MUST NOT** duplicate a parameter's default independently in the model and the
+  RTL. Derive both from the single source. *Why:* silent model/DUT divergence is the
+  hardest bug class to spot.
+
+---
+
+## 5. Reproducibility (seeded randomness)
+
+- **5.1 — MUST** derive every random event (stimulus, backpressure, slave data, reset
+  timing) from one master seed. *Why:* hardware bugs are often intermittent; an
+  unreproducible failure is nearly useless.
+- **5.2 — MUST** log the seed each run and support replay from it. *Why:* turns a flaky
+  discovery into a deterministic repro.
+- **5.3 — MUST NOT** call any unseeded/global RNG. Request a labelled child RNG from the
+  seeded context. *Why:* an unseeded call is invisible to replay.
+- **5.4 — MUST**, when a seed exposes a bug, promote that scenario to a permanent
+  **directed** test. *Why:* random coverage is probabilistic; a directed test guarantees
+  the corner stays covered.
+
+---
+
+## 6. Golden-model fidelity (hybrid)
+
+- **6.1 — MUST** model **data** at transaction level and check it **exactly** (no
+  tolerance): given inputs, predict the exact output words/bits/states. *Why:* data
+  correctness is exact by nature.
+- **6.2 — MUST** model **timing** by the requirement's closed-form formula and check with
+  a small **±1-cycle tolerance**. Derive the formula from the requirement by ID; never
+  copy a magic number, make it parametric with explicit names. *Why:* pipeline stages
+  add fixed small offsets that are legal, not bugs — and a copied constant silently
+  drifts when the requirement changes.
+- **6.3 — MUST NOT** model pipeline register contents or internal counters/latencies.
+  *Why:* re-couples the model to RTL internals (violates 1.2) and makes it brittle.
+- **6.4 — MUST** document, at the top of the model, any behavior it deliberately does not
+  cover. *Why:* an undocumented gap reads as coverage that does not exist.
+
+---
+
+## 7. Composing a test case
+
+- **7.1 — MUST** trace every test to at least one requirement ID with a **greppable,
+  punctual tag** on the line closest to the code that exercises it (the assertion or the
+  provoking stimulus), **not** in the docstring:
+
+  ```
+  # REQ: <requirement-id> - <optional brief comment>
+  ```
+
+  - **Exactly one ID per tag** — no commas, ranges, or wildcards. Two requirements near
+    the same code get two separate `# REQ:` lines.
+  - **Every testcase MUST carry a tag; a requirement MAY have many test homes.** There is
+    **no cap** on how many tests cite one ID. Ideally each requirement maps to a single
+    focused test (§0); nuance or specific conditions may split it across a few. A test
+    that exercises a requirement without its own tag is invisible to the coverage grep, so
+    tag it rather than cross-referencing in prose.
+  - The ID MUST exist in the requirements document.
+
+  *Why:* a machine-checkable trace lets a script prove coverage closure by grepping, which
+  prose cannot. Every test carrying a tag keeps that index complete — the grep finds all
+  coverage, not a hand-picked "canonical" subset. (The two-citation-max cap is an **RTL**
+  rule, §7.1.1 — it does not apply to tests.)
+- **7.1.1 — MUST**, for the **RTL** side of the trace, keep at most **two** `REQ:`
+  citations per requirement: the core always-block/logic that implements it, plus at most
+  one secondary site. Never scatter one ID across every module the signal touches. *Why:* a
+  requirement's signal may thread through many RTL modules while its heart is one small
+  block; capping RTL citations points the index at that heart instead of diffusing it.
+  Tests have no such cap — a testcase is a coverage point, not a signal path.
+- **7.2 — MUST** structure each test as *arrange* (config + build inputs via codec) →
+  *act* (drive through the harness) → *assert* (scoreboard compares monitor vs model).
+  *Why:* a uniform shape is reviewable and diffable.
+- **7.3 — MUST** let the scoreboard decide pass/fail and accumulate **all** mismatches
+  before failing. *Why:* one run should reveal every discrepancy, not just the first.
+- **7.4 — MUST** keep one test focused on one behavior; recombine behaviors only in
+  explicit *sequence* or *fuzz* tests. *Why:* a focused failure localizes the bug.
+- **7.5 — MUST** cover the boundary values each requirement names (zero/max length,
+  minimum/maximum, empty/full, sparse patterns, …). *Why:* bugs cluster at boundaries.
+- **7.6 — SHOULD** add a randomized/fuzz variant recombining validated behaviors under
+  random backpressure and ordering. *Why:* finds interaction bugs directed tests miss.
+- **7.7 — MUST** verify documented reset/idle values on every boundary output after any
+  reset, including resets injected mid-operation. *Why:* clean recovery from arbitrary
+  state is a core guarantee.
+- **7.8 — MUST**, when a bug is found, encode it as a test whose assertion checks the
+  **correct** (requirement-mandated) behavior, so it **fails hard on the current RTL** and
+  passes once the RTL is fixed. *Why:* a bug is a real defect; the suite MUST report it as
+  a failure, not as an expected/green result. A test that passes while the bug is present
+  hides the defect behind a wall of green.
+  - **7.8.1 — MUST NOT** use `expect_fail` (or any inverted/xfail assertion) to make a
+    known bug report as passing. The failing test stays red until the RTL is fixed; track
+    the open defect in `bug_log.md` (§7.8.2), not by flipping the test's polarity. *Why:*
+    an xfail'd bug is invisible in a green run and silently rots; a hard failure keeps the
+    defect in view until it is actually resolved.
+  - **7.8.2 — SHOULD** make that test catch the whole *class* of bug, not the single
+    observed instance — one parametric test over the failing dimension (e.g. all widths /
+    all divisors / any stall offset) rather than the one value that first tripped. *Why:*
+    a fix for the exact instance that leaves siblings broken must still fail the test.
+  - **7.8.3 — MUST** log every found bug in `bug_log.md`, one entry per bug, in the format
+    below. *Why:* a bug needs a durable, reproducible record that outlives the test.
+
+    ```
+    # <short class name> - <one-line symptom> (<flag id if any>)
+    - code revision: <repo + commit hash + branch/date the bug was characterized against>
+    - Requirement: <req-id> - <what the requirement guarantees>
+    - Test: <file::testcase> (fails on current RTL)
+    - Symptom: <observable failure, and the conditions under which it does/doesn't occur>
+    - Root cause: (<rtl file>) <mechanism>
+    - Decision needed: <RTL fix vs documented constraint, etc.>
+    - Run Command: <exact command to reproduce, incl. any params/env>
+    - Wave signals:
+      - <signal paths worth inspecting>
+    ```
+
+    The `code revision` line records the RTL each bug was characterized against, per
+    entry — the HDL revision moves, so a bug may reproduce on one revision and not
+    another; the per-entry stamp keeps each finding pinned to where it was seen.
+- **7.9 — SHOULD** push coverage through **input variation** — many stimuli/small cases —
+  rather than one monolith. Varying inputs needs no recompile; only DUT **generics** force
+  a rebuild. Keep generics fixed within a test and vary inputs freely. *Why:* input-space
+  coverage iterates far faster than anything requiring a rebuild.
+- **7.10 — SHOULD** split input variation across several independent test cases rather
+  than one large loop. *Why:* each case fails independently, so a failure localizes and
+  one bad scenario does not mask the rest.
+- **7.11 — MUST**, when a test is only meaningful under certain build/compile-time
+  configuration (DUT **generics** — e.g. a minimum `NUM_OF_SDIO`, a specific data width),
+  **skip** it on builds where it cannot be exercised, using the framework's test-skip
+  facility ("skip test" methods). **MUST NOT** substitute an `assert True`/`assert False`
+  (or any hard-coded pass/fail) to paper over a configuration in which the test does not
+  apply. *Why:* a skip is honestly reported as "not run in this configuration" and keeps
+  coverage accounting truthful, whereas a forced pass hides the gap and a forced fail
+  reports a spurious defect — either way it re-introduces the stub assertion §1.7 forbids.
+  Do **not** document *how* the skip is performed here: the mechanism is
+  framework-version-dependent and may change at any time; call the framework's current
+  skip method instead.
+- **7.12 — MUST NOT** reference this guideline from the testbench — no citation by name,
+  path, section, or rule number in any comment, docstring, or identifier. *Why:* this
+  guideline is a living, ever-evolving document; citing it creates an unnecessary
+  maintenance burden.
+
+---
+
+## 8. Backpressure & flow control
+
+- **8.1 — MUST** exercise independent random backpressure on each stream with a ready
+  signal the DUT must honor. *Why:* stalls are where handshake/flow-control bugs live.
+- **8.2 — MUST** verify backpressure causes **stall without data loss or reordering**,
+  not just "still passes". *Why:* the DUT may paper over a dropped word; check data
+  integrity, not survival.
+- **8.3 — SHOULD** inject stalls at varied bit/word/transaction boundaries. *Why:*
+  flow-control gates often behave differently at each.
+
+---
+
+## 9. Scope boundaries
+
+- **9.1 — MUST NOT** test behavior a requirement marks out-of-scope for this module
+  (belonging to a neighboring IP or the integration level). *Why:* a unit test asserting
+  a downstream effect is testing code not in the DUT.
+- **9.2 — MUST** honor a requirement that specifies *register-capture only* (input
+  accepted here, effect observable downstream) by checking only the accept, not the
+  effect. *Why:* the effect is not in this DUT's boundary.
+
+---
+
+## 10. Simulator portability & determinism
+
+- **10.1 — MUST** keep tests simulator-agnostic (pure cocotb/VPI); no vendor-specific
+  constructs in test logic. *Why:* the same test must run under multiple simulators.
+- **10.2 — MUST** confine simulator-specific flags/lint suppressions to the build file.
+  *Why:* keeps portability guarantees in one controlled place.
+- **10.3 — SHOULD** treat a 2-state simulator's lack of X/Z as covered by explicit
+  reset-value tests, not X-propagation checks. *Why:* a fast 2-state simulator cannot
+  model X; reset testing substitutes for it.
+
+---
+
+## 11. Coverage closure
+
+- **11.1 — SHOULD** give a self-contained sub-block its own small unit TB when its
+  interface is cleaner than reaching its corners through the full DUT. *Why:* sharper and
+  cheaper than driving those corners end-to-end.
+- **11.2 — SHOULD** add functional-coverage bins crossing the key parameters, paired with
+  simulator line/toggle coverage. *Why:* "ran N seeds" must become "hit every bin";
+  random effort without bins cannot prove closure.
+- **11.3 — SHOULD** keep IP-specific status — current coverage, known holes, next steps —
+  in a living status document, not here. *Why:* this guideline is method; status drifts
+  and belongs where it is maintained.
+
+---
+
+## 12. Definition of done (checklist for any new test)
+
+- [ ] Real test — drives the DUT and can fail for a behavioral reason; no stub/mock
+      assertion. *(1.7)*
+- [ ] Every testcase carries a punctual `# REQ:` tag on the closest line; one ID per tag;
+      no cap on tests per requirement (the two-citation-max is RTL-only, 7.1.1). *(7.1)*
+- [ ] Inputs built via the codec; no inline raw words. *(3.1, 3.2)*
+- [ ] Pass/fail on boundary signals only; no internal-signal assertions. *(1.3, 1.4)*
+- [ ] All randomness seeded. *(5.1, 5.3)*
+- [ ] Data checked exactly; timing checked with ±1-cycle tolerance. *(6.1, 6.2)*
+- [ ] Scoreboard-driven, accumulates all mismatches. *(7.3)*
+- [ ] Passes across multiple seeds and the relevant parameter sweep. *(4.2, 5.2)*
+- [ ] Coverage pushed through input variation, split across small independent cases. *(7.9, 7.10)*
+- [ ] Config-dependent test skips (framework skip method) on builds that cannot exercise
+      it — never a hard-coded `assert True`/`assert False`. *(7.11)*
+- [ ] Any found bug: captured as a class-generic test that asserts correct behavior and
+      thus **fails hard** on the current RTL (no `expect_fail`), and logged in
+      `bug_log.md`. *(7.8, 7.8.1, 7.8.2, 7.8.3)*
+- [ ] No reference to this guideline anywhere in the TB (name/path/section/rule); only
+      requirement IDs are cited. *(7.12)*

--- a/testbenches/ip/spi_engine/execution/doc/requirements/README.md
+++ b/testbenches/ip/spi_engine/execution/doc/requirements/README.md
@@ -1,0 +1,9 @@
+# SPI Engine Execution - Requirements
+
+**[Start here](spi_execution.spec.md)** - the actual requirements.
+Everything else is supporting evidence.
+
+- spi_execution.spec.md: the behavioral spec / requirements
+- spi_execution.rtl.md: RTL evidence backing the spec (implementation reference, not the spec).
+- spi_execution.driver.md: driver-usage evidence (no-OS / Linux) backing the spec.
+- spi_execution.findings.md: open questions and suspect-behavior flags.

--- a/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.driver.md
+++ b/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.driver.md
@@ -1,0 +1,300 @@
+# SPI Engine Execution Module — Driver Usage Reference (no-OS + Linux)
+
+> **This is NOT the specification.** Like its RTL sibling[^rtl], this file holds
+> *usage evidence*, not requirements. It records how the two **reference drivers
+> actually program** the execution module, so a designer resolving a flag — or a
+> verification engineer judging how much a test result matters — can see the concrete
+> software evidence behind a `(no-OS)`, `(Linux)`, or `(drivers)` tag in the spec. Both
+> drivers are non-independent (each SW team wrote its code from the same HDL-team docs).
+> The requirement-strength classification lives in the spec[^spec]; the code
+> mechanics behind it live here.
+
+**Structure:** Part A = no-OS reference driver; Part B = Linux mainline driver; Part C =
+the no-OS vs Linux divergence table (what one drives that the other does not).
+
+Drivers under study:
+
+- **no-OS** — paths relative to `no-os-repo/drivers/axi_core/spi_engine/`:
+  - `spi_engine.c` — command compilation, transfer/offload flow, FIFO drain
+  - `spi_engine.h` — public transfer macros (`WRITE`/`READ`/`WRITE_READ`, `CS_*`)
+  - `spi_engine_private.h` — register map, opcode/config constants, `SPI_ENGINE_CMD` encoder
+- **Linux** — `linux-repo-shallow-main/drivers/spi/spi-axi-spi-engine.c` (mainline; the
+  *modern* driver, not the separate `spi-axi-legacy-spi-engine.c`). Feature set is
+  version-gated on the IP core `ADI_AXI_REG_VERSION` (see L.3).
+
+Line references are from the revisions read on 2026-07-03; re-verify before quoting.
+
+---
+
+# Part A — no-OS reference driver
+
+---
+
+## D.1 The command sequence a `write_and_read` transfer emits
+
+`spi_engine_write_and_read` → `spi_engine_compile_message` build one command list.
+Config is *prepended* (`spi_engine_queue_append_cmd`, adds to front) and the sync is
+*appended* (`spi_engine_queue_add_cmd`, adds to end); the CS/transfer skeleton is set
+up in `write_and_read` itself. The net order written to the CMD FIFO is:
+
+| # | Instruction (boundary opcode) | Encoder / arguments |
+|---|-------------------------------|---------------------|
+| 1 | Configuration-Write `010`, reg `000` (prescaler) | `clk_div` from `ref_clk_hz / (2*max_speed_hz) - 1` (`spi_engine_init` / `spi_engine_set_speed`) |
+| 2 | Configuration-Write `010`, reg `010` (dyn. length) | `data_width`, clamped ≤ `max_data_width` in `spi_engine_set_transfer_width` |
+| 3 | Configuration-Write `010`, reg `001` (SPI config) | `desc->mode` OR `SPI_ENGINE_CONFIG_SDO_IDLE` when `sdo_idle_state != 0` |
+| 4 | Chip-Select `001`, `s=0xFF` (all deselected) | `CS_HIGH` = `SPI_ENGINE_CMD_ASSERT(0x03, 0xFF)` |
+| 5 | Chip-Select `001`, `s` = one bit cleared (select) | `spi_engine_set_cs(false)`: `mask ^= NO_OS_BIT(chip_select)`, delay = `cs_delay` |
+| 6 | Transfer `000`, `rw=11` (full-duplex), `n = words-1` | `WRITE_READ(bytes)` → `spi_engine_transfer` encodes `words_number - 1` |
+| 7 | Chip-Select `001`, `s=0xFF` (deselect) | `CS_HIGH` |
+| 8 | MISC `011`, `cmd[8]=0` (Sync), id `_sync_id` | `SPI_ENGINE_CMD_SYNC(_sync_id)` |
+
+After queuing, `spi_engine_transfer_message`:
+1. writes each SDO word to `SPI_ENGINE_REG_SDO_DATA_FIFO`,
+2. **busy-polls `SPI_ENGINE_REG_SYNC_ID` until it equals `_sync_id`, then `_sync_id++`**
+   — this poll is the driver's *sole* transfer-completion signal,
+3. drains `msg->length` words from `SPI_ENGINE_REG_SDI_DATA_FIFO`.
+
+Offload mode (`spi_engine_offload_transfer`) writes the **same** compiled command
+list to `SPI_ENGINE_REG_OFFLOAD_CMD_MEM(0)` instead of the CMD FIFO and moves data by
+DMA rather than register polling — same commands, different transport (spec basis for
+EXEC-OFF-03).
+
+---
+
+## D.2 Per-requirement code evidence (`(no-OS)` tags)
+
+For traceability of each spec item the driver corroborates:
+
+| Spec ID | Class | Driver evidence (`spi_engine.c` unless noted) |
+|---------|-------|-----------------------------------------------|
+| EXEC-SCLK-01 / EXEC-CFG-01 (`(div+1)*2` divisor) | **load-bearing** | `clk_div = ref_clk_hz / (2*speed_hz) - 1` — inverts the SCLK formula; wrong ⇒ wrong bus clock |
+| EXEC-SYNC-01 (sync id round-trip) | **load-bearing** | `SPI_ENGINE_CMD_SYNC(_sync_id)` appended per message; polled at `SPI_ENGINE_REG_SYNC_ID` |
+| EXEC-CFG-02 (config bit layout) | **load-bearing** | `spi_engine_private.h`: `CONFIG_CPHA/CPOL/3WIRE/SDO_IDLE` = `NO_OS_BIT(0..3)` |
+| EXEC-XFER-01 (`n` zero-based) | **load-bearing** | `spi_engine_transfer` encodes `words_number - 1` |
+| EXEC-CFG-06 (width ≤ DATA_WIDTH) | **load-bearing** | `spi_engine_set_transfer_width` clamps to `max_data_width` (read from `SPI_ENGINE_REG_DATA_WIDTH` at init) |
+| EXEC-SDO-02 / EXEC-SDI-01 (MSB align) | **load-bearing** | pack `data[i] << (data_width - (i%word_len + 1)*8)`; unpack symmetric in `write_and_read` |
+| EXEC-CS-01/02 (active-low, prescaled delay) | **load-bearing** | select clears one bit (field-bit-0 = selected); `cs_delay` in the `t` field of `SPI_ENGINE_CMD_ASSERT` |
+| EXEC-SLEEP-01 (`(t+1)` form) | **load-bearing** | `spi_get_sleep_div`: `sleep_div = …/((clk_div+1)*2) - 1` (pre-`-1` ⇒ HW adds it back) |
+| EXEC-XFER-05 (full-duplex) | load-bearing (core) | core `write_and_read` emits only `WRITE_READ` (`rw=11`) |
+| EXEC-XFER-05 (write-only / read-only) | driven elsewhere | `WRITE`/`READ` macros defined in `spi_engine.h`, used by device drivers, not the core path |
+| EXEC-OFF-03 (same cmds / diff transport) | load-bearing (offload) | `spi_engine_offload_transfer` reuses the compiled list via `OFFLOAD_CMD_MEM` + DMA |
+| EXEC-CSINV-* (CS-invert) | not driven — see D.3 / FLAG F8 | no macro; opcode unreachable by encoder |
+| EXEC-CFG-04/05, EXEC-LANE-*, EXEC-CC-08 (lane masks) | not driven — see D.3 / FLAG F9 | neither lane-mask register ever written |
+| EXEC-CS-05 (sparse multi-select) | not driven | driver only single-selects or fully deselects (`0xFF`) |
+
+---
+
+## D.3 Encoder / doc gaps surfaced by the driver
+
+- **2-bit opcode encoder (FLAG F8).** `spi_engine_private.h` `SPI_ENGINE_CMD(inst,
+  arg1, arg2)` masks the opcode with `((inst & 0x03) << 12)` — only 2 bits — yet the
+  instruction set defines a 3-bit `cmd[14:12]` opcode with `100` = CS-Invert-Mask.
+  Opcode `100` aliases to `000` (Transfer) under this mask, so the driver cannot
+  encode CS-invert; it also defines no macro for it and never emits it. Any software
+  needing CS-invert must bypass `SPI_ENGINE_CMD`. See F8 in the spec for the
+  expected-SW-lag framing.
+- **Lane-mask registers never written (FLAG F9).** `spi_engine_compile_message`
+  emits exactly three Configuration-Writes — prescaler `000`, dyn-length `010`, SPI
+  config `001`. Neither the SDI lane mask (`011`) nor the SDO lane mask (`100`) is
+  written by the core driver, so both stay at their reset default (all lanes active)
+  for a stock transfer. Consistent with multilane being a recent HDL addition the
+  reference SW has not yet caught up to.
+- **Sleep-formula tie-break (FLAG F3).** `spi_get_sleep_div`'s `-1` pre-decrement
+  matches `instruction-format.rst`'s `(t+1)` formula, not `pipeline-delays.rst`'s `t`
+  formula — a second (non-independent) vote for `(t+1)`. Still needs direct RTL
+  measurement to be authoritative.
+- **`SDI_DELAY` / `ECHO_SCLK` absent from the driver.** The driver exposes neither
+  (consistent with FLAG F5 — they are build-time-only RTL parameters). `sdo_idle_state`
+  *is* a driver-level concept (`spi_engine_desc.sdo_idle_state`, folded into the SPI
+  config byte), consistent with EXEC-PARAM-06 / EXEC-XFER-06.
+
+---
+
+---
+
+# Part B — Linux mainline driver
+
+The Linux `spi-axi-spi-engine` driver is a *fuller* user of the module than the no-OS
+core path: it drives CS-invert and lane masks, emits half-duplex transfers, and uses an
+interrupt (not a busy-poll) for message completion. Crucially, most of its extra reach
+is **version-gated** on the IP core version (L.3) — which is why the older-style no-OS
+core path does not exercise the same features. This is the concrete evidence that closes
+the previously-open FLAG F8 and FLAG F9 as *no-OS lag*, not spec problems.
+
+## L.1 How the Linux driver generates a command program
+
+`spi_engine_optimize_message` compiles each `spi_message` **once** (a dry pass sizes the
+buffer, then a real pass fills it — `spi_engine_compile_message`, lines 804–844) and
+caches it in `msg->opt_state`. `spi_engine_transfer_one_message` then streams that
+program to the CMD FIFO. For a simple single-transfer message the emitted order is:
+
+| # | Instruction (boundary opcode) | Encoder / arguments |
+|---|-------------------------------|---------------------|
+| 1 | Configuration-Write `010`, reg `001` (SPI config) | `spi_engine_get_config`: CPOL/CPHA/3WIRE/SDO_IDLE from `spi->mode` (lines 210–226) |
+| 2 | Chip-Select `001`, `s` = one bit cleared (assert) | `spi_engine_gen_cs`: `mask=0xff ^ BIT(cs)`, **delay `t`=0** always (lines 281–290) |
+| 3 | Configuration-Write `010`, reg `000` (prescaler) | only if `clk_div` changed: writes `clk_div-1`, "actual divider = reg+1" (lines 434–441) |
+| 4 | Configuration-Write `010`, reg `010` (xfer bits) | only if `bits_per_word` changed (lines 443–448) |
+| 5 | Transfer `000`, flags from tx/rx presence, `n = words-1` | `spi_engine_gen_xfer`: `WRITE` if `tx_buf`, `READ` if `rx_buf`; splits into ≤256-word chunks (lines 228–256) |
+| 6 | MISC `011` Sleep (`cmd[8]=1`), `t = periods-1` | only if `xfer->delay` exceeds one instruction time (lines 258–279) |
+| 7 | Chip-Select `001`, `s=0xFF` (deselect) | `spi_engine_gen_cs(assert=false)` unless `keep_cs` (lines 454–475) |
+| 8 | MISC `011` Sync (`cmd[8]=0`), id `AXI_SPI_ENGINE_CUR_MSG_SYNC_ID` (=1) | appended in `optimize_message` for non-offload (lines 828–830) |
+
+Completion is **interrupt-driven**: `spi_engine_irq` handles `INT_SYNC`, reads
+`SPI_ENGINE_REG_SYNC_ID`, and only completes the message when the id matches
+`AXI_SPI_ENGINE_CUR_MSG_SYNC_ID` (lines 658–711). The same handler refills the CMD/SDO
+FIFOs and drains the SDI FIFO on the `*_ALMOST_*` interrupts. (The synchronous
+`spi_engine_setup`/`spi_engine_trigger_enable` paths *do* busy-poll `SYNC_ID`, lines
+925–926, 1030–1031 — the same round-trip, different transport.)
+
+**`spi_engine_setup` (IP v1.2+)** runs once per device and emits, framed by Sync(0)/Sync(1):
+a **CS-Invert-Mask** write `SPI_ENGINE_CMD_CS_INV(cs_inv)` (line 899), optionally the
+initial lane masks when `num_data_lanes>1` (lines 902–913), then a CS-assert to latch the
+inversion (lines 919–920). `cs_inv` is a shadow of the per-device `SPI_CS_HIGH` mode bit
+(lines 891–894).
+
+**Offload** (`spi_engine_offload_prepare`, lines 713–789) writes the *same* compiled
+`p->instructions[]` list to `OFFLOAD_CMD_FIFO` and the tx words to `OFFLOAD_SDO_FIFO`,
+then execution is trigger-driven with DMA streaming — same commands, different transport
+(spec EXEC-OFF-03). Config/xfer-bits/lane-masks for offload are set once in
+`spi_engine_trigger_enable` rather than per message (lines 999–1041).
+
+## L.2 Per-requirement code evidence (`(Linux)` / `(drivers)` tags)
+
+| Spec ID | Class | Linux evidence (`spi-axi-spi-engine.c`) |
+|---------|-------|------------------------------------------|
+| EXEC-CMD-03 (3-bit opcode) | **load-bearing (Linux)** | `SPI_ENGINE_CMD(inst,a1,a2)=(inst<<12)|…` — **no opcode mask**; `INST_CS_INV=0x4` defined and emitted (lines 76, 93, 899). Full opcode reach — contrast no-OS's 2-bit mask. |
+| EXEC-CSINV-* (CS-invert `100`) | **load-bearing (Linux)** | `SPI_ENGINE_CMD_CS_INV(cs_inv)` in `setup()`; `cs_inv` tracks `SPI_CS_HIGH` (lines 76, 106–107, 885–927). This is the mechanism behind active-high CS. |
+| EXEC-CFG-04/05 & EXEC-LANE-* (lane masks) | **load-bearing (Linux), v2.0+** | `REG_SDI_MASK=0x3`, `REG_SDO_MASK=0x4`; masks from `rx_lane_map[]`/`tx_lane_map[]` written per-message (414–430), in `setup()` (902–913), and offload (1018–1025). Gated on `num_data_lanes` (IP major ≥2). |
+| EXEC-SCLK-01 / EXEC-CFG-01 (`(div+1)*2`) | **load-bearing (drivers)** | `clk_div = max_speed_hz/effective_speed_hz`, writes `clk_div-1`, comment "actual divider = register value + 1"; `max_speed_hz = ref_clk/2` (434–441, 1220). |
+| EXEC-CFG-02 (config bit layout) | **load-bearing (drivers)** | `CONFIG_CPHA/CPOL/3WIRE/SDO_IDLE_HIGH = BIT(0..3)` (lines 67–70). Identical to no-OS. |
+| EXEC-XFER-01 (`n` zero-based) | **load-bearing (drivers)** | `CMD_TRANSFER(flags, n-1)`, `n=min(len,256)` (lines 244–253). |
+| EXEC-XFER-05 (all `{r,w}` combos) | **load-bearing (Linux), core path** | flags set from `tx_buf`/`rx_buf` per transfer → emits write-only, read-only, and full-duplex directly in the core path (lines 245–250). no-OS core emits only `11`. |
+| EXEC-SDO-02 / EXEC-SDI-01 (MSB align) | **load-bearing (drivers)** | Linux writes native-width words to the FIFO and relies on HW left-alignment (lines 574–656); corroborates the alignment is a *hardware* behavior. |
+| EXEC-CS-01 (active-low select) | **load-bearing (drivers)** | `mask = 0xff ^ BIT(cs)` (lines 284–289). Field bit 0 = selected. |
+| EXEC-CS-03 (`t=0` CS, no pre/post wait) | **load-bearing (Linux)** | `gen_cs` always emits `ASSERT(0, mask)` — Linux never uses the ASSERT delay field. |
+| EXEC-SYNC-01 (sync id round-trip) | **load-bearing (drivers)** | id round-trip is the completion signal in both; Linux via **IRQ** (658–711), no-OS via poll. |
+| EXEC-SLEEP-01 (`(t+1)` form) | **load-bearing (drivers)** | `gen_sleep` encodes `SLEEP(n-1)` after subtracting one instruction time (`inst_ns`) — same `-1` pre-decrement as no-OS; votes `(t+1)` and the `2+` overhead (lines 258–279, 384). |
+| EXEC-OFF-03 (same cmds / diff transport) | **load-bearing (Linux), offload** | `offload_prepare` reuses `p->instructions[]` via `OFFLOAD_CMD_FIFO` + DMA (lines 763–789). |
+| EXEC-CFG-06 (width ≤ DATA_WIDTH) | **not enforced by Linux** — see L.3 / FLAG F6 | Linux hardcodes `bits_per_word_mask = 1..32` and does not clamp to the HW DATA_WIDTH field (lines 1219, 1185). |
+| EXEC-CS-02 (prescaled pre/post CS delay, `t>0`) | not driven by Linux | Linux uses separate Sleep commands for `cs_change_delay`; the ASSERT `t` field stays 0. Driven by no-OS only. |
+| EXEC-CS-05 (sparse multi-select) | not driven | Linux single-selects (`0xff ^ BIT(cs)`) or fully deselects (`0xff`) only, like no-OS. |
+
+## L.3 Encoder / version gating surfaced by the Linux driver
+
+- **Full 3-bit opcode encoder (resolves FLAG F8).** Linux's `SPI_ENGINE_CMD` applies
+  **no opcode mask**, so it reaches all five opcodes including `100`=CS-Invert-Mask,
+  which it *actively emits* from `spi_engine_setup` to implement `SPI_CS_HIGH`. This
+  makes the no-OS `(inst & 0x03)<<12` mask (Part A / D.3) a **no-OS encoder limitation**,
+  not a spec gap or a universal SW lag: CS-invert is a real, driven, documented feature.
+- **Lane masks are driven, and version-gated (resolves FLAG F9).** Linux writes both
+  `REG_SDI_MASK` (`011`) and `REG_SDO_MASK` (`100`) from the device's lane maps. The
+  multi-lane (`STRIPE`) path is enabled only when `host->num_data_lanes` is read from the
+  DATA_WIDTH register on **IP core major version ≥ 2** (lines 1237–1239). So multi-lane
+  is literally a v2.0 capability — corroborating that it is a recent HDL addition the
+  no-OS core has not caught up to, exactly as F9 framed it.
+- **Feature/version gating explains the no-OS↔Linux gap.** From `spi_engine_probe`:
+  CS-invert + `setup()` require IP **v1.2+** (lines 1230–1233); `SPI_MOSI_IDLE_*`
+  (sdo_idle) require **v1.3+** (lines 1234–1235); multi-lane requires **v2.0+**
+  (1237–1239); offload memory sizing and the "SYNC no longer required for offload" relax
+  are **v1.1+ / v1.5+** (lines 1187–1201). Version gating is the reason two ADI drivers
+  legitimately drive different feature subsets.
+- **Word length not clamped to DATA_WIDTH (strengthens FLAG F6).** Unlike no-OS, Linux
+  advertises `bits_per_word_mask = SPI_BPW_RANGE_MASK(1, 32)` and reads the DATA_WIDTH
+  register only for the *lane-count* field — it never clamps `bits_per_word` to the HW
+  transfer-width field. On a `DATA_WIDTH<32` build a client could request a `bits_per_word`
+  the module treats as out-of-range (FLAG F6's underflow region). Neither driver *defines*
+  behavior there; no-OS avoids it by clamping, Linux does not guard it at all.
+- **Completion by interrupt, not poll.** Linux completes messages from `spi_engine_irq`
+  on `INT_SYNC` with a matching `SYNC_ID` (lines 658–711); it busy-polls `SYNC_ID` only in
+  the synchronous `setup`/`trigger_enable` paths. This is a *transport* difference from
+  no-OS's universal busy-poll; the boundary contract (EXEC-SYNC-01: id round-trip gates
+  completion) is identical.
+- **`SDI_DELAY` / `ECHO_SCLK` absent from Linux too.** Like no-OS, the Linux driver
+  exposes neither — consistent with FLAG F5 (build-time-only RTL parameters). `SDO_IDLE`
+  *is* a Linux mode bit (`SPI_MOSI_IDLE_HIGH`/`_LOW`, v1.3+), consistent with
+  EXEC-XFER-06 / EXEC-PARAM-06.
+
+---
+
+# Part C — no-OS vs Linux divergence
+
+Both drivers are non-independent and agree on the core boundary contract. Where
+they *differ*, it is almost always **feature reach** (Linux drives more, gated on IP
+version) or **transport** (how data/completion move), not a contradiction about what the
+module does. Divergences that touch a requirement's strength:
+
+| Aspect | no-OS | Linux | Effect on spec |
+|--------|-------|-------|----------------|
+| Opcode encoder width | 2-bit mask (`&0x03`) — can't emit `100` | full 3-bit, emits `100` | **F8 resolved**: no-OS encoder limit, not spec gap; EXEC-CMD-03 / CSINV-* gain `(Linux)` |
+| CS-Invert-Mask (`100`) | never emitted | emitted in `setup()` for `SPI_CS_HIGH` | EXEC-CSINV-* → **load-bearing (Linux)** |
+| Lane masks (`011`/`100`) | never written | written (per-msg, setup, offload), **v2.0+** | **F9 resolved**: EXEC-CFG-04/05, EXEC-LANE-* → **load-bearing (Linux)** |
+| Transfer duplex in core path | full-duplex `11` only | write-only/read-only/full per `tx/rx_buf` | EXEC-XFER-05 `01`/`10` → **load-bearing (Linux)** |
+| CS delay | prescaled `t` in ASSERT field | ASSERT `t`=0 + separate Sleep for `cs_change_delay` | EXEC-CS-02 driven by **no-OS only**; EXEC-CS-03 by both |
+| Word-length vs DATA_WIDTH | clamps to readback | **no clamp** (`bpw_mask 1..32`) | **strengthens F6**: reference SW does not universally enforce the constraint |
+| Completion transport | busy-poll `SYNC_ID` | **IRQ** on `INT_SYNC` (poll only in setup) | EXEC-SYNC-01 boundary identical; transport differs |
+| SDO byte packing | explicit shift/align in SW | native words to FIFO, HW aligns | EXEC-SDO-02 confirmed as **HW** behavior |
+| Sleep sizing | `-1` pre-decrement | `-1` + subtract one instruction time | **both vote `(t+1)`** (F3) |
+
+**Net:** the two open TODO flags (F8, F9) are resolved by Linux as *no-OS lag*, not spec
+problems. F6 is *strengthened* (Linux is less defensive than no-OS). F3 gains a second
+`(t+1)` vote. No divergence forces a new flag: every difference is version-gated feature
+reach or transport, consistent with a single boundary contract.
+
+---
+
+## Requirement-Strength Cross-Check
+
+**Sources:** the **no-OS** reference driver (`no-os-repo/drivers/axi_core/spi_engine/`)
+and the **Linux** mainline `spi-axi-spi-engine` driver. This section grades *how much a
+verification result matters* — separating **load-bearing** behavior (a real deployment
+breaks if the RTL disagrees) from behavior **not driven** by any reference SW — and
+records which driver depends on each behavior and whether the dependence is
+**version-gated**. The code-level evidence is Part A (no-OS), Part B (Linux), and
+Part C (divergence) above.
+
+Driver key: **✓** driven, **—** not driven, **(gate)** version-gated.
+
+| Behavior (requirement) | no-OS | Linux | Strength | Note |
+|------------------------|:-----:|:-----:|----------|------|
+| SCLK divisor `(div+1)*2` (EXEC-SCLK-01/CFG-01) | ✓ | ✓ | **load-bearing (drivers)** | both invert the formula to set the bus clock |
+| Sync id round-trip (EXEC-SYNC-01) | ✓ | ✓ | **load-bearing (drivers)** | sole transfer-done signal; no-OS polls, Linux IRQ |
+| SPI-config bit layout (EXEC-CFG-02) | ✓ | ✓ | **load-bearing (drivers)** | CPHA/CPOL/3WIRE/SDO_IDLE = 0/1/2/3 |
+| Transfer `n` zero-based (EXEC-XFER-01) | ✓ | ✓ | **load-bearing (drivers)** | encodes `words - 1`, ≤256/instr |
+| MSB-first / MSB-aligned (EXEC-SDO-02, EXEC-SDI-01) | ✓ | ✓ | **load-bearing (drivers)** | no-OS aligns in SW; Linux relies on HW alignment |
+| Active-low CS (EXEC-CS-01), `t=0` CS (EXEC-CS-03) | ✓ | ✓ | **load-bearing (drivers)** | field bit 0 = selected |
+| Sleep `(t+1)` prescaler form (EXEC-SLEEP-01) | ✓ | ✓ | **load-bearing (drivers)** | both pre-decrement; see FLAG F3 |
+| Offload same-cmds/diff-transport (EXEC-OFF-03) | ✓ | ✓ | **load-bearing (drivers), offload** | reuse compiled list via cmd-mem + DMA |
+| Full 3-bit opcode / CS-Invert-Mask (EXEC-CMD-03, EXEC-CSINV-*) | — | ✓ | **load-bearing (Linux)** | Linux drives `SPI_CS_HIGH` (v1.2+); no-OS encoder is 2-bit → **FLAG F8 resolved** |
+| SDI/SDO lane masks + multi-lane (EXEC-CFG-04/05, EXEC-LANE-*, EXEC-CC-08) | — | ✓ (gate) | **load-bearing (Linux), v2.0+** | Linux drives from `lane_map`; no-OS targets earlier cores → **FLAG F9 resolved** |
+| Write-only / read-only Transfer in core path (EXEC-XFER-05 `01`/`10`) | dev | ✓ | **load-bearing (Linux) core; device-driver (no-OS)** | Linux core sets flags from tx/rx presence |
+| Prescaled CS pre/post delay via ASSERT `t` (EXEC-CS-02) | ✓ | Sleep | **(no-OS) only** | Linux uses separate Sleep commands instead |
+| Word length ≤ `DATA_WIDTH` (EXEC-CFG-06) | ✓ clamp | — | **(no-OS) enforces; Linux does not** | Linux `bpw_mask 1..32`, no clamp → **strengthens FLAG F6** |
+| Full-duplex Transfer `rw=11` (EXEC-XFER-05) | ✓ | ✓ | **load-bearing (drivers)** | both emit it |
+| Clock-only/dummy Transfer `rw=00` (EXEC-XFER-05) | — | — | **not driven** | neither driver emits it |
+| Sparse multi-CS select (EXEC-CS-05) | — | — | **not driven** | both single-select or fully deselect only |
+
+Legend: **dev** = driven by device drivers, not the core path; **Sleep** = Linux expresses
+the same *effect* via a separate Sleep instruction rather than this field.
+
+**Interpreting the strengths after the Linux pass:** the two previously "not yet driven"
+rows (CS-Invert-Mask, lane masks) are now **load-bearing under Linux** — the earlier
+reading was an artifact of looking only at no-OS. A TB mismatch on them is now a
+*conformance* signal for real Linux deployments, not a bare regression lock. What is
+still driven by **neither** driver — clock-only `rw=00`, sparse multi-CS, and the
+ASSERT-`t` CS delay under Linux — remains characterization-only: exercising it in the TB
+locks the RTL ahead of the SW, but a mismatch has no field consequence today. The one
+place the drivers *disagree in defensiveness* is EXEC-CFG-06: no-OS clamps, Linux does
+not — so the module's undefined >`DATA_WIDTH` region (FLAG F6) is reachable through the
+Linux path and deserves either an RTL guard or an explicit documented constraint.
+
+---
+
+## Cross-references
+
+- Behavioral spec[^spec] — the authority for the golden model; the `(no-OS)`/`(Linux)`/
+  `(drivers)` tags and the requirement-strength classification point here.
+- RTL implementation reference[^rtl] — the sibling holding RTL-level evidence.
+- Memory: `finding-sleep-formula-doc-contradiction`, `project-exec-spec-status`
+
+[^spec]: `doc/spi_execution.spec.md`
+[^rtl]: `doc/spi_execution.rtl.md`

--- a/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.findings.md
+++ b/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.findings.md
@@ -1,0 +1,281 @@
+# SPI Engine Execution Module — Findings, Flags & Analysis
+
+This is the **engineering-analysis companion** to the normative behavioral
+specification `spi_execution.spec.md`. It holds the material that is *not* a
+requirement: the revision note, the suspicious-behavior flags (`EXEC-F*`), the
+provenance/flag audit, the known coverage holes, and the out-of-scope / Echo-SCLK
+observations. The atomic `EXEC-*` requirements themselves live in the spec; each
+affected requirement carries a one-line `see FLAG EXEC-Fn` pointer back here.
+
+The requirement-strength driver cross-check (former Appendix C) now lives in
+`spi_execution.driver.md`.
+
+The RTL these findings were characterized against is **hdl_repo @ `8ae99f4c`**
+(main branch, Wed Jun 24). Line/signal references are to that revision.
+
+---
+
+## Revision note
+
+**Revision note:** this revision closes the previously-owed driver cross-check
+against **both** reference drivers — the no-OS driver
+and the Linux mainline `spi-axi-spi-engine` driver. Requirements carry `(no-OS)`,
+`(Linux)`, or `(drivers)` in-line where a driver corroborates them (see the
+*Driver corroboration* convention in `spec.md`); the full analysis — grading which
+behaviors are load-bearing vs not-yet-driven by the reference SW — is the driver
+cross-check in `spi_execution.driver.md`. The Linux
+pass **resolves** the two previously-open flags: **EXEC-F8** (CS-Invert-Mask *is*
+driven — by Linux — so no-OS's inability to emit it is a no-OS encoder limitation, not
+a spec gap) and **EXEC-F9** (lane masks *are* driven — by Linux, on IP core v2.0+ — so
+no-OS simply has not caught up). It also strengthens **EXEC-F6** (Linux does not clamp
+transfer width) and adds a second `(t+1)` vote to **EXEC-F3**.
+
+---
+
+## Flag detail
+
+The consolidated flag table is in the *Provenance & Flag Audit* below; the prose
+blocks here are the detailed observations relocated verbatim from the spec.
+
+### FLAG EXEC-F1
+
+> **FLAG EXEC-F1 (appears to violate the stream payload-stability contract):** At
+> `div=0` with backpressure that accepts at most one SDI word per word-period (e.g.
+> `sdi_data_ready` pulsed once every `word_length` cycles), the module drives a new
+> value onto `sdi_data` while `sdi_data_valid=1` and the previously-presented beat
+> has **not** yet been accepted (`sdi_data_ready=0`). This appears to conflict with
+> the AXI-Stream payload-stability rule (EXEC-FLOW-05). *Why noted:* a
+> strictly-compliant downstream sink could capture a corrupted word. In practice
+> this is not reached because the downstream asymmetric SDI FIFO always asserts
+> ready within a word-period. *Resolve via:* HDL designer — fix vs.
+> accept-with-documented-constraint. *Status:* captured as the `expect_fail`
+> regression `test_backpressure.py::test_sdi_handshake_stability`; reproduces across
+> `DATA_WIDTH ∈ {8,16,24,32}` and seeds. If the RTL is fixed, that test flips to
+> FAIL and this requirement becomes a clean conformance check.
+
+### FLAG EXEC-F5
+
+> **FLAG EXEC-F5 (documentation gap):** `SDO_DEFAULT`, `ECHO_SCLK`, and `SDI_DELAY`
+> are build parameters of the RTL but are **absent from
+> `spi_engine_execution.rst`** (which lists only NUM_OF_CS, DEFAULT_SPI_CFG,
+> DEFAULT_CLK_DIV, DATA_WIDTH, NUM_OF_SDIO). *Suspect:* the parameter table is
+> incomplete; a user reading the docs cannot discover the echo-SCLK feature or the
+> SDI latch delay. *Resolve via:* HDL designer / doc owner — confirm intended
+> defaults and semantics, then document them. Until then these are
+> `RTL-CHARACTERIZED`.
+
+### FLAG EXEC-F7
+
+> **FLAG EXEC-F7 (fragile timing):** The internal SDO assembly pipeline
+> requires "some settling time between `word_length` changing and a transfer
+> starting" (RTL comment). A Configuration-Write of `word_length` (or lane mask)
+> *immediately* followed by a Transfer relies on the fixed inter-instruction latency
+> for correctness. *Why noted:* correct today but margin-dependent; a refactor that
+> shortens the gap would break it. *Resolve via:* designer confirmation that the
+> minimum instruction spacing is guaranteed. Covered by EXEC-CC-01.
+
+### FLAG EXEC-F8
+
+> **FLAG EXEC-F8 (RESOLVED by the Linux cross-check — driven; was "not yet driven"):**
+> The CS-Invert-Mask instruction (opcode `100`) *is* driven — by the **Linux** driver,
+> which builds a CS-invert mask from each device's `SPI_CS_HIGH` mode and emits
+> `CS-Invert-Mask` in its per-device setup routine (IP core v1.2+). It is the mechanism
+> behind active-high chip-select. The earlier "not driven" reading came only from the
+> **no-OS** driver, whose command encoder truncates the opcode to two bits (aliasing
+> `100`→`000`) and so *cannot* emit it. *Conclusion:* this is a **no-OS encoder
+> limitation, not a spec gap or a universal SW lag** — CS-Invert-Mask is a real,
+> documented, Linux-driven feature. *Impact on verification:* EXEC-CSINV-* are now
+> `DOCUMENTED` **`(Linux)`**-corroborated (load-bearing for `SPI_CS_HIGH` devices under
+> Linux), not a bare regression lock. *Code-level evidence:* `driver.md` L.2/L.3, Part C.
+> *(Original TODO — "is CS-invert meant to be driver-programmable?" — is answered: yes,
+> Linux programs it. A residual note for the no-OS maintainers: the 2-bit opcode mask in
+> `SPI_ENGINE_CMD` should be widened to 3 bits if no-OS ever needs active-high CS.)*
+
+### FLAG EXEC-F9
+
+> **FLAG EXEC-F9 (RESOLVED by the Linux cross-check — driven on IP v2.0+; was "not yet
+> driven"):** Lane masks *are* driven — by the **Linux** driver, which writes both the
+> SDI (`011`) and SDO (`100`) lane-mask registers from each device's `rx_lane_map[]` /
+> `tx_lane_map[]`, in three places: per-message on a multi-lane-mode change, once in
+> per-device setup, and in the offload trigger path (with restoration to the primary
+> lane afterward). This confirms the F9 framing exactly: multi-lane is a **recent HDL
+> feature gated on IP core major version ≥ 2** (Linux enables it only when it can read
+> `num_data_lanes` from the DATA_WIDTH register on a v2.0+ core), which is why the
+> older-style **no-OS** core path — targeting earlier cores — never writes the masks and
+> leaves them at the all-lanes-active reset default. *Conclusion:* not a suspect
+> behavior and no longer "not yet driven" — it is version-gated feature reach. EXEC-CFG-
+> 04/05 and EXEC-LANE-* are now **`(Linux)`**-corroborated (load-bearing on v2.0+).
+> *Verification impact:* the TB's multi-lane / lane-mask coverage is now a *conformance*
+> check for the Linux use case, not merely an ahead-of-SW regression lock. *Code-level
+> evidence:* `driver.md` L.2/L.3, Part C.
+> *(Original TODO — "where are lane masks set once SW catches up?" — is answered:
+> device-`lane_map`-derived, written per-message and in setup, and once-per-enable on the
+> offload path.)*
+
+---
+
+## Appendix A — Provenance & Flag Audit
+
+**Requirements by provenance** (join key for triage):
+
+- `EXTERNAL` (strongest — mismatch = genuine RTL bug): EXEC-XFER-02, EXEC-SCLK-03,
+  EXEC-SCLK-05, EXEC-FLOW-05, EXEC-SDO-01, plus SPI-anchored clauses of EXEC-RST-03/04,
+  EXEC-XFER-06, EXEC-SCLK-01/02, EXEC-BUS-02/03.
+- `DOCUMENTED`: the bulk of §3–§5, §7 (stream/handshake), §9.
+- `DOCUMENTED (non-independent)`: the timing formulas (EXEC-XFER-08, EXEC-CS-02,
+  EXEC-SLEEP-01, EXEC-SCLK-01) — the docs restate the implementation; treat a
+  model/RTL match as *consistency*, not independent confirmation.
+- `RTL-CHARACTERIZED` (regression locks, **not** conformance): EXEC-PARAM-06/07/08,
+  EXEC-RST-01/03/05/07, EXEC-CMD-01(idle-gate), EXEC-FLOW-04, EXEC-SDO-02(alignment),
+  EXEC-LANE-01/03/04, EXEC-SDI-04/05, EXEC-CC-07/08, EXEC-ECHO-C1/C2, EXEC-BUS-07.
+- **Driver-corroborated** (non-independent usage evidence; grades requirement
+  strength — see the driver cross-check in `spi_execution.driver.md`). Tag key:
+  `(drivers)` = both, `(no-OS)`/`(Linux)` = one only.
+  - **`(drivers)` — both agree:** EXEC-XFER-01(n zero-based), EXEC-CS-01(active-low),
+    EXEC-CS-03(`t=0` CS), EXEC-SCLK-01/EXEC-CFG-01(clk_div formula), EXEC-CFG-02(config
+    bit layout), EXEC-SDO-02(MSB alignment), EXEC-SYNC-01(completion id round-trip),
+    EXEC-SLEEP-01(`(t+1)` form), EXEC-OFF-03(same-commands/different-transport).
+  - **`(Linux)` — Linux only (mostly IP-version-gated feature reach):** EXEC-CMD-03(full
+    3-bit opcode), EXEC-CSINV-01/02(CS-invert for `SPI_CS_HIGH`), EXEC-CFG-04/05 &
+    EXEC-LANE-01/03/04 & EXEC-CC-08(lane masks, v2.0+), EXEC-XFER-05(write/read-only in
+    the core path).
+  - **`(no-OS)` — no-OS only:** EXEC-CS-02(prescaled CS delay in the ASSERT `t` field),
+    EXEC-CFG-06(width clamp — Linux does *not* clamp; see F6).
+
+**Open flags** (each: observed → suspect → resolver):
+
+#### Flag: EXEC-F1
+- Summary: `sdi_data` mutates while valid & unaccepted at `div=0` sub-word backpressure (appears to violate AXI-Stream payload stability). Captured as an `expect_fail` regression.
+- Resolver: HDL designer (fix vs accept).
+
+#### Flag: EXEC-F2
+- Summary: SDI lane mask has no boundary-visible effect in *this* module (effect is downstream in `axi_spi_engine`). **Linux does write the SDI-mask register** (from `rx_lane_map[]`, v2.0+), so the register is exercised — but its observable effect is still not at this module's boundary; no-OS never writes it. The flag stands: at this boundary the spec can require only that the write is accepted.
+- Resolver: HDL designer.
+
+#### Flag: EXEC-F3
+- Summary: Sleep-time formula disagreement: `instruction-format.rst` says `2+(t+1)*(div+1)*2`; `pipeline-delays.rst` says `2+t*(div+1)*2`. Spec follows the former (matches "prescaler cycles minus one" wording); RTL should be measured to confirm. **Both drivers corroborate the `(t+1)` form** — each pre-decrements the sleep parameter by 1 (`SLEEP(n-1)`), expecting hardware to add it back. Still needs RTL measurement to be authoritative.
+- Resolver: Simulation + designer/doc owner.
+
+#### Flag: EXEC-F4
+- Summary: `ECHO_SCLK=1` datapath undocumented and unverified (coverage hole); build-time-fixed capture edge is surprising.
+- Resolver: Designer + datasheet.
+
+#### Flag: EXEC-F5
+- Summary: `SDO_DEFAULT`, `ECHO_SCLK`, `SDI_DELAY` parameters missing from the `.rst` parameter table.
+- Resolver: Doc owner.
+
+#### Flag: EXEC-F6
+- Summary: Dynamic transfer length > `DATA_WIDTH` behavior unspecified (constraint stated, not enforced/defined). **Strengthened by Linux:** no-OS clamps width to the `DATA_WIDTH` readback, but Linux does **not** clamp (`bits_per_word_mask = 1..32`), so the reference SW does not universally enforce the constraint — a narrow-`DATA_WIDTH` build could be driven into the undefined region.
+- Resolver: Designer.
+
+#### Flag: EXEC-F7
+- Summary: word_length/lane-mask-then-transfer correctness relies on fixed inter-instruction settling margin (fragile).
+- Resolver: Designer.
+
+#### Flag: EXEC-F8
+- Summary: **RESOLVED (Linux):** CS-Invert-Mask (opcode `100`) *is* driven — by Linux, to implement `SPI_CS_HIGH` (IP v1.2+). The no-OS driver's inability to emit it is a **no-OS 2-bit-opcode-encoder limitation**, not a spec gap. EXEC-CSINV-* now `(Linux)`-corroborated. Residual: no-OS encoder could be widened to 3 bits if it ever needs active-high CS.
+- Resolver: Closed (was HDL/SW designer).
+
+#### Flag: EXEC-F9
+- Summary: **RESOLVED (Linux):** lane-mask registers *are* written — by Linux, from device `lane_map`s, on IP core **v2.0+**. no-OS targets earlier cores and leaves the masks at reset default. Confirms multi-lane as version-gated feature reach, not a suspect behavior. EXEC-CFG-04/05 & EXEC-LANE-* now `(Linux)`-corroborated.
+- Resolver: Closed (was HDL/SW designer).
+
+#### Flag: EXEC-F10
+- Summary: **Sticky `sdo_data_ready` after reset (FIFO mode).** In FIFO mode (`s_offload_active=0`) `sdo_data_ready` can assert with no command pending and no valid write instruction — but only *after* a prior transfer, and it survives an intervening `resetn` pulse. Appears rooted in `exec_transfer_cmd_reg` (fed to the shiftreg as `exec_cmd`), which is set inside `if (exec_cmd)` and has no reset branch, so a stale `1` leaves the shiftreg gate `(exec_cmd & index_ready)` satisfied post-reset. Reads as a protocol smell: the engine requests SDO with no transfer in flight. Encoded as `expect_fail` regression.
+- Resolver: HDL designer (should reset clear `exec_transfer_cmd_reg`? if intended, document required power-on sequence).
+
+#### Flag: EXEC-F11
+- Summary: **Confirmed bug (see `bug_log.md`).** EXEC-OFF-02 not implemented in RTL: `execution.rst` states offload prefetch requires *all* SDO lanes active, else the module waits for the write instruction, but the prefetch gate has no lane-mask term. Under a sub-mask the engine prefetches early and corrupts the SDO bus data. Kept as a failing regression (`test_offload.py`) to guard against reintroduction.
+- Resolver: HDL designer (implement all-lanes gate, or correct the `.rst`).
+
+## Appendix B — Known Coverage Holes
+
+Absence of a requirement here is a coverage gap, not implied coverage:
+
+1. `ECHO_SCLK=1` datapath — no conformance requirements (FLAG EXEC-F4).
+2. Offload path — now exercised at this boundary (§9): EXEC-OFF-01 prefetch
+   readiness and EXEC-OFF-03 waveform-parity are verified; **EXEC-OFF-02
+   (all-lanes-required prefetch) is not implemented in RTL** — a confirmed bug kept
+   as a failing regression (see `bug_log.md`).
+3. SDI lane-mask effect — out of scope here (FLAG EXEC-F2); must be verified at
+   `axi_spi_engine`.
+4. CS-delay and transfer-duration **cycle counts** (EXEC-CS-02, EXEC-XFER-08) —
+   formulas stated; assert them in the TB (currently only SCLK period and sleep
+   duration are checked, per README *Current state*).
+5. Sleep-formula off-by-one prescaler period (FLAG EXEC-F3) — must be resolved by
+   direct measurement.
+6. **Behavior not driven by *any* reference software.** After the Linux cross-check this
+   set has shrunk substantially: CS-Invert-Mask (was F8) and lane masks (was F9) are now
+   Linux-driven, so a TB mismatch on them is a *conformance* signal for the Linux use
+   case, not a bare regression lock. What remains **undriven by both** drivers:
+   **sparse multi-CS select** (EXEC-CS-05 — both only single-select or fully deselect),
+   **the clock-only/dummy `{r,w}=00` Transfer** (EXEC-XFER-05, neither emits it), and
+   **prescaled CS pre/post delay via the ASSERT `t` field** (EXEC-CS-02 — no-OS drives it,
+   Linux uses separate Sleeps). These carry no corroborating driver usage, so a TB
+   mismatch there is a regression-lock signal, not a field-bug signal. See the driver
+   cross-check in `spi_execution.driver.md`.
+
+---
+
+## Out-of-Scope & Echo-SCLK Observations
+
+> **NOTE:** The entries below are **not conformance requirements of this module**. They
+> are observations about behavior specified/verified elsewhere (Out-of-Scope pointers)
+> or about a datapath deferred to a future revision (Echo-SCLK). They were relocated
+> here from the former §9/§10 during the guideline refactor and are retained pending a
+> decision on whether to delete them from the requirements set. Their verification
+> method is `N/A` because there is nothing to check at *this* module's boundary.
+
+### O.1 Out-of-Scope Behavior (specified elsewhere / not boundary-visible here)
+
+Behavior whose effect lives in another IP is marked out of scope with a pointer, not
+specified here.
+
+#### EXEC-OOS-01
+- Description: SDI lane mask **masking effect** (which lanes reach the host) is not boundary-visible in this module.
+- Rationale: The masking is applied downstream, so no requirement on `sdi_data` masking can be stated here.
+- Provenance: N/A — behavior lives in `axi_spi_engine` asymmetric SDI FIFO. See **FLAG EXEC-F2**.
+- Verification method: N/A (out of scope — verified at `axi_spi_engine`)
+
+#### EXEC-OOS-02
+- Description: Offload command/SDO prefetch from RAM, trigger-driven execution, and `enable`/`enabled` are not specified here; this module only exposes `s_offload_active` (§9).
+- Rationale: The offload control datapath is a separate module; only its boundary effect is in scope here.
+- Provenance: N/A — behavior lives in `spi_engine_offload` + offload-control-interface.
+- Verification method: N/A (out of scope — verified at the offload module)
+
+#### EXEC-OOS-03
+- Description: Multi-manager arbitration and CDC/FIFO latencies are not specified here.
+- Rationale: These are interconnect/CDC concerns outside this module's boundary.
+- Provenance: N/A — behavior lives in `spi_engine_interconnect`, `axi_spi_engine`; see pipeline-delays.rst.
+- Verification method: N/A (out of scope — verified at the interconnect)
+
+> **FLAG EXEC-F2 (no boundary-visible effect):** The SDI lane mask is written by a
+> Configuration-Write and accepted here (EXEC-CFG-04), but its masking effect is
+> downstream in `axi_spi_engine`. *Suspect:* a spec at this module's boundary can only
+> require the register write to be *accepted*, not that any `sdi_data` masking occurs.
+> *Resolve via:* HDL designer — confirm the execution module is meant to expose no
+> observable SDI-mask effect. (Contrast the **SDO** lane mask, which IS
+> boundary-visible: EXEC-LANE-*.)
+
+### O.2 Echo-SCLK Capture (`ECHO_SCLK=1`) — OUT OF SCOPE this revision
+
+> **FLAG EXEC-F4 (coverage hole + documentation gap):** The entire
+> `ECHO_SCLK=1` datapath (SDI captured on the looped-back `echo_sclk` instead of the
+> internal SPI clock) is **undocumented** in the `.rst` and **unverified** by the
+> current testbench. It is called out here as an explicit coverage hole so its
+> absence is not mistaken for coverage. The two `RTL-CHARACTERIZED` observations below
+> are worth a designer's confirmation before any conformance spec is written for this
+> path. No `EXEC-ECHO-*` conformance requirements are asserted until this path is
+> documented and modeled.
+
+#### EXEC-ECHO-C1
+- Description: In `ECHO_SCLK=1` builds the SDI capture edge is selected **at build time** from `DEFAULT_SPI_CFG[1:0]` (modes `01`/`10` use the negedge datapath, others posedge); a **runtime** CPOL/CPHA change does *not* re-select the echo latch edge.
+- Rationale: Recorded because it is surprising — a user who changes CPOL at runtime in an echo build gets a mismatched capture edge.
+- Provenance: `RTL-CHARACTERIZED` — see **FLAG EXEC-F4**. *Resolve via:* designer + device datasheet (e.g. AD4630 echo-SCLK usage).
+- Verification method: N/A (out of scope this revision)
+
+#### EXEC-ECHO-C2
+- Description: In `ECHO_SCLK=1` builds transfer completion is derived from an edge-detected, clock-synchronized "last bit received," a different mechanism than the `ECHO_SCLK=0` path.
+- Rationale: Recorded because its timing (and single-word `n=0` handling) should be independently characterized before being specified.
+- Provenance: `RTL-CHARACTERIZED` — see **FLAG EXEC-F4**.
+- Verification method: N/A (out of scope this revision)

--- a/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.rtl.md
+++ b/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.rtl.md
@@ -1,0 +1,116 @@
+# SPI Engine Execution Module — Implementation Reference (RTL evidence)
+
+> **This is NOT the specification.** This file holds RTL-level evidence to help a
+> designer resolving a flag; the behavioral spec is `doc/spi_execution.spec.md`.
+
+RTL under study (paths relative to `hdl_repo/library/spi_engine/spi_engine_execution/`):
+
+- `spi_engine_execution.v` — top FSM, decoder, timing/counters, SPI outputs
+- `spi_engine_execution_shiftreg.v` — SDO/SDI shift registers, SDI latch, ECHO path
+- `spi_engine_execution_shiftreg_data_assemble.v` — multi-lane SDO assembly
+
+Line numbers are from the revision read on 2026-07-01; re-verify before quoting.
+
+---
+
+## Flag → RTL evidence
+
+### FLAG EXEC-F1 — `sdi_data` mutates while valid & unaccepted (`div=0`, sub-word backpressure)
+
+Confirmed AXI-Stream payload-stability violation (spec EXEC-FLOW-05). Full root
+cause already in memory finding `finding-sdi-handshake-violation`; summarized here:
+
+- `spi_engine_execution_shiftreg.v`, `g_sclk_miso_latch` branch:
+  - `sdi_data` is the combinational output of `data_sdi_shift`, which shifts on
+    **every** `trigger_rx_s` (~lines 283–293) — ignores valid/ready.
+  - `sdi_data_valid` sets on `last_sdi_bit && trigger_rx_s`, clears only on
+    `sdi_data_ready` (~lines 308–315).
+- `spi_engine_execution.v`: `pending_sdi_data_valid` (~lines 366–372) is driven from
+  the **early** `trigger_rx`, while the port output uses the 2-cycle-delayed
+  `trigger_rx_s`. The delay mismatch lets the next word shift into `sdi_data` before
+  the held beat is accepted.
+- **Masked in production:** downstream asymmetric SDI FIFO always asserts ready
+  within a word-period.
+- **Regression:** `test_backpressure.py::test_sdi_handshake_stability` (`expect_fail`).
+
+### FLAG EXEC-F2 — SDI lane mask has no boundary-visible effect in this module
+
+- `spi_engine_execution.v` ~lines 123–127 (comment) and ~lines 285–287: a
+  `REG_SDI_LANE_CONFIG` write only latches `sdi_lane_mask`; the register is **not
+  read anywhere** in the execution datapath.
+- The comment states the masking effect is downstream: `axi_spi_engine` intercepts
+  the same command to configure `sdi_fifo_tkeep_int` on the asymmetric SDI FIFO
+  (`util_axis_fifo_asym`).
+- Contrast SDO lane mask, which IS used here — see F-none / EXEC-LANE-* evidence
+  below.
+
+### FLAG EXEC-F4 — `ECHO_SCLK=1` datapath: build-time-fixed capture edge
+
+- `spi_engine_execution_shiftreg.v`, `g_echo_sclk_miso_latch` generate block
+  (~lines 176–275):
+  - Edge selection is a **generate-time** decision on `DEFAULT_SPI_CFG[1:0]`:
+    modes `2'b01`/`2'b10` → `g_echo_miso_nshift_reg` (negedge `echo_sclk`, ~line
+    183); else `g_echo_miso_pshift_reg` (posedge, ~line 217).
+  - Because it is `generate`/`if`, a **runtime** CPOL/CPHA change (via
+    `REG_CONFIG`) does not re-select the latch edge — EXEC-ECHO-C1.
+- Completion path (EXEC-ECHO-C2): `last_sdi_bit` is synchronized to core clock via
+  `last_sdi_bit_m` (2FF+edge, ~lines 254–265); `echo_last_bit` is the rising-edge
+  detect (~line 265). `transfer_done` uses this echo path when `ECHO_SCLK=1`
+  (`spi_engine_execution.v` ~lines 510–511), a different mechanism than the
+  `end_of_word` path used when `ECHO_SCLK=0` (~line 513).
+- Single-word `n=0` handling: `echo_last_transfer` special-cases
+  `cmd_d1_time_is_zero` (`spi_engine_execution.v` ~lines 456–470).
+- **Untested:** TB never sets `ECHO_SCLK=1`.
+
+### FLAG EXEC-F6 — dynamic transfer length > DATA_WIDTH unspecified
+
+- `spi_engine_execution.v` ~lines 279–284: `REG_WORD_LENGTH` writes
+  `word_length <= cmd[7:0]` and `left_aligned <= DATA_WIDTH - cmd[7:0]` with only a
+  comment ("the max value of this reg must be DATA_WIDTH") — **no clamp/guard**.
+- If `cmd[7:0] > DATA_WIDTH`, `left_aligned` underflows (unsigned wrap) and the
+  bit/latch counts (`last_bit_count = word_length-1`, ~line 300) exceed the shift
+  register width. Behavior undefined; constraint is by convention only.
+
+### FLAG EXEC-F7 — word_length/lane-mask-then-transfer relies on settling margin
+
+- `spi_engine_execution.v` ~lines 297–302: `last_bit_count`/`latch_last_bit_count`
+  are recomputed from `word_length` with a **one-cycle delay** (comment: "even in
+  the worst case (transfer after config), we still have another cycle before using
+  it").
+- `spi_engine_execution_shiftreg.v` ~lines 210 & 242 (comments): "these paths would
+  be unsafe if there wasn't a guarantee of some settling time between word_length
+  changing and a transfer starting."
+- Correct today because a Configuration-Write (1 cycle) plus the Transfer's fixed
+  2-cycle prologue provides the margin; a refactor shortening that gap would break
+  it. Covered by spec EXEC-CC-01.
+
+---
+
+## Supporting evidence for RTL-CHARACTERIZED requirements (non-flag)
+
+For traceability of spec items whose only authority is the RTL:
+
+| Spec ID | RTL evidence (`spi_engine_execution.v` unless noted) |
+|---------|------------------------------------------------------|
+| EXEC-RST-03 (`cs`=all-ones) | ~line 419 `cs <= 'hff` |
+| EXEC-RST-05 (`sdo_t`=1, sdo idle) | ~lines 522–523; shiftreg ~line 140 `{DATA_WIDTH{sdo_idle_state}}` |
+| EXEC-RST-07 / EXEC-CS-04 (clear on CS activate) | `cs_activate` ~lines 527–533; shiftreg clears `data_sdi_shift` on `cs_activate` ~line 284 |
+| EXEC-CMD-01 (idle-gate) | `assign cmd_ready = idle;` ~line 226 |
+| EXEC-FLOW-04 (last-word gate relax) | `io_ready2` includes `last_transfer` ~lines 445–446 |
+| EXEC-SDO-02 (MSB alignment) | `left_aligned` shift; assemble `data_reg << left_shift_count` (assemble ~line 143) |
+| EXEC-LANE-01/03 (SDO lane distribution) | assemble `lane_lookup[]` scan ~lines 167–193; `active_lane_idx` ~lines 209–221 |
+| EXEC-SDI-05 (`SDI_DELAY`) | shiftreg `trigger_rx_d`/`trigger_rx_s` ~lines 161–164 |
+| EXEC-OFF-01/02 (prefetch gating) | shiftreg `sdo_data_ready_int` = `... && (s_offload_active \|\| (exec_cmd & index_ready))` ~line 106 |
+
+---
+
+## Cross-references
+
+- Behavioral spec[^spec] — the authority for the golden model.
+- Driver usage reference[^driver] — the *software* sibling of this doc: how the
+  no-OS driver programs the module (evidence behind the spec's `(no-OS)` tags).
+- Memory: `finding-sdi-handshake-violation`, `finding-sleep-formula-doc-contradiction`,
+  `project-exec-spec-status`
+
+[^spec]: `doc/spi_execution.spec.md`
+[^driver]: `doc/spi_execution.driver.md`

--- a/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.spec.md
+++ b/testbenches/ip/spi_engine/execution/doc/requirements/spi_execution.spec.md
@@ -1,0 +1,549 @@
+# SPI Engine Execution Module — Behavioral Specification & Requirements
+
+Requirements in this document follow the project requirement-authoring guideline.
+
+## Module boundary
+
+(the only vocabulary this requirement may use)
+
+| Group | Signals |
+|-------|---------|
+| Clock/reset | `clk`, `resetn` (active-low) |
+| CMD stream (in) | `cmd_valid`, `cmd_ready`, `cmd[15:0]` |
+| SDO stream (in) | `sdo_data_valid`, `sdo_data_ready`, `sdo_data[DATA_WIDTH-1:0]` |
+| SDI stream (out)| `sdi_data_valid`, `sdi_data_ready`, `sdi_data[NUM_OF_SDIO*DATA_WIDTH-1:0]` |
+| SYNC stream (out)| `sync_valid`, `sync_ready`, `sync[7:0]` |
+| Offload | `s_offload_active` |
+| SPI bus | `sclk`, `sdo[NUM_OF_SDIO-1:0]`, `sdo_t`, `sdi[NUM_OF_SDIO-1:0]`, `cs[NUM_OF_CS-1:0]`, `three_wire`, `echo_sclk` |
+
+All four `ctrl` streams use AXI-stream valid/ready handshaking: a beat transfers on
+the cycle where valid and ready are both asserted; once valid is asserted the
+payload MUST remain stable until the beat is accepted (`EXTERNAL`, AXI-Stream rule).
+
+---
+
+## 1. Parameters & Configuration Space (validity domains)
+
+These define the parameter space over which every later requirement's validity
+domain is stated. They are boundary-visible because they size the bus and the
+streams, or set reset defaults.
+
+#### EXEC-PARAM-01
+- Description: `NUM_OF_CS` ∈ [1..8] sets the width of the `cs` bus. All requirements referencing chip-select hold for every value in this range.
+- Rationale: Bounds the chip-select validity domain for every downstream requirement.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-PARAM-02
+- Description: `NUM_OF_SDIO` ∈ [1..8] sets the number of SDO/SDI lanes (`sdo`/`sdi` width) and the width of `sdi_data` (= `NUM_OF_SDIO*DATA_WIDTH`).
+- Rationale: Sizes the lane and receive datapath domain for the multi-lane requirements.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-PARAM-03
+- Description: `DATA_WIDTH` ∈ {8,16,24,32} sets the parallel-word granularity: `sdo_data` width, each `sdi_data` lane slice, and the maximum transfer word length.
+- Rationale: Sizes the stream words and bounds the legal word-length range.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-PARAM-04
+- Description: `DEFAULT_SPI_CFG` is the reset value of the SPI configuration register (CPHA=bit0, CPOL=bit1, three_wire=bit2, sdo_idle_state=bit3), observable via the reset waveform (EXEC-RST-*).
+- Rationale: Defines the post-reset SPI mode a host observes before any config write.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-PARAM-05
+- Description: `DEFAULT_CLK_DIV` is the reset value of the prescaler; it sets the SCLK period of the first transfer issued after reset with no intervening prescaler write.
+- Rationale: Fixes the bus clock of the first transfer before software programs the divider.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-PARAM-06
+- Description: `SDO_DEFAULT` (1 bit) is the reset/idle level presented on every `sdo` lane before any configuration write changes `sdo_idle_state`.
+- Rationale: Defines the `sdo` idle level at power-on.
+- Provenance: `RTL-CHARACTERIZED` — see **FLAG EXEC-F5**
+
+#### EXEC-PARAM-07
+- Description: `ECHO_SCLK` ∈ {0,1} selects the SDI capture datapath (0 = capture on the internally-generated SPI clock; 1 = capture on the looped-back `echo_sclk`). Only `ECHO_SCLK=0` is in scope for this spec revision — see the Echo-SCLK observations and **FLAG EXEC-F4** in `findings.md`.
+- Rationale: Fixes the capture-path validity domain; the echo path is deferred.
+- Provenance: `RTL-CHARACTERIZED` — see **FLAG EXEC-F5**
+
+#### EXEC-PARAM-08
+- Description: `SDI_DELAY` ∈ [0..3] adds a fixed number of core-clock cycles of latency between an SCLK sampling edge and the cycle on which the corresponding `sdi` bit is captured, to tolerate high-SCLK round-trip delay (`ECHO_SCLK=0` path).
+- Rationale: Lets high-SCLK builds tolerate round-trip delay without misaligning captured bits.
+- Provenance: `RTL-CHARACTERIZED` — see **FLAG EXEC-F5**
+
+---
+
+## 2. Reset Behavior (boundary-observable)
+
+Validity domain: all parameters. Only outputs are specified; internal state is out
+of scope.
+
+#### EXEC-RST-01
+- Description: While `resetn` is deasserted (0) and for the first cycle after it is released, the module accepts no command and drives its `spi` bus and `ctrl` outputs to defined idle values (EXEC-RST-02..07).
+- Rationale: Guarantees a defined power-on state before any command is accepted.
+- Provenance: `RTL-CHARACTERIZED`
+
+#### EXEC-RST-02
+- Description: After reset the module is ready to accept a command: `cmd_ready` is asserted.
+- Rationale: The engine is immediately available to the command generator after reset.
+- Provenance: `DOCUMENTED` (implied by EXEC-CMD-01)
+
+#### EXEC-RST-03
+- Description: After reset `cs` reads all-ones (every chip-select **inactive**), consistent with active-low default polarity.
+- Rationale: No device is selected at power-on.
+- Provenance: `RTL-CHARACTERIZED`; rationale `EXTERNAL` (SPI CS idle = deasserted)
+
+#### EXEC-RST-04
+- Description: After reset `sclk` idles at the CPOL level taken from `DEFAULT_SPI_CFG[1]`.
+- Rationale: The idle bus clock matches the configured clock polarity.
+- Provenance: `DOCUMENTED` (SPI config register) + `EXTERNAL` (CPOL idle semantics)
+
+#### EXEC-RST-05
+- Description: After reset every `sdo` lane idles at `sdo_idle_state` (= `SDO_DEFAULT`) and `sdo_t` is asserted (1, tri-stated).
+- Rationale: Transmit lines are tri-stated and held at a defined idle after reset.
+- Provenance: `RTL-CHARACTERIZED`
+
+<!-- TODO: EXEC-RST-06 bundles two independently-testable behaviors (the three_wire
+     reset value, and the sync_valid/sdi_data_valid outputs being deasserted). Per the
+     atomicity smell in the authoring guideline these could fail independently and
+     arguably warrant separate IDs. Splitting requires appending new IDs, so this is
+     left flagged for review rather than changed here. -->
+#### EXEC-RST-06
+- Description: After reset `three_wire` reflects `DEFAULT_SPI_CFG[2]`; `sync_valid` and `sdi_data_valid` are deasserted. (Note: `sdo_data_ready` is *not* reliably cleared by reset in FIFO mode — see FLAG EXEC-F10 in `findings.md`.)
+- Rationale: The three-wire mode line reflects its configured default and no stream output claims valid data at reset.
+- Provenance: `DOCUMENTED` (config reg) / `RTL-CHARACTERIZED` (valids low)
+
+#### EXEC-RST-07
+- Description: Any receive state left over from a prior transaction is cleared by reset, so the first read transfer after reset returns only newly-sampled bits (no stale `sdi_data`).
+- Rationale: Reset must not leak captured data from before the reset into the next read.
+- Provenance: `RTL-CHARACTERIZED`; the instruction-format note ("Additional logic … reset counters … when CS active state is asserted") documents the *CS-driven* clear, not the reset-driven one
+
+---
+
+## 3. Command Stream (CMD) — acceptance & sequencing
+
+Validity domain: all parameters.
+
+#### EXEC-CMD-01
+- Description: The module accepts a new command **only when idle**: `cmd_ready` is asserted exactly when no instruction is executing, and a command transfers on the single cycle `cmd_valid && cmd_ready`.
+- Rationale: Serializes execution so no command overlaps another in flight.
+- Provenance: `DOCUMENTED` (control-interface AXI handshake) / `RTL-CHARACTERIZED` (idle-gating)
+
+#### EXEC-CMD-02
+- Description: While an instruction is executing, `cmd_ready` is deasserted, so the upstream generator stalls until the instruction completes; no command is lost or reordered.
+- Rationale: Backpressure to the generator prevents command loss or reordering.
+- Provenance: `DOCUMENTED` (implied)
+
+#### EXEC-CMD-03
+- Description: The opcode is taken from `cmd[14:12]`: `000`=Transfer, `001`=Chip-Select, `010`=Configuration-Write, `011`=MISC (Sync/Sleep), `100`=CS-Invert-Mask. Reserved bits `cmd[15]`, `cmd[11]` are 0 (and `cmd[10]` is used only by Configuration-Write).
+- Rationale: Defines how the module decodes an instruction at its boundary.
+- Provenance: `DOCUMENTED` (instruction-format) **`(Linux)`** — see FLAG EXEC-F8 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-CMD-04
+- Description: Commands execute strictly in the order accepted; the module completes one instruction (returns to idle) before accepting the next, except that a Configuration-Write completes in a single cycle (EXEC-CFG-07).
+- Rationale: Deterministic in-order execution is required for the command program to be meaningful.
+- Provenance: `DOCUMENTED` (pipeline-delays)
+
+---
+
+## 4. Instruction Semantics
+
+### 4.1 Transfer (opcode `000`) — `cmd[9]=r`, `cmd[8]=w`, `cmd[7:0]=n`
+
+Validity domain: all parameters, `ECHO_SCLK=0`.
+
+#### EXEC-XFER-01
+- Description: A Transfer generates SCLK for `n+1` words, each `word_length` bits long (word_length per §4.3).
+- Rationale: Defines the transfer-length encoding (zero-based word count).
+- Provenance: `DOCUMENTED` **`(drivers)`** — evidence in `driver.md`.
+
+#### EXEC-XFER-02
+- Description: Bits are shifted **MSB-first** on both SDO and SDI.
+- Rationale: SPI bit ordering convention that external devices expect.
+- Provenance: `EXTERNAL` (SPI) + `DOCUMENTED`
+
+#### EXEC-XFER-03
+- Description: When `w=1` (write): each transmitted word is consumed from the SDO stream and driven onto `sdo`; `sdo_t` is deasserted (0, driven) for the duration of the transfer.
+- Rationale: A write transfer must actively drive the transmit line with stream data.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-XFER-04
+- Description: When `r=1` (read): `sdi` is sampled for the whole word and the assembled word is presented on the SDI stream (`sdi_data` with `sdi_data_valid`).
+- Rationale: A read transfer must capture the input line and deliver the received word.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-XFER-05
+- Description: All four `{r,w}` combinations are supported: full-duplex (`11`), write-only (`01`), read-only (`10`), and clock-only/dummy (`00`, SCLK toggles, no stream traffic).
+- Rationale: The transfer instruction must cover every direction combination the protocol allows.
+- Provenance: `DOCUMENTED` **`(Linux)`** — Linux core drives `01`/`10`/`11`; `00` driven by neither driver. Evidence in `driver.md`.
+
+#### EXEC-XFER-06
+- Description: During a read-only transfer (`w=0`), `sdo` is held at `sdo_idle_state`; outside a write transfer `sdo_t` is asserted (tri-stated).
+- Rationale: The module must not drive spurious data on `sdo` when not writing.
+- Provenance: `DOCUMENTED` (sdo_idle_state) / `EXTERNAL` (tri-state)
+
+#### EXEC-XFER-07
+- Description: A Transfer does not begin, and mid-transfer does not advance past a word boundary, until flow-control readiness is met (§6); when not ready it stalls with no data loss.
+- Rationale: Flow-control gating keeps the transfer lossless under backpressure.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-XFER-08
+- Description: Instruction execution time = 2 core clocks + transfer time, where transfer time = `(n+1) * word_length * (div+1) * 2` core clocks. After the last bit of the last word the module returns to idle.
+- Rationale: Gives a closed-form transfer duration for timing verification.
+- Provenance: `DOCUMENTED (non-independent)` (pipeline-delays: "2 cycles plus transfer time") + closed form derived from EXEC-SCLK-01
+
+### 4.2 Chip-Select (opcode `001`) — `cmd[9:8]=t`, `cmd[7:0]=s`
+
+Validity domain: all parameters.
+
+#### EXEC-CS-01
+- Description: The instruction drives the `cs` output to the value `s` (low `NUM_OF_CS` bits), after applying the CS-invert mask (EXEC-CSINV-*). A field bit of 0 selects the corresponding device.
+- Rationale: Chip-select control with active-low selection semantics.
+- Provenance: `DOCUMENTED` **`(drivers)`** — active-low confirmed; sparse multi-select (EXEC-CS-05) undriven by both. Evidence in `driver.md`.
+
+#### EXEC-CS-02
+- Description: A prescaler-scaled delay `t` is inserted **both before and after** the CS change. The CS value changes at `2 + t*(div+1)*2` core clocks after the instruction starts, and the instruction completes at `2 + 2*t*(div+1)*2` core clocks.
+- Rationale: Provides programmable setup/hold time around the chip-select edge.
+- Provenance: `DOCUMENTED (non-independent)` (instruction-format + pipeline-delays) **`(no-OS)`** — only no-OS uses the ASSERT `t` field; Linux uses separate Sleeps. Evidence in `driver.md`.
+
+#### EXEC-CS-03
+- Description: With `t=0` the instruction applies the CS change with only the fixed internal-logic latency (no pre/post wait).
+- Rationale: Allows an immediate chip-select change when no guard delay is needed.
+- Provenance: `DOCUMENTED` **`(drivers)`** — both emit `t=0` chip-selects (Linux exclusively so). Evidence in `driver.md`.
+
+#### EXEC-CS-04
+- Description: Asserting a chip-select (driving at least one selected/low bit that was previously deselected) clears any residual receive state before the next transaction captures data; a pure deselect (all-inactive field) does **not** trigger this clear.
+- Rationale: A new transaction must start from clean receive state, keyed on selection.
+- Provenance: `DOCUMENTED` (instruction-format note, paraphrased)
+
+#### EXEC-CS-05
+- Description: Any subset of the `NUM_OF_CS` lines may be selected simultaneously.
+- Rationale: Supports multi-device selection in a single instruction.
+- Provenance: `DOCUMENTED`
+
+### 4.3 Configuration-Write (opcode `010`) — register `cmd[10:8]`, value `cmd[7:0]`
+
+Validity domain: all parameters. Each write completes in 1 core clock and does not
+stall the command stream (EXEC-CFG-07).
+
+#### EXEC-CFG-01
+- Description: Register `000` (prescaler): sets the clock divider `div`; takes effect on subsequent transfers (SCLK period per EXEC-SCLK-01).
+- Rationale: Runtime control of the SPI bus clock rate.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CFG-02
+- Description: Register `001` (SPI config): sets CPHA=`v[0]`, CPOL=`v[1]`, three_wire=`v[2]`, sdo_idle_state=`v[3]`; observable on `sclk` idle level, `three_wire`, and `sdo` idle level respectively.
+- Rationale: Runtime control of SPI mode and idle levels.
+- Provenance: `DOCUMENTED` **`(drivers)`** — config bit constants match 0/1/2/3 exactly. Evidence in `driver.md`.
+
+#### EXEC-CFG-03
+- Description: Register `010` (dynamic transfer length): sets `word_length` = `v`, the number of SCLK bit-periods per word for subsequent transfers. Default (and reset) is `DATA_WIDTH`.
+- Rationale: Runtime control of per-word bit length.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CFG-04
+- Description: Register `011` (SDI lane mask): the value is accepted. **This module produces no boundary-visible effect from the SDI lane mask** — its masking effect is downstream in `axi_spi_engine`. Out of scope here; see **FLAG EXEC-F2** (Out-of-Scope observations in `findings.md`).
+- Rationale: The register write must be accepted here even though its effect is observable only downstream.
+- Provenance: `DOCUMENTED` (register) / effect out of scope **`(Linux)`** — Linux writes it (IP v2.0+); no-OS never does. See FLAG EXEC-F9 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-CFG-05
+- Description: Register `100` (SDO lane mask): selects which `sdo` lanes carry transmit data; lanes whose mask bit is 0 output `sdo_idle_state` (EXEC-LANE-*).
+- Rationale: Runtime selection of active transmit lanes.
+- Provenance: `DOCUMENTED` **`(Linux)`** — Linux writes it (IP v2.0+); unexercised by no-OS. See FLAG EXEC-F9 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-CFG-06
+- Description: A value written to the dynamic transfer length register MUST NOT exceed `DATA_WIDTH`; behavior for larger values is unspecified — see **FLAG EXEC-F6**.
+- Rationale: The hardware word datapath is only `DATA_WIDTH` wide; larger values leave defined behavior.
+- Provenance: `DOCUMENTED` (constraint stated) **`(no-OS)`** — no-OS clamps; Linux does *not*, so it can drive the out-of-range region. See FLAG EXEC-F6 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-CFG-07
+- Description: A Configuration-Write executes in 1 core clock and does not remove the module from its command-accepting state for more than that cycle (back-to-back config writes accept at 1 command/cycle).
+- Rationale: Configuration must not stall the command stream, so setup sequences stay fast.
+- Provenance: `DOCUMENTED` (pipeline-delays)
+
+### 4.4 MISC — Sync (opcode `011`, `cmd[8]=0`) and Sleep (`cmd[8]=1`)
+
+#### EXEC-SYNC-01
+- Description: Sync drives `sync = cmd[7:0]` (event id) and asserts `sync_valid`; `sync_valid` holds until `sync_ready` is seen, then the module returns to idle. Execution time = 2 core clocks plus any wait for `sync_ready`.
+- Rationale: Emits a host-visible event marker used to signal transfer progress/completion.
+- Provenance: `DOCUMENTED` **`(drivers)` — load-bearing.** The `sync[7:0]` id round-trip is the sole transfer-completion signal in both drivers. Evidence in `driver.md`.
+
+#### EXEC-SLEEP-01
+- Description: Sleep stalls the command stream for `sleep_time = 2 + (t+1) * (div+1) * 2` core clocks (`t=cmd[7:0]`), then resumes; no `spi`/`ctrl` activity occurs during the stall.
+- Rationale: Inserts a programmable inter-instruction delay without bus activity.
+- Provenance: `DOCUMENTED (non-independent)` **`(drivers)`** — both pre-decrement, voting the `(t+1)` form. See FLAG EXEC-F3 (docs disagree on this formula, `findings.md`), evidence in `driver.md`.
+
+#### EXEC-SLEEP-02
+- Description: Sleep with `t=0` still produces the minimum non-zero delay given by the EXEC-SLEEP-01 formula.
+- Rationale: Even the smallest sleep guarantees a defined minimum stall.
+- Provenance: `DOCUMENTED`
+
+### 4.5 CS-Invert-Mask (opcode `100`) — `cmd[7:0]=m` (low `NUM_OF_CS` bits used)
+
+#### EXEC-CSINV-01
+- Description: For each mask bit set, the corresponding `cs` pin is inverted at the output register: that pin becomes active-high; mask bit 0 leaves it active-low (default). The inversion is applied only at the output — the Chip-Select instruction's `s` field still names the same logical selection regardless of mask.
+- Rationale: Supports active-high chip-select devices without changing the logical selection encoding.
+- Provenance: `DOCUMENTED` **`(Linux)`** — Linux emits CS-Invert-Mask to implement `SPI_CS_HIGH`. See FLAG EXEC-F8 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-CSINV-02
+- Description: The mask persists across subsequent Chip-Select instructions until re-written or reset (reset = 0, no inversion).
+- Rationale: CS polarity must remain stable across the transfers of a device without re-programming.
+- Provenance: `DOCUMENTED` / `RTL-CHARACTERIZED` (reset value) **`(Linux)`** — Linux sets the mask once in setup and relies on persistence. Evidence in `driver.md`.
+
+#### EXEC-CSINV-03
+- Description: Changing the invert mask does not itself change which device the "assert a chip-select" clear logic (EXEC-CS-04) reacts to — that logic keys on the logical selection, not the inverted pin level.
+- Rationale: Receive-state clearing must track the logical selection, independent of pin polarity.
+- Provenance: `DOCUMENTED` (instruction-format note)
+
+---
+
+## 5. SPI Waveform (SCLK / CPOL / CPHA / prescaler)
+
+Validity domain: all parameters, `ECHO_SCLK=0`.
+
+#### EXEC-SCLK-01
+- Description: The SCLK period is `(div+1) * 2` core clocks; equivalently `f_sclk = f_clk / ((div+1)*2)`. `div=0` gives the fastest SCLK (half the core-clock rate).
+- Rationale: Defines the exact bus clock a slave device sees.
+- Provenance: `DOCUMENTED (non-independent)` + `EXTERNAL` **`(drivers)` — load-bearing.** Both drivers invert this exact formula to pick the prescaler, so a mismatch means a wrong bus clock in the field. Evidence in `driver.md`.
+
+#### EXEC-SCLK-02
+- Description: When not transferring, `sclk` idles at the CPOL level.
+- Rationale: Bus clock idles at the configured polarity between transfers.
+- Provenance: `DOCUMENTED` + `EXTERNAL`
+
+#### EXEC-SCLK-03
+- Description: The CPOL/CPHA pair selects sampling/update edges per the SPI standard: CPHA=0 samples on the leading edge and updates on the trailing edge; CPHA=1 samples on the trailing edge and updates on the leading edge; CPOL sets the idle polarity. All four modes (00/01/10/11) MUST produce the standard edge relationship a compliant SPI slave expects.
+- Rationale: Correct edge relationships are required for interoperability with standard SPI slaves.
+- Provenance: `EXTERNAL` (SPI) + `DOCUMENTED`
+
+#### EXEC-SCLK-04
+- Description: A runtime change of CPOL/CPHA or of the prescaler (via Configuration-Write) takes effect on the next transfer, not the current one.
+- Rationale: Configuration changes must be atomic at transfer boundaries.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-SCLK-05
+- Description: `sclk`, `sdo`, and `sdo_t` retain a fixed mutual timing alignment across all CPOL/CPHA/div settings (a slave sees data valid at the specified sampling edge).
+- Rationale: Data must be valid at the sampling edge regardless of mode or clock rate.
+- Provenance: `EXTERNAL` (SPI) — the *effect*; the extra output pipeline stage that produces it is implementation
+
+---
+
+## 6. Flow Control / Backpressure
+
+Validity domain: all parameters, `ECHO_SCLK=0`.
+
+#### EXEC-FLOW-01
+- Description: A write-enabled Transfer does not start a word until the outbound word is available on the SDO stream; if not, the transfer stalls (SCLK does not advance) with no invalid data emitted.
+- Rationale: Prevents transmitting undefined data when the source is not ready.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-FLOW-02
+- Description: A read-enabled Transfer does not start / advance past a word until the SDI sink can accept the previously captured word (`sdi_data_ready`); otherwise it stalls with no captured data lost.
+- Rationale: Prevents overwriting a captured word the sink has not yet taken.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-FLOW-03
+- Description: Backpressure applied at an arbitrary bit or word boundary (on SDO, SDI, SYNC, or CMD) suspends progress and resumes correctly, preserving word ordering and data integrity across the stall.
+- Rationale: The module must be lossless under backpressure applied anywhere.
+- Provenance: `DOCUMENTED` (transfer instruction: "stalled until there's no longer any backpressure")
+
+#### EXEC-FLOW-04
+- Description: For the **last** word of a transfer, the continue-gate does not require a further outbound word (there is none to fetch).
+- Rationale: The end of a transfer must not stall waiting for a nonexistent next word.
+- Provenance: `RTL-CHARACTERIZED` (optimization; effect is boundary-visible timing)
+
+#### EXEC-FLOW-05
+- Description: Once `sdi_data_valid` is asserted, `sdi_data` MUST remain stable until the beat is accepted (`sdi_data_valid && sdi_data_ready`).
+- Rationale: AXI-Stream payload-stability contract; a compliant sink relies on it.
+- Provenance: `EXTERNAL` (AXI-Stream payload stability). **This is violated in the current RTL under sub-word backpressure at `div=0` — see FLAG EXEC-F1.**
+
+---
+
+## 7. Transmit Data Path (SDO) — boundary behavior
+
+Validity domain: all parameters.
+
+#### EXEC-SDO-01
+- Description: Each transmitted word appears on `sdo` MSB-first, one bit per SCLK bit-period, for `word_length` bits.
+- Rationale: Standard serial transmit framing.
+- Provenance: `EXTERNAL` (SPI) + `DOCUMENTED`
+
+#### EXEC-SDO-02
+- Description: When `word_length < DATA_WIDTH`, the word's most-significant bit (bit `word_length-1` of the value) is transmitted first — i.e. the short word is MSB-aligned on the wire, independent of `DATA_WIDTH`.
+- Rationale: Short words must be positioned deterministically on the wire regardless of build width.
+- Provenance: `DOCUMENTED` (dynamic length register intent) / left-alignment detail `RTL-CHARACTERIZED` **`(drivers)`** — Linux relies on hardware left-alignment, confirming it is a module behavior. Evidence in `driver.md`.
+
+#### EXEC-SDO-03
+- Description: When no write transfer is active, or outside a command, every `sdo` lane presents `sdo_idle_state`.
+- Rationale: Defined idle level on the transmit lines at all non-write times.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-SDO-04
+- Description: Outbound words are consumed from the SDO stream via `sdo_data_valid`/`sdo_data_ready`; exactly `n+1` words are consumed per write-enabled Transfer of length `n`.
+- Rationale: The stream consumption count must match the transfer length exactly.
+- Provenance: `DOCUMENTED` (control-interface)
+
+### 7.1 Multi-lane transmit (NUM_OF_SDIO > 1)
+
+Validity domain: `NUM_OF_SDIO ∈ [1..8]`.
+
+#### EXEC-LANE-01
+- Description: Only lanes selected by the SDO lane mask carry transmit data; the sequence of words consumed from the SDO stream is distributed across the **active** lanes in ascending physical-lane order.
+- Rationale: Deterministic mapping of stream words onto physical lanes.
+- Provenance: `DOCUMENTED` (SDO lane mask register) / distribution order `RTL-CHARACTERIZED` **`(Linux)`** — Linux drives the SDO mask (IP v2.0+). See FLAG EXEC-F9 (`findings.md`), evidence in `driver.md`.
+
+#### EXEC-LANE-02
+- Description: Lanes whose mask bit is 0 present `sdo_idle_state` (they carry no data).
+- Rationale: Inactive lanes must present the idle level, not stale data.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-LANE-03
+- Description: Arbitrary masks — contiguous, sparse (e.g. `1010`), single-lane, all-lanes — MUST map words to the correct physical lanes for every `NUM_OF_SDIO ∈ [1..8]`.
+- Rationale: Lane routing must be correct for any mask pattern, not just contiguous ones.
+- Provenance: `DOCUMENTED` (register) / behavior `RTL-CHARACTERIZED` **`(Linux)`** — Linux drives per-lane masks, but only those its `lane_map` produces, not arbitrary sparse patterns. Evidence in `driver.md`.
+
+#### EXEC-LANE-04
+- Description: Re-writing the SDO lane mask between transfers remaps the lanes for the next transfer.
+- Rationale: Per-transfer lane reconfiguration must take effect on the following transfer.
+- Provenance: `RTL-CHARACTERIZED` **`(Linux)`** — Linux rewrites the masks per-message on a multi-lane-mode change and restores them afterward. Evidence in `driver.md`.
+
+---
+
+## 8. Receive Data Path (SDI) — standard capture (`ECHO_SCLK=0`)
+
+Validity domain: all parameters, `ECHO_SCLK=0`.
+
+#### EXEC-SDI-01
+- Description: For each read-enabled word, `sdi` is sampled MSB-first for `word_length` bits and the assembled word is presented on the corresponding `sdi_data` lane slice (`sdi_data[i*DATA_WIDTH +: DATA_WIDTH]` for lane `i`).
+- Rationale: Standard serial receive assembly into the correct lane slice.
+- Provenance: `DOCUMENTED` + `EXTERNAL` (MSB-first)
+
+#### EXEC-SDI-02
+- Description: `sdi_data_valid` asserts once a word has been fully received and holds until `sdi_data_ready` accepts it (subject to EXEC-FLOW-05 / FLAG EXEC-F1).
+- Rationale: Received words are handed off with a valid/ready handshake.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-SDI-03
+- Description: Exactly `n+1` SDI words are produced per read-enabled Transfer of length `n`.
+- Rationale: The produced word count must match the transfer length exactly.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-SDI-04
+- Description: Each SDIO lane is captured independently into its own `DATA_WIDTH` slice of `sdi_data` (multi-lane receive).
+- Rationale: Multi-lane receive must keep each lane's data in its own slice.
+- Provenance: `DOCUMENTED` (interface width) / per-lane `RTL-CHARACTERIZED`
+
+#### EXEC-SDI-05
+- Description: `SDI_DELAY ∈ [0..3]` shifts the `sdi` sampling point later by that many core clocks to tolerate high-SCLK round-trip delay, without changing which bit lands in which position.
+- Rationale: Round-trip delay compensation must not reorder captured bits.
+- Provenance: `RTL-CHARACTERIZED` — see FLAG EXEC-F5
+
+---
+
+## 9. Offload Interaction (boundary view)
+
+Validity domain: all parameters. Full offload behavior is out of scope (EXEC-OOS-02);
+only the `s_offload_active` effect at this boundary is stated.
+
+#### EXEC-OFF-01
+- Description: When `s_offload_active=1`, the module may prefetch SDO data (assert `sdo_data_ready` ahead of the write instruction); when `0`, it waits for the write instruction and lane-mask processing before consuming SDO data.
+- Rationale: Offload mode allows prefetch to hide DMA latency; FIFO mode does not.
+- Provenance: `DOCUMENTED` (execution.rst theory-of-operation; offload prefetch)
+
+#### EXEC-OFF-02
+- Description: Offload prefetch requires **all** SDO lanes active; otherwise the module waits for the write instruction.
+- Rationale: Prefetch across a sub-mask would consume stream words for lanes that carry no data.
+- Provenance: `DOCUMENTED` — **not implemented in RTL** (confirmed bug, see `bug_log.md`): the prefetch gate ignores the lane mask, so a sub-mask does not suppress prefetch. Kept as a failing regression.
+
+#### EXEC-OFF-03
+- Description: The resulting `spi`-bus waveform for a given command/SDO sequence MUST be identical whether driven in FIFO mode or offload mode; only stream readiness/prefetch **timing** differs.
+- Rationale: Offload must not change the wire behavior, only the transport of commands/data.
+- Provenance: `DOCUMENTED` (implied) — **coverage hole:** the TB hardwires `s_offload_active=0`, so this requirement is currently unverified. **`(drivers)`** — both drivers' offload paths reuse the same compiled command list (same commands, different transport), the invariant asserted here. Evidence in `driver.md`.
+
+---
+
+## 10. SPI Bus Outputs (summary of boundary contract)
+
+#### EXEC-BUS-01
+- Description: `sclk` per §5.
+- Rationale: Collects the SCLK contract into the bus-output summary.
+- Provenance: `DOCUMENTED` + `EXTERNAL`
+
+#### EXEC-BUS-02
+- Description: `sdo[NUM_OF_SDIO-1:0]`: per-lane serial out, MSB-first, idle = `sdo_idle_state`.
+- Rationale: Summarizes the transmit-line boundary contract.
+- Provenance: `DOCUMENTED` + `EXTERNAL`
+
+#### EXEC-BUS-03
+- Description: `sdo_t`: 0 (driven) only during a write transfer, 1 (tri-stated) otherwise.
+- Rationale: Summarizes the transmit tri-state contract.
+- Provenance: `DOCUMENTED` + `EXTERNAL`
+
+#### EXEC-BUS-04
+- Description: `cs[NUM_OF_CS-1:0]`: chip-selects with invert mask applied; reset = all-inactive.
+- Rationale: Summarizes the chip-select boundary contract.
+- Provenance: `DOCUMENTED` (mask) / reset `RTL-CHARACTERIZED`
+
+#### EXEC-BUS-05
+- Description: `three_wire` reflects SPI-config bit 2; in three-wire mode the external top level muxes `sdi` onto MOSI.
+- Rationale: Exposes the three-wire mode selection at the boundary.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-BUS-06
+- Description: `sdi[NUM_OF_SDIO-1:0]`: sampled input, up to 8 lanes.
+- Rationale: Summarizes the receive-line boundary contract.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-BUS-07
+- Description: `echo_sclk`: consumed only in `ECHO_SCLK=1` builds (out of scope this revision — see the Echo-SCLK observations in `findings.md`).
+- Rationale: Notes the echo-clock input exists but is out of scope here.
+- Provenance: `RTL-CHARACTERIZED`
+
+---
+
+## 11. Cross-Cutting Corner Cases (regression focus)
+
+Each combines base requirements above; validity domains inherited from them.
+
+#### EXEC-CC-01
+- Description: A Configuration-Write of `word_length` (or lane mask, CPOL/CPHA, div) immediately followed by a Transfer uses the **new** value on that Transfer.
+- Rationale: Verifies the fragile config-then-transfer settling margin (FLAG EXEC-F7).
+- Provenance: `DOCUMENTED` — see FLAG EXEC-F7
+
+#### EXEC-CC-02
+- Description: Single-word (`n=0`) and multi-word (`n>0`) transfers both terminate correctly and return to idle.
+- Rationale: Exercises the transfer-termination boundary at both extremes.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CC-03
+- Description: Minimum and maximum (`=DATA_WIDTH`) `word_length` both work; short words are MSB-aligned (EXEC-SDO-02).
+- Rationale: Exercises the word-length range and alignment together.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CC-04
+- Description: Zero-delay (`t=0`) vs non-zero CS and Sleep instructions both produce the timing of their closed-form formulas.
+- Rationale: Verifies the CS/Sleep timing formulas at both `t=0` and `t>0`.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CC-05
+- Description: An interleaved sequence (CS-assert → config → transfer → sleep → sync → CS-deselect) executes in order with correct idle transitions.
+- Rationale: Verifies in-order execution across a mixed instruction stream.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CC-06
+- Description: Back-to-back transfers with SDI/SDO backpressure inserted at arbitrary bit/word boundaries preserve data integrity and ordering (subject to FLAG EXEC-F1).
+- Rationale: Verifies lossless backpressure handling across consecutive transfers.
+- Provenance: `DOCUMENTED`
+
+#### EXEC-CC-07
+- Description: Reset asserted mid-transfer returns all outputs to their §2 reset values and clears receive state.
+- Rationale: Verifies mid-transfer reset recovery.
+- Provenance: `RTL-CHARACTERIZED`
+
+#### EXEC-CC-08
+- Description: Lane-mask reconfiguration (SDO) between transfers remaps lanes on the next transfer.
+- Rationale: Verifies per-transfer lane remapping in a sequence.
+- Provenance: `RTL-CHARACTERIZED` **`(Linux)`** — Linux rewrites and restores lane masks around multi-lane-mode changes. Evidence in `driver.md`.
+
+#### EXEC-CC-09
+- Description: All `DATA_WIDTH ∈ {8,16,24,32}` and representative `NUM_OF_SDIO` / `NUM_OF_CS` values are exercised.
+- Rationale: Ensures the parameter space is covered, not just the default build.
+- Provenance: `DOCUMENTED` (param space)
+

--- a/testbenches/ip/spi_engine/execution/model_execution.py
+++ b/testbenches/ip/spi_engine/execution/model_execution.py
@@ -1,0 +1,215 @@
+"""Python golden model for spi_engine_execution (hybrid fidelity).
+
+This model is an *independent* reimplementation of the SPI Engine execution
+semantics from the specification / RTL behaviour, deliberately expressed at the
+transaction level (words, not pipeline registers) so it does not merely restate
+the Verilog. It predicts:
+
+  * data correctness: SDO words shifted out, SDI words captured, CS state,
+    SYNC events, configuration register state
+  * cycle-count timing for the timing-sensitive features, via closed-form
+    formulas checked with a ±tolerance to absorb pipeline latency
+
+What it intentionally does NOT model: internal pipeline register values, exact
+bit_counter / clk_div_counter states, data-assembler pipeline stages. ECHO_SCLK
+is out of scope (ECHO_SCLK=0 only), as is SDI_DELAY (fixed 0 this revision; see
+EXEC-SDI-05 / FLAG EXEC-F5). The ``s_offload_active`` input changes only SDO
+prefetch *readiness timing*, not data or waveform (EXEC-OFF-03), so it needs no
+model branch — offload and FIFO mode share this same prediction.
+
+Timing formulas (sclk_period = (clk_div+1)*2 core clocks):
+
+  * SCLK period           : (div+1)*2
+  * transfer duration     : ~ 2 + n_words * word_length * (div+1)*2
+  * CS delay (before)     : 2 + t * (div+1)*2   (t = cmd[9:8])
+  * CS delay (after)      :     t * (div+1)*2
+  * sleep duration        : 2 + (t+1) * (div+1)*2   (t = cmd[7:0])
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from framework.spi import instructions as ins
+
+
+# ----------------------------------------------------------------------------
+# Predicted output records
+# ----------------------------------------------------------------------------
+@dataclass
+class TransferResult:
+    # Multi-lane note (NUM_OF_SDIO > 1): SDO/SDI words are flat lists in
+    # *period-major, lane-minor* order. With L active lanes and n SPI periods,
+    # each list holds n*L words: index (p*L + l) is the word on lane l during
+    # period p. At L=1 this is just one word per period, identical to the
+    # single-lane case, so the same tests cover both. The single input stream is
+    # distributed round-robin across the active lanes (default mask = all lanes).
+    sdo_words: list           # words the DUT should drive on SDO (write side)
+    sdi_words: list           # words the DUT should capture on SDI (read side)
+    n_words: int              # number of SPI periods (cmd[7:0]+1)
+    word_length: int
+    write: bool
+    read: bool
+    n_lanes_sdo: int = 1      # active SDO lanes (popcount of sdo_lane_mask)
+    n_lanes_sdi: int = 1      # active SDI lanes (popcount of sdi_lane_mask)
+
+
+@dataclass
+class SyncEvent:
+    sync_id: int
+
+
+@dataclass
+class CSEvent:
+    cs_value: int             # value driven onto cs[] (post inv-mask XOR)
+
+
+@dataclass
+class ModelOutputs:
+    transfers: list = field(default_factory=list)
+    syncs: list = field(default_factory=list)
+    cs_events: list = field(default_factory=list)
+    sleeps: list = field(default_factory=list)        # predicted durations
+    cs_delays: list = field(default_factory=list)     # predicted durations
+
+
+class ExecutionModel:
+    """Mirrors the engine's configuration state and predicts I/O per command."""
+
+    def __init__(self, params):
+        self.data_width = params["DATA_WIDTH"]
+        self.num_cs = params["NUM_OF_CS"]
+        self.num_sdio = params["NUM_OF_SDIO"]
+        cfg = params["DEFAULT_SPI_CFG"]
+        self.cpha = cfg & 1
+        self.cpol = (cfg >> 1) & 1
+        self.three_wire = (cfg >> 2) & 1
+        self.sdo_idle_state = params.get("SDO_DEFAULT", 0)
+        self.clk_div = params["DEFAULT_CLK_DIV"]
+        self.word_length = self.data_width
+        all_lanes = (1 << self.num_sdio) - 1
+        self.sdi_lane_mask = all_lanes
+        self.sdo_lane_mask = all_lanes
+        self.cs_inv_mask = 0
+        self.cs_state = (1 << self.num_cs) - 1   # reset: all deasserted
+
+        self.outputs = ModelOutputs()
+
+    # ---- timing helpers -------------------------------------------------
+    @property
+    def sclk_period(self):
+        return (self.clk_div + 1) * 2
+
+    def transfer_duration(self, n_words):
+        return 2 + n_words * self.word_length * self.sclk_period
+
+    def sleep_duration(self, t):
+        return 2 + (t + 1) * self.sclk_period
+
+    def cs_delay_before(self, t):
+        return 2 + t * self.sclk_period
+
+    def cs_delay_after(self, t):
+        return t * self.sclk_period
+
+    # ---- command application -------------------------------------------
+    def apply(self, cmd, *, sdo_data=None, sdi_data=None):
+        """Apply one 16-bit command, updating state and predicted outputs.
+
+        ``sdo_data`` : list of words supplied on the SDO stream (write side)
+        ``sdi_data`` : list of words the slave will return (read side)
+        """
+        inst = (cmd >> 12) & 0b111
+        if inst == ins.CMD_TRANSFER:
+            return self._transfer(cmd, sdo_data or [], sdi_data or [])
+        if inst == ins.CMD_CHIPSELECT:
+            return self._chipselect(cmd)
+        if inst == ins.CMD_WRITE:
+            return self._write_reg(cmd)
+        if inst == ins.CMD_MISC:
+            return self._misc(cmd)
+        if inst == ins.CMD_CS_INV:
+            self.cs_inv_mask = cmd & ((1 << self.num_cs) - 1)
+            return None
+        raise ValueError(f"unknown instruction in cmd 0x{cmd:04x}")
+
+    @staticmethod
+    def _popcount(mask):
+        return bin(mask).count("1")
+
+    def _transfer(self, cmd, sdo_data, sdi_data):
+        write = bool((cmd >> 8) & 1)
+        read = bool((cmd >> 9) & 1)
+        n_periods = (cmd & 0xFF) + 1
+        mask = (1 << self.word_length) - 1
+
+        # Active lane counts come from the lane masks (default: all lanes). The
+        # engine drives/captures one word per active lane each SPI period, so a
+        # transfer of n_periods moves n_periods * n_lanes words on that side.
+        n_lanes_sdo = max(1, self._popcount(self.sdo_lane_mask & ((1 << self.num_sdio) - 1)))
+        n_lanes_sdi = max(1, self._popcount(self.sdi_lane_mask & ((1 << self.num_sdio) - 1)))
+
+        # Flat period-major, lane-minor expectations (see TransferResult docs).
+        # The single sdo_data stream is consumed in order and distributed
+        # round-robin across active lanes; SDI is supplied the same way.
+        sdo_words = []
+        if write:
+            total = n_periods * n_lanes_sdo
+            for i in range(total):
+                w = sdo_data[i] if i < len(sdo_data) else 0
+                sdo_words.append(w & mask)
+
+        sdi_words = []
+        if read:
+            total = n_periods * n_lanes_sdi
+            for i in range(total):
+                w = sdi_data[i] if i < len(sdi_data) else 0
+                sdi_words.append(w & mask)
+
+        res = TransferResult(sdo_words, sdi_words, n_periods,
+                             self.word_length, write, read,
+                             n_lanes_sdo=n_lanes_sdo, n_lanes_sdi=n_lanes_sdi)
+        self.outputs.transfers.append(res)
+        return res
+
+    def _chipselect(self, cmd):
+        delay = (cmd >> 8) & 0b11
+        cs_bits = cmd & ((1 << self.num_cs) - 1)
+        # cs <= cmd[NUM_OF_CS-1:0] ^ cs_inv_mask
+        self.cs_state = cs_bits ^ self.cs_inv_mask
+        ev = CSEvent(self.cs_state)
+        self.outputs.cs_events.append(ev)
+        if delay == 0:
+            self.outputs.cs_delays.append(0)          # early-exit, no delay
+        else:
+            self.outputs.cs_delays.append(self.cs_delay_before(delay))
+        return ev
+
+    def _write_reg(self, cmd):
+        reg = (cmd >> 8) & 0b111
+        val = cmd & 0xFF
+        if reg == ins.REG_CLK_DIV:
+            self.clk_div = val
+        elif reg == ins.REG_CONFIG:
+            self.cpha = val & 1
+            self.cpol = (val >> 1) & 1
+            self.three_wire = (val >> 2) & 1
+            self.sdo_idle_state = (val >> 3) & 1
+        elif reg == ins.REG_WORD_LENGTH:
+            self.word_length = val
+        elif reg == ins.REG_SDI_LANE_CONFIG:
+            self.sdi_lane_mask = val
+        elif reg == ins.REG_SDO_LANE_CONFIG:
+            self.sdo_lane_mask = val
+        return None
+
+    def _misc(self, cmd):
+        sub = (cmd >> 8) & 1
+        t = cmd & 0xFF
+        if sub == ins.MISC_SYNC:
+            ev = SyncEvent(t)
+            self.outputs.syncs.append(ev)
+            return ev
+        # MISC_SLEEP
+        self.outputs.sleeps.append(self.sleep_duration(t))
+        return self.outputs.sleeps[-1]

--- a/testbenches/ip/spi_engine/execution/runner.py
+++ b/testbenches/ip/spi_engine/execution/runner.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Build + run entry point for the spi_engine_execution cocotb TB.
+
+Single entry point, no arguments: ``./runner.py``. It builds and runs a
+curated list of DUT-generic configurations (``CONFIGS``), each against the full
+test suite over ``N_SEEDS`` random seeds, and prints one PASS/FAIL summary.
+
+DUT generics are compile-time, so each config is a separate compile. Build and
+run use separate directories keyed differently:
+  * build dir is keyed by (sim, generics, instrumentation) so an unchanged
+    config reuses its binary and differing generics never share a stale one;
+  * run dir is keyed by (runid, config, seed) so no two runs write the same
+    results/coverage file — the basis for safe parallel and multi-agent use.
+
+Each config feeds its generics through BOTH channels the TB needs:
+  * ``build(parameters=...)``   -> simulator generic overrides (the RTL);
+  * ``test(extra_env=PARAM_*)`` -> env vars read by ``tb_env.get_params()`` (the
+    Python golden model). These must agree.
+
+Everything a user edits lives in the CONFIGURATION block below.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from cocotb_tools.runner import get_runner
+
+# ============================ CONFIGURATION ============================
+# Everything a user edits lives in this block.
+
+SIM = "icarus"           # "verilator" (fast, default) or "icarus"
+WHITEBOX = "require"     # "require" internal-signal checks, or "off" (black-box)
+WAVES = False            # dump dump.vcd per run (GTKWave / Surfer)
+COVERAGE = False         # Verilator RTL line coverage -> one merged report
+N_SEEDS = 5              # random seeds per config (each is logged for replay)
+MAX_JOBS = 4             # parallel config-runs; 1 = serial with live output
+
+# Reproduce one run: set SEED to a seed the summary logged, and optionally pin
+# TESTCASE to a single test name. Leave both None for the normal random sweep.
+SEED = None                # int, e.g. 1587325506
+TESTCASE = None            # str, e.g. "test_sdi_handshake_stability"
+
+# Label for this invocation's run/coverage dirs. Give concurrent agents distinct
+# ids to keep their runs apart; None -> "run".
+RUN_ID = None
+
+# Extra compile flags (generics and --coverage are added automatically).
+VERILATOR_BUILD_ARGS = ["--timing", "-Wno-fatal"]
+ICARUS_BUILD_ARGS = []
+
+# Configs to be executed are defined after the "class Config"
+# ========================== END CONFIGURATION ==========================
+
+
+HERE = Path(__file__).resolve().parent
+# Bootstrap: put <repo>/cocotb on sys.path so `framework.*` imports resolve.
+# This is the one unavoidable relative hop — every path anchor beyond it
+# (REPO_ROOT, COCOTB_DIR) is derived once in framework.paths.
+_COCOTB_DIR = (HERE / "../../../../cocotb").resolve()
+if str(_COCOTB_DIR) not in sys.path:
+    sys.path.insert(0, str(_COCOTB_DIR))
+
+from framework.sweep import (  # noqa: E402
+    SweepLayout,
+    dispatch,
+    merge_and_report_coverage,
+    parse_results,
+    print_analysis,
+)
+
+_adi_hdl_dir = os.environ.get("ADI_HDL_DIR")
+if not _adi_hdl_dir:
+    sys.exit("ADI_HDL_DIR export missing\n  Example: export ADI_HDL_DIR=/path/to/hdl")
+HDL_DIR = Path(_adi_hdl_dir).resolve()
+EXEC_DIR = HDL_DIR / "library/spi_engine/spi_engine_execution"
+
+# The runner exports PYTHONPATH from this process's sys.path (it ignores an
+# extra_env PYTHONPATH), so the test modules import `framework` and the local
+# `model_execution`/`tb_env` only if those dirs are on sys.path here. COCOTB_DIR
+# is already on sys.path (added above for the framework import); add the TB dir.
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+TOPLEVEL = "spi_engine_execution"
+VERILOG_SOURCES = [
+    EXEC_DIR / "spi_engine_execution.v",
+    EXEC_DIR / "spi_engine_execution_shiftreg.v",
+    EXEC_DIR / "spi_engine_execution_shiftreg_data_assemble.v",
+]
+for src in VERILOG_SOURCES:
+    assert src.exists(), f"src file not found {src}"
+
+# Every test module. cocotb runs them all unless TESTCASE pins a single test.
+TEST_MODULES = [
+    "test_reset", "test_command", "test_transfer", "test_chipselect",
+    "test_config", "test_misc", "test_waveform", "test_flow_control",
+    "test_lanes", "test_offload", "test_sequences",
+]
+
+# Short tags for compact config names (dw8_cs1_sd1_cfg0_div0_echo0).
+_TAGS = {
+    "DATA_WIDTH": "dw", "NUM_OF_CS": "cs", "NUM_OF_SDIO": "sd",
+    "DEFAULT_SPI_CFG": "cfg", "DEFAULT_CLK_DIV": "div", "ECHO_SCLK": "echo",
+}
+
+
+@dataclass
+class Config:
+    """One generic combination (the VUnit ``add_config`` analogue).
+
+    Fields default to the DUT's own generic defaults; a config only overrides
+    what it exercises. ``name`` is derived from the generics for the build dir
+    and the report.
+    """
+    data_width: int = 8
+    num_of_cs: int = 1
+    num_of_sdio: int = 1
+    spi_cfg: int = 0
+    default_clk_div: int = 0
+    echo_sclk: int = 0
+    # TODO: the RTL also has SDO_DEFAULT and SDI_DELAY generics; add fields for
+    # them here (and in generics/_TAGS below) so they can be swept. They are
+    # pinned at their RTL defaults today — see the TODOs under CONFIGS.
+
+    @property
+    def generics(self) -> dict:
+        return {
+            "DATA_WIDTH": self.data_width,
+            "NUM_OF_CS": self.num_of_cs,
+            "NUM_OF_SDIO": self.num_of_sdio,
+            "DEFAULT_SPI_CFG": self.spi_cfg,
+            "DEFAULT_CLK_DIV": self.default_clk_div,
+            "ECHO_SCLK": self.echo_sclk,
+        }
+
+    @property
+    def name(self) -> str:
+        return "_".join(f"{_TAGS[k]}{v}" for k, v in self.generics.items())
+
+
+# Configs to build + run: the baseline, one variation per generic, then a
+# combined stress config. Exercises every generic's interesting values without
+# the full cartesian blow-up.
+#
+# To run a single custom config, comment out the sweep and add your own, e.g.:
+#   CONFIGS = [Config(data_width=32, num_of_sdio=4, default_clk_div=2)]
+CONFIGS = [
+    Config(),                                       # baseline: 8-bit, 1 CS, 1 lane, mode 0
+    Config(data_width=24),                          # non-power-of-2 word
+    Config(data_width=32),                          # widest typical word
+    Config(num_of_cs=2),                            # multiple chip selects
+    Config(num_of_cs=4),
+    Config(num_of_sdio=2),                          # multi-lane (dual)
+    Config(num_of_sdio=3),                          # multi-lane (odd; non-contiguous sub-mask)
+    Config(num_of_sdio=4),                          # multi-lane (quad)
+    Config(spi_cfg=3),                              # CPOL+CPHA reset defaults
+    Config(default_clk_div=2),                      # slower SCLK
+    Config(data_width=32, num_of_cs=2, num_of_sdio=4, spi_cfg=3),  # combined stress
+]
+# TODO: add Config(echo_sclk=1). The current TB does not support it: tb_env ties
+# the echo_sclk input to a constant 0, but ECHO_SCLK=1 clocks the entire SDI
+# capture path off that port, so every read transfer hangs. Once the TB drives
+# echo_sclk (loop sclk back to it) this becomes a real config. NOTE: spi_cfg=1/2
+# (DEFAULT_SPI_CFG[1:0] == 01/10) subtly change the ECHO branch too — they select
+# a neg- vs pos-edge MISO latch — so echo_sclk is interesting to sweep together
+# with spi_cfg=1 and spi_cfg=2.
+# TODO: add Config(spi_cfg=1) and Config(spi_cfg=2).
+# TODO: add Config(data_width=16).
+# TODO: add a Config(sdi_delay=...) sweep over SDI_DELAY (0..3).
+# TODO: add a Config(sdo_default=1) sweep over SDO_DEFAULT.
+# ======================================================================
+
+_RUNID = RUN_ID or "run"
+
+SIM_BUILD = HERE / "sim_build"
+
+# The reusable directory-layout / build-flag rules live in the framework; this
+# runner only supplies the values from the CONFIGURATION block above.
+LAYOUT = SweepLayout(
+    sim=SIM,
+    build_root=SIM_BUILD / "build",
+    runs_root=SIM_BUILD / "runs" / _RUNID,
+    coverage_dir=SIM_BUILD / "coverage" / _RUNID,
+    coverage=COVERAGE,
+    waves=WAVES,
+    verilator_build_args=tuple(VERILATOR_BUILD_ARGS),
+    icarus_build_args=tuple(ICARUS_BUILD_ARGS),
+)
+RUNS_ROOT = LAYOUT.runs_root
+
+
+def build_config(cfg: Config) -> tuple[Config, bool, Path]:
+    """Compile one config into its build dir. Returns (cfg, ok, log).
+
+    Output goes to build.log, never the terminal — a full sweep is too noisy.
+    """
+    bdir = LAYOUT.build_dir(cfg.name)
+    log = bdir / "build.log"
+    try:
+        get_runner(SIM).build(
+            sources=VERILOG_SOURCES,
+            hdl_toplevel=TOPLEVEL,
+            parameters=cfg.generics,          # -> simulator generic overrides
+            build_args=LAYOUT.build_args(),
+            build_dir=bdir,
+            waves=WAVES,
+            log_file=log,
+        )
+        return (cfg, True, log)
+    except (SystemExit, RuntimeError):
+        return (cfg, False, log)
+
+
+def run_config(cfg: Config, seed: int):
+    """Run one built config for one seed in its own run dir.
+
+    Returns (tag, rows, secs); rows is [(name, ran, failed)] parsed from the
+    JUnit XML, or None if the sim crashed (no results file). Output goes to
+    run.log, never the terminal. Verilator writes coverage.dat into the run dir
+    (its cwd), so no per-seed copy is needed.
+    """
+    tag = f"{cfg.name}_seed{seed}"
+    tdir = LAYOUT.run_dir(cfg.name, seed)
+    log = tdir / "run.log"
+    t0 = time.perf_counter()
+
+    # tb_env.get_params() reads PARAM_<NAME> from the environment, so mirror the
+    # generics there too (build parameters alone don't reach the Python model).
+    extra_env = {f"PARAM_{name}": str(val) for name, val in cfg.generics.items()}
+    extra_env["WHITEBOX"] = WHITEBOX
+    # The TB RNG reads RANDOM_SEED (random_ctx.from_env); the runner's seed= only
+    # sets COCOTB_RANDOM_SEED. Set both so the logged seed actually reproduces.
+    extra_env["RANDOM_SEED"] = str(seed)
+
+    try:
+        # A fresh runner never saw build()'s sources, so pin the language rather
+        # than let test() infer it from unset source attributes.
+        results_xml = get_runner(SIM).test(
+            hdl_toplevel=TOPLEVEL,
+            hdl_toplevel_lang="verilog",
+            test_module=TEST_MODULES,
+            seed=seed,
+            extra_env=extra_env,
+            build_dir=LAYOUT.build_dir(cfg.name),
+            test_dir=tdir,
+            waves=WAVES,
+            testcase=TESTCASE,
+            log_file=log,
+        )
+        return (tag, parse_results(results_xml), time.perf_counter() - t0)
+    except (SystemExit, RuntimeError):
+        return (tag, None, time.perf_counter() - t0)
+
+
+def main() -> int:
+    if COVERAGE and SIM != "verilator":
+        print(f"coverage: ignored (only supported on verilator, SIM={SIM}).", file=sys.stderr)
+
+    seeds = (
+        [SEED] if SEED is not None else [random.randrange(1, 1 << 31) for _ in range(N_SEEDS)]
+    )
+
+    print(f"SIM={SIM} WHITEBOX={WHITEBOX} WAVES={WAVES} COVERAGE={COVERAGE} "
+          f"MAX_JOBS={MAX_JOBS} RUN_ID={_RUNID}")
+    print(f"Running {len(CONFIGS)} config(s) x {len(seeds)} seed(s); "
+          f"seeds = {seeds}"
+          + (f"; TESTCASE={TESTCASE}" if TESTCASE else ""))
+
+    # Build phase: one compile per config into distinct dirs (parallel-safe,
+    # no shared-dir race), so the run phase only ever reads finished binaries.
+    print("Building...")
+    t0 = time.perf_counter()
+    built = {}
+    for cfg, ok, log in dispatch(build_config, [(cfg,) for cfg in CONFIGS],
+                                 max_jobs=MAX_JOBS):
+        built[cfg.name] = ok
+        mark = "" if ok else " FAILED"
+        print(f"  build complete{mark} - {log}")
+    print(f"All builds complete! (took {time.perf_counter() - t0:.1f}s)")
+
+    results = []                        # (status, tag, ntests, nfailed, nskipped)
+    counts: dict[str, int] = {}         # per-test execution tally across the sweep
+    failures: dict[str, list[str]] = {}  # test name -> run tags where it failed
+    skips: dict[str, list[str]] = {}     # test name -> run tags where it skipped
+
+    for cfg in CONFIGS:
+        if not built[cfg.name]:
+            for seed in seeds:
+                results.append(("FAIL", f"{cfg.name}_seed{seed}", 0, 0, 0))
+
+    print("\n" + "=" * 18 + " RUN RESULTS " + "=" * 18)
+    # Align the "(tests=...)" column: tags vary in width across configs.
+    align = max(len(f"{cfg.name}_seed{seed}") for seed in seeds for cfg in CONFIGS) + 2
+    # Run phase: unique run dir per (config, seed), so workers never clash on
+    # results/coverage files. Ctrl+C still reports the runs that did finish.
+    jobs = [(cfg, seed) for seed in seeds for cfg in CONFIGS if built[cfg.name]]
+    run_tag = lambda job: f"{job[0].name}_seed{job[1]}"
+    try:
+        for tag, rows, secs in dispatch(run_config, jobs, max_jobs=MAX_JOBS,
+                                        label=run_tag):
+            if rows is None:
+                results.append(("FAIL", tag, 0, 0, 0))
+                print(f"FAIL  {tag:<{align}}(aborted, no results file)")
+                continue
+            for name, ran, failed in rows:
+                counts[name] = counts.get(name, 0) + (1 if ran else 0)
+                if failed:
+                    failures.setdefault(name, []).append(tag)
+                elif not ran:
+                    skips.setdefault(name, []).append(tag)
+            ntests = len(rows)
+            nfailed = sum(1 for _, _, f in rows if f)
+            nskipped = sum(1 for _, ran, _ in rows if not ran)
+            status = "PASS" if nfailed == 0 else "FAIL"
+            results.append((status, tag, ntests, nfailed, nskipped))
+            print(f"{status}  {tag:<{align}}"
+                  f"(tests={ntests} fail={nfailed} skip={nskipped} in {secs:.1f}s)")
+    except KeyboardInterrupt:
+        print("\n^C — interrupted; reporting the runs that finished.", file=sys.stderr)
+
+    print_analysis(counts, failures, skips, RUNS_ROOT)
+
+    if COVERAGE and SIM == "verilator":
+        merge_and_report_coverage(LAYOUT.runs_root, LAYOUT.coverage_dir)
+
+    fail_total = sum(1 for status, *_ in results if status == "FAIL")
+    if fail_total:
+        print(f"\nSWEEP RESULT: {fail_total} config-run(s) FAILED")
+        return 1
+    print(f"\nSWEEP RESULT: all {len(results)} config-run(s) PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testbenches/ip/spi_engine/execution/tb_env.py
+++ b/testbenches/ip/spi_engine/execution/tb_env.py
@@ -1,0 +1,386 @@
+"""Test environment for spi_engine_execution: wires DUT to framework agents.
+
+Centralises clock/reset bring-up, the CMD and SDO drivers, the SDI/SYNC
+monitors, the SPI bus monitor and slave model, the golden model, and the
+scoreboard so each test reads as stimulus + check rather than boilerplate.
+"""
+
+from __future__ import annotations
+
+import os
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, ClockCycles, Timer
+
+from framework.axi_stream import AXIStreamDriver, AXIStreamMonitor
+from framework.backpressure import RandomBackpressure
+from framework.scoreboard import Scoreboard
+from framework.random_ctx import RandomContext
+from framework.reset import apply_reset, check_reset_values
+from framework.spi.bus_monitor import SPIBusMonitor
+from framework.spi.slave_model import SPISlaveModel
+from framework.spi import instructions as ins
+
+from model_execution import ExecutionModel
+
+CLK_PERIOD_NS = 10
+
+# Verilator inlines module boundaries and prunes internal nets unless they are
+# kept public; this flag exposes them so hierarchical hooks resolve. Named here
+# so the whitebox failure message can point the user at it.
+VERILATOR_PUBLIC_FLAG = "--public-flat-rw"
+
+
+def get_params():
+    return {
+        "DATA_WIDTH": int(os.environ.get("PARAM_DATA_WIDTH", 8)),
+        "NUM_OF_CS": int(os.environ.get("PARAM_NUM_OF_CS", 1)),
+        "NUM_OF_SDIO": int(os.environ.get("PARAM_NUM_OF_SDIO", 1)),
+        "DEFAULT_SPI_CFG": int(os.environ.get("PARAM_DEFAULT_SPI_CFG", 0)),
+        "DEFAULT_CLK_DIV": int(os.environ.get("PARAM_DEFAULT_CLK_DIV", 0)),
+        "ECHO_SCLK": int(os.environ.get("PARAM_ECHO_SCLK", 0)),
+        "SDO_DEFAULT": 0,
+    }
+
+
+class WhiteboxSignalError(Exception):
+    """An expected internal (white-box) DUT signal could not be resolved.
+
+    Raised inside a test coroutine, so cocotb marks only that test as failed
+    and continues with the rest of the suite — the TB is not halted.
+    """
+
+
+def _resolve_whitebox(dut, path, *, mode):
+    """Resolve a hierarchical internal signal handle (e.g. "shiftreg.trigger_rx_s").
+
+    ``mode="require"`` (default): raise :class:`WhiteboxSignalError` if any
+    segment of the path is missing — the sim optimized it away or it is not
+    accessible. The message is simulator-agnostic but points Verilator users at
+    the flag that keeps internal nets public.
+
+    ``mode="off"``: return ``None`` on a miss, so the caller degrades to its
+    black-box strategy on purpose.
+    """
+    node = dut
+    for seg in path.split("."):
+        node = getattr(node, seg, None)
+        if node is None:
+            if mode == "off":
+                return None
+            raise WhiteboxSignalError(
+                f"unable to hook into whitebox signal <{path}> - "
+                f"if using verilator use flag <{VERILATOR_PUBLIC_FLAG}>")
+    return node
+
+
+class ExecutionTB:
+    def __init__(self, dut, *, whitebox=None):
+        # Default from the environment so a deliberate black-box run of the whole
+        # suite is `WHITEBOX=off make`; an explicit kwarg always wins.
+        if whitebox is None:
+            whitebox = os.environ.get("WHITEBOX", "require")
+        if whitebox not in ("require", "off"):
+            raise ValueError(
+                f"whitebox must be 'require' or 'off', got {whitebox!r}")
+        self.dut = dut
+        self.log = dut._log
+        self.whitebox = whitebox
+        self.params = get_params()
+        self.rc = RandomContext.from_env(self.log)
+        self.model = ExecutionModel(self.params)
+        self.sb = Scoreboard("execution", logger=self.log)
+        self._sdo_tasks = []
+
+        # Drivers (manager side).
+        self.cmd = AXIStreamDriver.from_dut(
+            dut, "cmd", rng=self.rc.derive("cmd_gap"))
+        self.sdo = AXIStreamDriver.from_dut(
+            dut, "sdo_data", rng=self.rc.derive("sdo_gap"))
+
+        # Monitors (passive).
+        self.sdi_mon = AXIStreamMonitor.from_dut(dut, "sdi_data")
+        self.sync_mon = AXIStreamMonitor.from_dut(dut, "sync")
+
+        # SPI-side observation + stimulus.
+        cfg = self.params["DEFAULT_SPI_CFG"]
+        self.num_sdio = self.params["NUM_OF_SDIO"]
+        # Gate sampling on transfer_active so CPOL idle-level settling between
+        # transfers cannot inject phantom SCLK edges into a captured word. In
+        # whitebox="require" mode a missing hook fails this test (and only this
+        # test); in "off" mode it resolves to None and the agents run black-box.
+        gate = _resolve_whitebox(dut, "transfer_active", mode=self.whitebox)
+        # Kept so the sdo_t sampler can *time* its boundary read to the transfer
+        # window; the pass/fail check is on the boundary sdo_t output.
+        self.gate = gate
+        self.bus_mon = SPIBusMonitor(
+            dut, cpol=(cfg >> 1) & 1, cpha=cfg & 1,
+            word_length=self.params["DATA_WIDTH"],
+            num_sdio=self.num_sdio,
+            gate_signal=gate)
+        # Prefer the DUT's actual SDI sample strobe (trigger_rx_s in the shiftreg
+        # submodule) to drive the slave: it stays in lock-step with the DUT's SDI
+        # shift register even under backpressure stalls, where SCLK emits phantom
+        # edges that a black-box edge-counting slave would miscount.
+        strobe = _resolve_whitebox(
+            dut, "shiftreg.trigger_rx_s", mode=self.whitebox)
+        self.slave = SPISlaveModel(
+            dut, cpol=(cfg >> 1) & 1, cpha=cfg & 1,
+            word_length=self.params["DATA_WIDTH"],
+            num_sdio=self.params["NUM_OF_SDIO"],
+            rng=self.rc.derive("slave"),
+            gate_signal=gate,
+            sample_strobe=strobe)
+
+        # Backpressure controllers on consumer-side ready signals.
+        self.bp_sdi = RandomBackpressure(
+            dut.clk, dut.sdi_data_ready, self.rc.derive("bp_sdi"), name="sdi")
+        self.bp_sync = RandomBackpressure(
+            dut.clk, dut.sync_ready, self.rc.derive("bp_sync"), name="sync")
+
+    async def start(self):
+        self.rc.log_seed()
+        self.log.info(f"DUT params: {self.params}")
+        cocotb.start_soon(Clock(self.dut.clk, CLK_PERIOD_NS, unit="ns").start())
+        self._init_inputs()
+        await apply_reset(self.dut)
+        # Default: all consumers ready, monitors running.
+        self.bp_sdi.start_always_ready()
+        self.bp_sync.start_always_ready()
+        self.sdi_mon.start()
+        self.sync_mon.start()
+        self.bus_mon.start()
+
+    def _init_inputs(self):
+        d = self.dut
+        d.resetn.value = 0
+        d.s_offload_active.value = 0
+        d.cmd_valid.value = 0
+        d.cmd.value = 0
+        d.sdo_data_valid.value = 0
+        d.sdo_data.value = 0
+        d.sdi_data_ready.value = 0
+        d.sync_ready.value = 0
+        d.echo_sclk.value = 0
+        d.sdi.value = 0
+
+    # ---- convenience command issue (drives DUT + advances golden model) --
+    async def issue(self, cmd, *, sdo_data=None, sdi_data=None):
+        """Send a command on the CMD stream and apply it to the golden model.
+
+        For transfers, ``sdo_data`` is streamed on the SDO data interface and
+        ``sdi_data`` is loaded into the slave model.
+        """
+        res = self.model.apply(cmd, sdo_data=sdo_data, sdi_data=sdi_data)
+        # Reconfigure SPI-side agents if this command changed mode/length.
+        self._sync_agents_from_model()
+        if sdi_data is not None:
+            # Load the model's canonical flat layout (period-major, lane-minor)
+            # so the slave drives the right word on each active lane per period.
+            self.slave.load(res.sdi_words if res is not None else sdi_data)
+        await self.cmd.send(cmd)
+        return res
+
+    async def stream_sdo(self, words, *, min_gap=0, max_gap=0):
+        """Stream SDO data words (write transfers consume these)."""
+        await self.sdo.send_queue(words, min_gap=min_gap, max_gap=max_gap)
+
+    def start_sdo_stream(self, words, *, min_gap=0, max_gap=0):
+        """Start a tracked background SDO stream (cancellable via abort())."""
+        task = cocotb.start_soon(
+            self.stream_sdo(words, min_gap=min_gap, max_gap=max_gap))
+        self._sdo_tasks.append(task)
+        return task
+
+    def abort_streams(self):
+        """Kill any in-flight SDO streams and deassert sdo_data_valid.
+
+        Used after an injected reset aborts a transfer, so leftover words do not
+        leak onto the bus during the next transfer.
+        """
+        for t in self._sdo_tasks:
+            t.kill()
+        self._sdo_tasks = []
+        self.dut.sdo_data_valid.value = 0
+
+    def after_reset(self):
+        """Clean up TB-side state after an injected DUT reset.
+
+        Aborts leftover SDO streams, flushes the bus monitor's partial word, and
+        resets the golden model so its state matches the freshly-reset DUT.
+        """
+        self.abort_streams()
+        self.bus_mon.flush()
+        self.bus_mon.words.clear()
+        self.sdi_mon.received.clear()
+        self.model = ExecutionModel(self.params)
+
+    async def run_transfer(self, *, n, write, read, sdo_words=None,
+                           sdi_words=None, sdo_gap=(0, 0), cs=0):
+        """Assert CS, run one transfer to completion, return (result).
+
+        Streams SDO words concurrently (with optional random gaps) and starts
+        the slave model for reads. Leaves CS asserted on return.
+        """
+        await self.issue(ins.chipselect(cs, delay=1))
+        await self.wait_idle()
+        res = await self.issue(ins.transfer(n - 1, write=write, read=read),
+                               sdo_data=sdo_words, sdi_data=sdi_words)
+        tasks = []
+        if write and sdo_words is not None:
+            # Stream the model's canonical flat layout (n_periods * n_lanes
+            # words, masked) so multi-lane round-robin distribution is handled
+            # in one place rather than at every call site.
+            tasks.append(cocotb.start_soon(
+                self.stream_sdo(res.sdo_words, min_gap=sdo_gap[0],
+                                max_gap=sdo_gap[1])))
+        if read:
+            self.slave.start()
+        await self.wait_idle()
+        await ClockCycles(self.dut.clk, 3)
+        return res
+
+    def _sync_agents_from_model(self):
+        self.bus_mon.configure(cpol=self.model.cpol, cpha=self.model.cpha,
+                               word_length=self.model.word_length,
+                               sdo_lane_mask=self.model.sdo_lane_mask,
+                               sdi_lane_mask=self.model.sdi_lane_mask)
+        self.slave.configure(cpol=self.model.cpol, cpha=self.model.cpha,
+                             word_length=self.model.word_length,
+                             sdi_lane_mask=self.model.sdi_lane_mask)
+
+    @property
+    def sdi_values(self):
+        """Consumer-side SDI words flattened period-major, active-lane-minor.
+
+        Each accepted ``sdi_data`` AXI beat carries NUM_OF_SDIO*DATA_WIDTH bits
+        (one captured word per lane, lane l at bits [l*DW +: DW]). Split each
+        beat into its active lanes in ascending order so the result lines up
+        with the golden model's flat expectation. At a single lane this is just
+        the raw beat values (the previous ``sdi_mon.values``).
+        """
+        if self.num_sdio == 1:
+            return self.sdi_mon.values
+        dw = self.params["DATA_WIDTH"]
+        mask = (1 << dw) - 1
+        lanes = [l for l in range(self.num_sdio)
+                 if (self.model.sdi_lane_mask >> l) & 1]
+        out = []
+        for beat in self.sdi_mon.values:
+            for l in lanes:
+                out.append((beat >> (l * dw)) & mask)
+        return out
+
+    # ---- boundary timing utilities (shared by timing/waveform tests) -----
+    def now_cycles(self):
+        """Current sim time expressed in whole core-clock cycles."""
+        from cocotb.utils import get_sim_time
+        return int(get_sim_time("ns") / CLK_PERIOD_NS)
+
+    async def measure_sclk_period(self, *, timeout=4000):
+        """Measure the SCLK period in core-clock cycles (two rising edges).
+
+        Observes only the boundary ``sclk`` output. Returns -1 if two edges are
+        not seen within ``timeout`` core clocks.
+        """
+        dut = self.dut
+        prev = int(dut.sclk.value)
+        edges = []
+        for _ in range(timeout):
+            await RisingEdge(dut.clk)
+            cur = int(dut.sclk.value)
+            if prev == 0 and cur == 1:
+                edges.append(self.now_cycles())
+                if len(edges) == 2:
+                    return edges[1] - edges[0]
+            prev = cur
+        return -1
+
+    async def wait_idle(self, *, timeout_cycles=100000):
+        """Wait until the engine returns to idle (cmd_ready high)."""
+        for _ in range(timeout_cycles):
+            await RisingEdge(self.dut.clk)
+            if int(self.dut.cmd_ready.value) == 1:
+                return
+        raise TimeoutError("engine did not return to idle")
+
+    def check_reset_values(self):
+        return check_reset_values(self.dut, self.params, scoreboard=self.sb)
+
+    def check_reset_values_extra(self, *, index=-1):
+        """DUT-specific reset-value checks not in the generic reset helper.
+
+        Covers boundary outputs the spec pins at reset that the reusable
+        ``framework.reset.check_reset_values`` (kept DUT-generic) does not: the
+        SPI-config-derived ``three_wire`` (EXEC-RST-06), ``sdi_data_valid`` low
+        (EXEC-RST-06), and every ``sdo`` lane resting at ``sdo_idle_state``
+        (EXEC-RST-05). Placed here rather than in the generic helper to avoid
+        adding more DUT knowledge to Tier 1 (that file already carries some).
+        Returns a list of human-readable error strings.
+        """
+        cfg = self.params["DEFAULT_SPI_CFG"]
+        expected_three_wire = (cfg >> 2) & 1
+        idle = self.params.get("SDO_DEFAULT", 0)
+        expected_sdo = (idle * ((1 << self.num_sdio) - 1))  # every lane = idle
+        checks = [
+            ("three_wire", int(self.dut.three_wire.value), expected_three_wire),
+            ("sdi_data_valid", int(self.dut.sdi_data_valid.value), 0),
+            ("sdo", int(self.dut.sdo.value), expected_sdo),
+        ]
+        errs = []
+        for name, actual, expected in checks:
+            self.sb.compare(index, f"reset.{name}", expected, actual)
+            if actual != expected:
+                errs.append(f"{name}={actual} expected {expected}")
+        return errs
+
+    # ---- offload boundary interaction (prefetch/readiness only) -----
+    def set_offload_active(self, active):
+        """Drive the s_offload_active boundary input (EXEC-OFF-01/02).
+
+        This is the only offload-related signal exposed at this module's
+        boundary; full offload semantics belong to the offload IP, so the
+        tests using this only observe SDO prefetch *readiness* timing, never
+        RAM/trigger behaviour.
+        """
+        self.dut.s_offload_active.value = 1 if active else 0
+
+    async def observe_sdo_ready_before_cmd(self, *, window=40):
+        """Watch whether sdo_data_ready asserts *before* a write instruction.
+
+        Returns True if the DUT asserts ``sdo_data_ready`` (prefetch) while idle,
+        ahead of any transfer command being issued. Used to distinguish offload
+        prefetch (EXEC-OFF-01) from the FIFO-mode behaviour where the engine only
+        requests SDO data after the write instruction. Purely observational on a
+        boundary handshake output.
+        """
+        prefetched = False
+        for _ in range(window):
+            await RisingEdge(self.dut.clk)
+            if int(self.dut.sdo_data_ready.value) == 1:
+                prefetched = True
+                break
+        return prefetched
+
+    async def sample_sdo_t_during_transfer(self, *, settle=2, timeout=2000):
+        """Return the sdo_t value sampled while a transfer is active.
+
+        Times the boundary read to the transfer window using the transfer gate
+        (a stimulus-timing use of an internal signal), waiting ``settle``
+        cycles after the window opens so the registered ``sdo_t`` output has
+        stabilised; the returned value is the boundary ``sdo_t`` output, which is
+        what the caller asserts on. Returns None if no active window is seen
+        within ``timeout`` cycles.
+        """
+        if self.gate is None:
+            return None
+        for _ in range(timeout):
+            await RisingEdge(self.dut.clk)
+            if int(self.gate.value) == 1:
+                for _ in range(settle):
+                    if int(self.gate.value) != 1:
+                        break
+                    await RisingEdge(self.dut.clk)
+                return int(self.dut.sdo_t.value)
+        return None

--- a/testbenches/ip/spi_engine/execution/test_chipselect.py
+++ b/testbenches/ip/spi_engine/execution/test_chipselect.py
@@ -1,0 +1,214 @@
+"""Chip-Select and CS-Invert-Mask, and EXEC-CC-04.
+
+Covers driving cs to the selected value (active-low), the prescaled CS pre/post
+delay timing (EXEC-CS-02), the t=0 early-exit path, sparse multi-select
+(RTL-CHARACTERIZED lock), receive-state clear on assert, and the CS-invert mask
+(polarity flip, persistence, and that the clear keys on the logical selection).
+
+Assertions are on the boundary cs output and command timing only.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_cs_select_deselect(dut):
+    """CS drives the selected value (active-low) and fully deselects."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    res = await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CS-01 - cs driven to s (field bit 0 selects device, active-low)
+    # REQ: EXEC-PARAM-01 - NUM_OF_CS sizes the cs bus
+    tb.sb.compare(0, "cs.asserted", res.cs_value, int(dut.cs.value))
+
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    res2 = await tb.issue(ins.chipselect(allcs, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    tb.sb.compare(1, "cs.deasserted", res2.cs_value, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_no_delay(dut):
+    """CS with t=0 applies the change via the early-exit path (no pre/post wait)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    res = await tb.issue(ins.chipselect(0, delay=0))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CS-03 - t=0 applies CS with only fixed internal latency
+    tb.sb.compare(0, "cs.nodelay", res.cs_value, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_delay_timing(dut):
+    """CS change and completion times match the closed-form formulas (±tol)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    div = 2
+    await tb.issue(ins.config_clk_div(div))
+    await tb.wait_idle()
+    # Ensure a known starting cs (all deselected) so the change is observable.
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.chipselect(allcs, delay=0))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 3)
+
+    t = 3
+    before_val = int(dut.cs.value)
+    start = tb.now_cycles()
+    res = await tb.issue(ins.chipselect(0, delay=t))
+    # Time until cs actually changes.
+    change_at = None
+    for _ in range(400):
+        await RisingEdge(dut.clk)
+        if int(dut.cs.value) != before_val:
+            change_at = tb.now_cycles() - start
+            break
+    await tb.wait_idle()
+    total = tb.now_cycles() - start
+
+    tb.sb.compare(0, "cs.delay_value", res.cs_value, int(dut.cs.value))
+    # REQ: EXEC-CS-02 - cs changes at 2 + t*(div+1)*2 core clocks
+    tb.sb.compare_within(0, "cs_delay_before",
+                         tb.model.cs_delay_before(t), change_at, 3)
+    # REQ: EXEC-CC-04 - non-zero CS delay produces its closed-form timing
+    total_expected = 2 + 2 * t * tb.model.sclk_period
+    tb.sb.compare_within(0, "cs_delay_total", total_expected, total, 4)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_sparse_multi_select(dut):
+    """Sparse multi-CS select (RTL-CHARACTERIZED lock; NUM_OF_CS>1 only).
+
+    Neither reference driver ever selects a sparse subset (spec Appendix C: both
+    single-select or fully deselect), so this pins the RTL's documented
+    "any subset may be selected" behaviour as a regression lock, not conformance.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    ncs = tb.params["NUM_OF_CS"]
+    if ncs < 2:
+        # Degenerates to the single-line case, already covered elsewhere.
+        return
+    # Select lowest and highest lines, leave the middle deselected: field bits
+    # 0 for selected (active-low), 1 for deselected.
+    allcs = (1 << ncs) - 1
+    sel = allcs & ~1 & ~(1 << (ncs - 1))  # low & high bits driven to 0
+    res = await tb.issue(ins.chipselect(sel, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CS-05 - any subset of cs lines may be selected simultaneously
+    tb.sb.compare(0, "cs.sparse", res.cs_value, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_assert_clears_receive_state(dut):
+    """Asserting a chip-select clears residual receive state before capture.
+
+    Two reads separated by a CS re-assert both return exactly their fresh
+    responses; the assert-driven clear (EXEC-CS-04) guarantees no bleed-through
+    from the previous transfer. The pure-deselect *non*-trigger is an internal
+    gating detail (RTL-CHARACTERIZED) not independently boundary-observable, so
+    only the assert-clears half is asserted here.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("cs_rxclear")
+
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    for k in range(2):
+        await tb.issue(ins.chipselect(0, delay=1))  # assert -> clears rx state
+        await tb.wait_idle()
+        resp = [rng.randrange(1 << wl) for _ in range(2 * tb.num_sdio)]
+        tb.sdi_mon.received.clear()
+        res = await tb.issue(ins.transfer(1, write=False, read=True),
+                             sdi_data=resp)
+        tb.slave.start()
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 8)
+        # REQ: EXEC-CS-04 - CS assert clears residual rx state; capture is clean
+        tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field=f"rx[{k}]")
+        tb.slave.stop()
+        await tb.issue(ins.chipselect(allcs, delay=1))  # deselect between reads
+        await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_invert_mask(dut):
+    """CS-invert mask flips polarity of the driven cs bits."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    mask = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.cs_invert(mask))
+    await tb.wait_idle()
+
+    res = await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CSINV-01 - masked cs pins inverted at the output register
+    tb.sb.compare(0, "cs.inverted", res.cs_value, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_invert_persists(dut):
+    """The invert mask persists across subsequent CS instructions."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    mask = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.cs_invert(mask))
+    await tb.wait_idle()
+
+    # Several CS instructions after a single mask write: all see the inversion.
+    for k, sel in enumerate((0, mask, 0)):
+        res = await tb.issue(ins.chipselect(sel, delay=1))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 2)
+        # REQ: EXEC-CSINV-02 - mask persists across CS instructions until rewrite
+        tb.sb.compare(k, "cs.inv_persist", res.cs_value, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cs_invert_clear_keys_on_logical(dut):
+    """The rx-clear keys on the logical selection, not the inverted pin level.
+
+    With a full invert mask, selecting logical device 0 drives cs high (inverted)
+    yet must still perform the assert-clear so the following read is clean —
+    proving the clear logic keys on the logical selection (EXEC-CSINV-03), not on
+    the physical pin level.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("cs_inv_clear")
+    mask = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.cs_invert(mask))
+    await tb.wait_idle()
+
+    await tb.issue(ins.chipselect(0, delay=1))  # logical select, pins go high
+    await tb.wait_idle()
+    resp = [rng.randrange(1 << wl) for _ in range(2 * tb.num_sdio)]
+    tb.sdi_mon.received.clear()
+    res = await tb.issue(ins.transfer(1, write=False, read=True), sdi_data=resp)
+    tb.slave.start()
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 8)
+    # REQ: EXEC-CSINV-03 - clear logic keys on logical selection, not pin level
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="inv_clear")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_command.py
+++ b/testbenches/ip/spi_engine/execution/test_command.py
@@ -1,0 +1,97 @@
+"""Command stream (CMD) acceptance & sequencing.
+
+Checks the AXI-stream handshake on the CMD interface: a command transfers only on
+cmd_valid && cmd_ready, cmd_ready is idle-gated (deasserted while an instruction
+executes), and commands execute strictly in order. All assertions are on the
+boundary CMD handshake and the resulting bus data ordering.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_cmd_ready_idle_gated(dut):
+    """cmd_ready is high when idle and low while an instruction executes."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    # REQ: EXEC-CMD-01 - cmd_ready asserted only when idle
+    assert int(dut.cmd_ready.value) == 1, "cmd_ready not high when idle"
+
+    # Issue a slow transfer and confirm cmd_ready drops during execution.
+    await tb.issue(ins.config_clk_div(3))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    wl = tb.params["DATA_WIDTH"]
+    data = [tb.rc.derive("cmd_gate").randrange(1 << wl)
+            for _ in range(2 * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(1, write=True, read=False), sdo_data=data)
+    tb.start_sdo_stream(res.sdo_words)
+    for _ in range(40):
+        await RisingEdge(dut.clk)
+        if int(dut.transfer_active.value) == 1:
+            break
+    # REQ: EXEC-CMD-02 - cmd_ready deasserted while executing (upstream stalls)
+    assert int(dut.cmd_ready.value) == 0, "cmd_ready high mid-instruction"
+    await tb.wait_idle()
+    assert int(dut.cmd_ready.value) == 1, "cmd_ready not restored after exec"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cmd_handshake_single_beat(dut):
+    """A command transfers on exactly the cmd_valid && cmd_ready cycle."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    # Hold cmd back manually: drive valid, wait for the accept cycle.
+    cmd = ins.sync(0x21)
+    tb.model.apply(cmd)
+    dut.cmd.value = cmd
+    dut.cmd_valid.value = 1
+    accepted = 0
+    for _ in range(20):
+        await RisingEdge(dut.clk)
+        if int(dut.cmd_valid.value) == 1 and int(dut.cmd_ready.value) == 1:
+            accepted += 1
+        # deassert the cycle after the first accept
+        if accepted == 1:
+            dut.cmd_valid.value = 0
+    # REQ: EXEC-CMD-03 - opcode taken from cmd[14:12] (sync opcode accepted here)
+    assert accepted == 1, f"command accepted {accepted} times, expected 1"
+    await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cmd_in_order_execution(dut):
+    """Commands execute strictly in the order accepted."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("cmd_order")
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    # A run of distinct single-word transfers; the captured bus order must match
+    # the issue order exactly (no reordering, no loss).
+    expected = []
+    tb.bus_mon.words.clear()
+    for _ in range(5):
+        d = [rng.randrange(1 << wl) for _ in range(tb.num_sdio)]
+        res = await tb.issue(ins.transfer(0, write=True, read=False),
+                             sdo_data=d)
+        expected += res.sdo_words
+        await tb.stream_sdo(res.sdo_words)
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CMD-04 - commands complete in order, one before the next
+    tb.sb.compare_sequences(expected, tb.bus_mon.sdo_words, field="order")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_config.py
+++ b/testbenches/ip/spi_engine/execution/test_config.py
@@ -1,0 +1,192 @@
+"""Configuration-Write registers, and EXEC-CC-01.
+
+Each configuration register write is exercised for its boundary-observable
+effect: prescaler (SCLK period), SPI-config bits (CPOL idle level, three_wire,
+sdo_idle_state), dynamic word length, and the two lane-mask registers (SDI is
+accept-only, its effect is downstream; SDO effect is covered in test_lanes). Also checks the
+single-cycle / back-to-back property (EXEC-CFG-07), config-then-transfer using
+the new value (EXEC-CC-01), and the >DATA_WIDTH region (FLAG EXEC-F6).
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_config_clk_div(dut):
+    """Register 000 (prescaler) sets the SCLK period on the next transfer."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    div = 3
+    await tb.issue(ins.config_clk_div(div))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    data = [(0xA5 + i) & ((1 << wl) - 1) for i in range(tb.num_sdio)]
+    res = await tb.issue(ins.transfer(0, write=True, read=False), sdo_data=data)
+    tb.start_sdo_stream(res.sdo_words)
+    period = await tb.measure_sclk_period()
+    await tb.wait_idle()
+    # REQ: EXEC-CFG-01 - prescaler register sets clk divider for later transfers
+    tb.sb.compare_within(0, "clkdiv_period", (div + 1) * 2, period, 1)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_spi_bits(dut):
+    """Register 001 sets CPOL (idle sclk), three_wire, and sdo_idle_state."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    # three_wire bit observable directly on the boundary output.
+    await tb.issue(ins.config_spi_mode(three_wire=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CFG-02 - three_wire = config bit 2
+    # REQ: EXEC-BUS-05 - three_wire reflects SPI-config bit 2
+    tb.sb.compare(0, "cfg.three_wire", 1, int(dut.three_wire.value))
+
+    # sdo_idle_state bit: with it set, sdo idles high between transfers.
+    await tb.issue(ins.config_spi_mode(three_wire=1, sdo_idle_state=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 3)
+    # (SDO-03 idle level is homed in test_transfer; here the sdo_idle_state bit)
+    all_lanes = (1 << tb.num_sdio) - 1
+    tb.sb.compare(0, "cfg.sdo_idle_high", all_lanes, int(dut.sdo.value))
+
+    # CPOL bit: idle sclk tracks it.
+    for cpol in (0, 1):
+        await tb.issue(ins.config_spi_mode(cpol=cpol))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 3)
+        tb.sb.compare(cpol, "cfg.cpol_idle", cpol, int(dut.sclk.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_word_length(dut):
+    """Register 010 (dynamic word length) is honoured by the transfer."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl_full = tb.params["DATA_WIDTH"]
+    new_wl = max(1, wl_full // 2)
+    await tb.issue(ins.config_word_length(new_wl))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    data = [tb.rc.derive("wl_cfg").randrange(1 << new_wl)
+            for _ in range(tb.num_sdio)]
+    res = await tb.issue(ins.transfer(0, write=True, read=False), sdo_data=data)
+    await tb.stream_sdo(res.sdo_words)
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+    # REQ: EXEC-CFG-03 - word_length register sets bit-periods per word
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="wl_cfg")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_sdi_lane_mask_accepted(dut):
+    """Register 011 (SDI lane mask) is accepted; masking effect is downstream."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    mask = 1 if nsd == 1 else (1 | (1 << (nsd - 1)))
+    # The write must be accepted (engine stays functional) — its masking effect
+    # lives downstream in axi_spi_engine (FLAG EXEC-F2 / EXEC-OOS-01), so only
+    # acceptance is checkable at this boundary.
+    await tb.issue(ins.config_sdi_lane_mask(mask))
+    await tb.wait_idle()
+    # REQ: EXEC-CFG-04 - SDI lane-mask register accepted (no boundary effect here)
+    assert int(dut.cmd_ready.value) == 1, "engine stalled after SDI mask write"
+
+    # A normal read still works after accepting the mask.
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    resp = [tb.rc.derive("sdi_after_mask").randrange(1 << wl)
+            for _ in range(2 * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(1, write=False, read=True), sdi_data=resp)
+    tb.slave.start()
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 8)
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="sdi_after_mask")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_back_to_back(dut):
+    """Config writes complete in one cycle; back-to-back at 1 cmd/cycle."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    # Stream several config writes with no gaps; cmd_ready must stay high (each
+    # retires in a single cycle, never removing the engine from accepting).
+    cmds = [ins.config_clk_div(1), ins.config_word_length(tb.params["DATA_WIDTH"]),
+            ins.config_spi_mode(cpol=0, cpha=0), ins.config_clk_div(2)]
+    stalled_cycles = 0
+    for c in cmds:
+        tb.model.apply(c)
+        dut.cmd.value = c
+        dut.cmd_valid.value = 1
+        await RisingEdge(dut.clk)
+        if int(dut.cmd_ready.value) == 0:
+            stalled_cycles += 1
+    dut.cmd_valid.value = 0
+    await tb.wait_idle()
+    # REQ: EXEC-CFG-07 - config write is 1 cycle; does not stall command stream
+    assert stalled_cycles == 0, f"config write stalled cmd stream {stalled_cycles}x"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_then_transfer_uses_new_value(dut):
+    """A config write immediately followed by a transfer uses the new value."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl_full = tb.params["DATA_WIDTH"]
+    new_wl = max(1, wl_full // 2)
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    # No wait_idle stall other than command handshake between config and transfer.
+    await tb.issue(ins.config_word_length(new_wl))
+    await tb.wait_idle()
+    data = [tb.rc.derive("cc01").randrange(1 << new_wl)
+            for _ in range(2 * tb.num_sdio)]
+    res = await tb.run_transfer(n=2, write=True, read=False, sdo_words=data, cs=0)
+    # REQ: EXEC-CC-01 - config-then-transfer uses the new value on that transfer
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="cc01")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_word_length_over_data_width(dut):
+    """word_length > DATA_WIDTH: write accepted; region unspecified (FLAG F6).
+
+    The spec constrains word_length <= DATA_WIDTH and leaves larger values
+    unspecified (EXEC-CFG-06 / FLAG EXEC-F6; Linux does not clamp). So this only
+    asserts the write is *accepted* and the engine stays alive — it deliberately
+    does NOT assert any transfer semantics in the undefined region.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    over = min(255, tb.params["DATA_WIDTH"] + 4)
+    await tb.issue(ins.config_word_length(over))
+    await tb.wait_idle()
+    # REQ: EXEC-CFG-06 - value > DATA_WIDTH is accepted; behaviour unspecified
+    assert int(dut.cmd_ready.value) == 1, "engine stalled on oversized word len"
+    # Restore a valid length and confirm the engine still transfers correctly.
+    await tb.issue(ins.config_word_length(tb.params["DATA_WIDTH"]))
+    await tb.wait_idle()
+    data = [tb.rc.derive("f6").randrange(1 << tb.params["DATA_WIDTH"])
+            for _ in range(tb.num_sdio)]
+    res = await tb.run_transfer(n=1, write=True, read=False, sdo_words=data)
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="f6_recover")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_flow_control.py
+++ b/testbenches/ip/spi_engine/execution/test_flow_control.py
@@ -1,0 +1,229 @@
+"""Flow control / backpressure, and EXEC-CC-06.
+
+Exercises independent random backpressure on each stream that has a ready the DUT
+must honour (SDO, SDI, SYNC, CMD), and verifies stall-without-loss-or-reordering.
+Includes the last-word continue-gate characterization (EXEC-FLOW-04) and two
+regressions that assert correct behaviour against open RTL defects: the FLAG
+EXEC-F1 handshake-stability violation (second home of EXEC-FLOW-05) and the FLAG
+EXEC-F10 sticky-sdo_data_ready-after-reset gap (second home of EXEC-SDO-04).
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.reset import apply_reset
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_sdo_backpressure(dut):
+    """Random gaps in the SDO data stream during a write transfer."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 6
+    data = [tb.rc.derive("sdo_bp").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+    res = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data,
+                                sdo_gap=(0, 3))
+    # REQ: EXEC-FLOW-01 - write transfer stalls until the outbound word is ready
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sdi_backpressure(dut):
+    """Random sdi_data_ready toggling during a read transfer (bounded stalls).
+
+    Uses a non-zero clk_div so a ready-stall stays within one SCLK word period;
+    the div=0 sub-word corner is the FLAG EXEC-F1 case exercised separately below.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 6
+    resp = [tb.rc.derive("sdi_bp").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+
+    await tb.issue(ins.config_clk_div(2))
+    await tb.wait_idle()
+    tb.bp_sdi.start_burst(min_on=2, max_on=6, min_off=1, max_off=2)
+    res = await tb.run_transfer(n=n, write=False, read=True, sdi_words=resp)
+    await ClockCycles(dut.clk, 40)
+    # REQ: EXEC-FLOW-02 - read transfer stalls until the SDI sink can accept
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="sdi")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sync_backpressure(dut):
+    """Holding sync_ready low stalls the engine until released."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    tb.bp_sync.stop(final_value=0)
+    sync_id = 0x33
+    await tb.issue(ins.sync(sync_id))
+    for _ in range(30):
+        await RisingEdge(dut.clk)
+    # REQ: EXEC-FLOW-03 - backpressure suspends progress; resumes losslessly
+    assert int(dut.cmd_ready.value) == 0, "engine retired sync without ready"
+    assert int(dut.sync_valid.value) == 1, "sync_valid should be held high"
+    tb.sb.compare(0, "sync.id", sync_id, int(dut.sync.value))
+    dut.sync_ready.value = 1
+    await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_cmd_backpressure(dut):
+    """Gaps before commands; engine resumes correctly each time."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("cmd_bp")
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    expected, captured_field = [], "cmd_bp"
+    tb.bus_mon.words.clear()
+    for k in range(4):
+        await ClockCycles(dut.clk, rng.randint(0, 5))
+        data = [rng.randrange(1 << wl) for _ in range(tb.num_sdio)]
+        res = await tb.issue(ins.transfer(0, write=True, read=False),
+                             sdo_data=data)
+        expected += res.sdo_words
+        cocotb.start_soon(tb.stream_sdo(res.sdo_words))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 3)
+    # REQ: EXEC-CC-06 - back-to-back transfers with backpressure keep order+data
+    tb.sb.compare_sequences(expected, tb.bus_mon.sdo_words, field=captured_field)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_combined_backpressure(dut):
+    """All streams under random backpressure simultaneously (read+write)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 8
+    nwords = n * tb.num_sdio
+    wdata = [tb.rc.derive("comb_w").randrange(1 << wl) for _ in range(nwords)]
+    rdata = [tb.rc.derive("comb_r").randrange(1 << wl) for _ in range(nwords)]
+
+    await tb.issue(ins.config_clk_div(2))
+    await tb.wait_idle()
+    tb.bp_sdi.start_burst(min_on=2, max_on=5, min_off=1, max_off=2)
+    res = await tb.run_transfer(n=n, write=True, read=True, sdo_words=wdata,
+                                sdi_words=rdata, sdo_gap=(0, 2))
+    await ClockCycles(dut.clk, 40)
+    # REQ: EXEC-FLOW-03 - simultaneous backpressure on all streams stays lossless
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo")
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="sdi")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_last_word_no_extra_fetch(dut):
+    """The last word does not require a further outbound word (FLOW-04).
+
+    RTL-CHARACTERIZED optimization with a boundary-visible effect: a write
+    transfer completes cleanly when exactly n+1 words are supplied and no more —
+    the continue-gate on the last word does not wait for an (n+2)th word.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 4
+    data = [tb.rc.derive("lastword").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+    # Supply exactly n words (no trailing extra); transfer must still finish.
+    res = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+    # REQ: EXEC-FLOW-04 - last word does not require fetching a further word
+    assert int(dut.cmd_ready.value) == 1, "engine hung waiting past last word"
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="lastword")
+    tb.sb.assert_no_errors()
+
+
+# FLAG EXEC-F1: at clk_div=0 with sub-word backpressure on sdi_data_ready, the RTL
+# mutates sdi_data while sdi_data_valid=1 before the beat is accepted, violating
+# AXI-Stream payload stability. Fails on current RTL (see bug_log.md).
+@cocotb.test()
+async def test_sdi_handshake_stability(dut):
+    """SDI payload must stay stable while valid & unaccepted (fails on current RTL).
+
+    AXI-Stream requires TDATA hold once VALID is asserted until VALID && READY.
+    Accepting one beat every `wl` core clocks at clk_div=0 drains slower than the
+    engine produces, so the next word shifts in before the previous is accepted.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 6
+    resp = [(0x11 * (k + 1)) & ((1 << wl) - 1) for k in range(n)]
+
+    tb.bp_sdi.stop(final_value=0)
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    await tb.issue(ins.transfer(n - 1, write=False, read=True), sdi_data=resp)
+    tb.slave.start()
+
+    ready_pattern = [1] + [0] * (wl - 1)
+    held = None
+    prev_accept = True
+    violation = False
+    for i in range(n * wl * 4 + 80):
+        dut.sdi_data_ready.value = ready_pattern[i % len(ready_pattern)]
+        await RisingEdge(dut.clk)
+        v = int(dut.sdi_data_valid.value)
+        r = int(dut.sdi_data_ready.value)
+        d = int(dut.sdi_data.value)
+        if v == 1:
+            if held is not None and not prev_accept and d != held:
+                violation = True
+                break
+            held = d
+        else:
+            held = None
+        prev_accept = (v == 1 and r == 1)
+    dut.sdi_data_ready.value = 0
+    # REQ: EXEC-FLOW-05 - sdi_data must stay stable under unaccepted valid
+    assert not violation, "sdi_data changed under unaccepted valid (handshake)"
+
+
+# FLAG EXEC-F10: exec_transfer_cmd_reg has no reset branch, so after a transfer it
+# stays 1 across a resetn pulse and the prefetch gate asserts sdo_data_ready in
+# FIFO mode with no command in flight. Fails on current RTL (see bug_log.md).
+@cocotb.test()
+async def test_sdo_ready_cleared_by_reset(dut):
+    """sdo_data_ready must not assert after reset with no command (fails on current RTL)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("sticky_ready")
+
+    # Run a write transfer so exec_transfer_cmd_reg gets set to 1.
+    n = 3
+    data = [rng.randrange(1 << wl) for _ in range(n * tb.num_sdio)]
+    await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+
+    # Reset the engine. A clean reset should return the SDO request handshake to
+    # its idle state (no data requested until a write instruction is in flight).
+    await apply_reset(dut, cycles_before=0, hold=3)
+    tb.after_reset()
+
+    # FIFO mode, no command issued: drive sdo_data_valid and watch sdo_data_ready.
+    tb.set_offload_active(False)
+    dut.sdo_data_valid.value = 1
+    dut.sdo_data.value = 0xA5 & ((1 << wl) - 1)
+    asserted = False
+    for _ in range(20):
+        await RisingEdge(dut.clk)
+        if int(dut.sdo_data_ready.value) == 1:
+            asserted = True
+            break
+    dut.sdo_data_valid.value = 0
+    # REQ: EXEC-SDO-04 - engine must not request SDO with no write instruction
+    assert not asserted, "sdo_data_ready asserted post-reset with no command"

--- a/testbenches/ip/spi_engine/execution/test_lanes.py
+++ b/testbenches/ip/spi_engine/execution/test_lanes.py
@@ -1,0 +1,136 @@
+"""Multi-lane transmit (NUM_OF_SDIO>1), and EXEC-CC-08.
+
+Only SDO lanes are boundary-visible in this module (the SDI lane mask's effect is
+downstream — its acceptance is covered in test_config). These tests drive
+the SDO lane-mask register and confirm words map to the correct physical lanes:
+all-active, sparse (e.g. 1010), single-lane, and re-masking between transfers.
+
+At NUM_OF_SDIO=1 the mask cases degenerate to the single-lane write path, which
+still exercises the all-active mask and the register-accept path.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_all_lanes_active(dut):
+    """Default all-active mask distributes words across every lane."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    rng = tb.rc.derive("lanes_all")
+
+    all_mask = (1 << nsd) - 1
+    await tb.issue(ins.config_sdo_lane_mask(all_mask))
+    await tb.wait_idle()
+    nper = 3
+    data = [rng.randrange(1 << wl) for _ in range(nper * nsd)]
+    res = await tb.run_transfer(n=nper, write=True, read=False, sdo_words=data)
+    # REQ: EXEC-LANE-01 - active lanes carry data in ascending physical order
+    # REQ: EXEC-CFG-05 - SDO lane-mask register selects transmit lanes
+    # REQ: EXEC-PARAM-02 - NUM_OF_SDIO sizes the sdo/sdi lanes
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo_all")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sparse_and_single_lane_masks(dut):
+    """Sparse (1010-style) and single-lane masks map to the right lanes.
+
+    RTL-CHARACTERIZED for the exact distribution order; Linux drives only the
+    masks its lane_map produces, not arbitrary sparse patterns (spec Appendix C),
+    so the sparse case is a characterization lock. Inactive lanes carry
+    sdo_idle_state (EXEC-LANE-02).
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    rng = tb.rc.derive("lanes_sparse")
+
+    if nsd < 2:
+        # Single physical lane: only the trivial mask exists; verify it accepts
+        # and transfers, which is the degenerate LANE case.
+        await tb.issue(ins.config_sdo_lane_mask(1))
+        await tb.wait_idle()
+        data = [rng.randrange(1 << wl) for _ in range(2)]
+        res = await tb.run_transfer(n=2, write=True, read=False, sdo_words=data)
+        # (LANE-03 single-lane degenerate case; tag lives on the sparse path below)
+        tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words,
+                                field="sdo_1lane")
+        tb.sb.assert_no_errors()
+        return
+
+    # Sparse mask: lane 0 and the top lane (10..01). Interior lanes idle only for
+    # nsd>=3; at nsd=2 it degenerates to 0b11 (all-active), which harmlessly
+    # re-covers the all-active routing path here.
+    sparse = 1 | (1 << (nsd - 1))
+    n_active = bin(sparse).count("1")
+    await tb.issue(ins.config_sdo_lane_mask(sparse))
+    await tb.wait_idle()
+    nper = 3
+    data = [rng.randrange(1 << wl) for _ in range(nper * n_active)]
+    res = await tb.run_transfer(n=nper, write=True, read=False, sdo_words=data)
+    # REQ: EXEC-LANE-03 - sparse mask maps words to correct physical lanes
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words,
+                            field=f"sdo_sparse_0x{sparse:x}")
+
+    # Idle lanes present sdo_idle_state (checked between transfers on the bus).
+    idle = tb.params.get("SDO_DEFAULT", 0)
+    await ClockCycles(dut.clk, 3)
+    # REQ: EXEC-LANE-02 - lanes with mask bit 0 present sdo_idle_state
+    idle_lanes_ok = True
+    val = int(dut.sdo.value)
+    for l in range(nsd):
+        if not ((sparse >> l) & 1):
+            if ((val >> l) & 1) != idle:
+                idle_lanes_ok = False
+    tb.sb.compare(0, "sdo_idle_lanes", True, idle_lanes_ok)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_lane_remask_between_transfers(dut):
+    """Re-writing the SDO lane mask remaps lanes on the next transfer."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    rng = tb.rc.derive("lanes_remask")
+
+    if nsd < 2:
+        return  # remasking is only meaningful with more than one lane
+
+    all_mask = (1 << nsd) - 1
+    # At nsd=2 this is 0b11 (== all_mask): the re-mask step below then re-applies
+    # the same all-active set, so remapping is only genuinely exercised for
+    # nsd>=3. Harmless (the compare still holds), but the remap is a no-op at nsd=2.
+    sparse = 1 | (1 << (nsd - 1))
+
+    # First transfer: all lanes.
+    await tb.issue(ins.config_sdo_lane_mask(all_mask))
+    await tb.wait_idle()
+    d1 = [rng.randrange(1 << wl) for _ in range(2 * nsd)]
+    res1 = await tb.run_transfer(n=2, write=True, read=False, sdo_words=d1)
+    tb.sb.compare_sequences(res1.sdo_words, tb.bus_mon.sdo_words, field="remask_all")
+
+    # Re-mask to sparse; next transfer must use the new lane set.
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.chipselect(allcs, delay=1))
+    await tb.wait_idle()
+    await tb.issue(ins.config_sdo_lane_mask(sparse))
+    await tb.wait_idle()
+    tb.bus_mon.words.clear()
+    n_active = bin(sparse).count("1")
+    d2 = [rng.randrange(1 << wl) for _ in range(2 * n_active)]
+    res2 = await tb.run_transfer(n=2, write=True, read=False, sdo_words=d2)
+    # REQ: EXEC-LANE-04 - re-writing the SDO mask remaps lanes next transfer
+    # REQ: EXEC-CC-08 - lane-mask reconfiguration remaps lanes on next transfer
+    tb.sb.compare_sequences(res2.sdo_words, tb.bus_mon.sdo_words,
+                            field="remask_sparse")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_misc.py
+++ b/testbenches/ip/spi_engine/execution/test_misc.py
@@ -1,0 +1,73 @@
+"""MISC instructions: Sync (opcode 011, cmd[8]=0) and Sleep (cmd[8]=1).
+
+Sync raises sync_valid carrying the event id and holds until sync_ready; Sleep
+stalls the command stream for the closed-form duration with no bus/ctrl activity.
+Sleep timing is checked with a ±tolerance; the sync id is checked exactly.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_sync_id_and_valid(dut):
+    """Sync asserts sync_valid carrying cmd[7:0] and retires on sync_ready."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    sync_id = 0x5A
+    res = await tb.issue(ins.sync(sync_id))
+    for _ in range(50):
+        await RisingEdge(dut.clk)
+        if int(dut.sync_valid.value) == 1:
+            break
+    # REQ: EXEC-SYNC-01 - sync drives sync=id, asserts sync_valid, retires on ready
+    tb.sb.compare(0, "sync.id", res.sync_id, int(dut.sync.value))
+    tb.sb.compare(0, "sync.valid", 1, int(dut.sync_valid.value))
+    await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sleep_duration(dut):
+    """Sleep idles for the formula-predicted duration (±tolerance)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    div = 1
+    await tb.issue(ins.config_clk_div(div))
+    await tb.wait_idle()
+
+    t = 4
+    predicted = tb.model.sleep_duration(t)
+    start = tb.now_cycles()
+    await tb.issue(ins.sleep(t))
+    await tb.wait_idle()
+    elapsed = tb.now_cycles() - start
+    tb.log.info(f"sleep t={t} div={div} predicted~{predicted} elapsed={elapsed}")
+    # REQ: EXEC-SLEEP-01 - sleep stalls for 2 + (t+1)*(div+1)*2 core clocks
+    tb.sb.compare_within(0, "sleep_duration", predicted, elapsed, 4)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sleep_t_zero(dut):
+    """Sleep with t=0 still produces the minimum non-zero delay."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    div = 1
+    await tb.issue(ins.config_clk_div(div))
+    await tb.wait_idle()
+
+    predicted = tb.model.sleep_duration(0)
+    start = tb.now_cycles()
+    await tb.issue(ins.sleep(0))
+    await tb.wait_idle()
+    elapsed = tb.now_cycles() - start
+    # REQ: EXEC-SLEEP-02 - t=0 still yields the minimum non-zero sleep delay
+    assert elapsed > 0, "sleep t=0 produced zero delay"
+    tb.sb.compare_within(0, "sleep_t0", predicted, elapsed, 4)
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_offload.py
+++ b/testbenches/ip/spi_engine/execution/test_offload.py
@@ -1,0 +1,268 @@
+"""Offload interaction (boundary view only).
+
+Full offload semantics belong to the offload IP (EXEC-OOS-02); at this
+module's boundary only the s_offload_active effect is observable: SDO prefetch
+readiness. These tests drive s_offload_active and observe the sdo_data_ready
+handshake timing, plus confirm the produced spi-bus waveform is identical in
+offload and FIFO mode for the same command/SDO sequence (EXEC-OFF-03).
+"""
+
+import os
+
+import cocotb
+from cocotb.triggers import ClockCycles
+
+from framework.spi import instructions as ins
+from framework.reset import apply_reset
+from tb_env import ExecutionTB
+
+# Build-time lane count (DUT generic). Several tests below are only meaningful at
+# certain lane counts and are skipped otherwise.
+_NSD = int(os.environ.get("PARAM_NUM_OF_SDIO", 1))
+
+
+def _partial_masks(nsd, *, min_active, rng=None, cap=16):
+    """Lane masks that are NOT all-active (the sub-mask class), over ``nsd`` lanes.
+
+    Returns every mask with ``min_active <= popcount < nsd``. The offload lane-mask
+    bug is a property of the whole class, so a test sweeps this set rather than one
+    mask. Enumerates fully when the set is small (covers the whole sweep, nsd<=4);
+    above ``cap`` it returns a seeded sample keeping the sparsest and densest
+    extremes, so large-``nsd`` builds stay bounded without losing the corners.
+    """
+    full = (1 << nsd) - 1
+    cand = [m for m in range(1, full) if bin(m).count("1") >= min_active]
+    if rng is None or len(cand) <= cap:
+        return cand
+    lo = min(cand, key=lambda m: bin(m).count("1"))
+    hi = max(cand, key=lambda m: bin(m).count("1"))
+    rest = [m for m in cand if m not in (lo, hi)]
+    return sorted({lo, hi, *rng.sample(rest, cap - 2)})
+
+
+@cocotb.test()
+async def test_offload_prefetch_readiness(dut):
+    """With s_offload_active=1 the engine may prefetch SDO before the write cmd.
+
+    Baseline note: the engine only requests SDO data (asserts sdo_data_ready) in
+    FIFO mode *after* a write instruction has been seen; that gating latches and
+    is not cleared by reset, so we first issue a non-transfer (config) command to
+    establish a clean "no recent write instruction" state. Using this stimulus
+    knowledge to set up the baseline is legitimate; the pass/fail check is on the
+    boundary sdo_data_ready handshake in each mode.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+
+    # Clean baseline: a non-transfer command so no write instruction is pending.
+    await tb.issue(ins.config_clk_div(0))
+    await tb.wait_idle()
+
+    # FIFO mode: with no write instruction pending, the engine must NOT prefetch.
+    tb.set_offload_active(False)
+    dut.sdo_data_valid.value = 1
+    dut.sdo_data.value = 0xA5 & ((1 << wl) - 1)
+    fifo_prefetch = await tb.observe_sdo_ready_before_cmd(window=20)
+    # REQ: EXEC-OFF-01 - when inactive, engine waits for the write instruction
+    tb.sb.compare(0, "fifo_no_prefetch", False, fifo_prefetch)
+
+    # Offload mode: the engine may assert sdo_data_ready ahead of any command.
+    tb.set_offload_active(True)
+    offload_prefetch = await tb.observe_sdo_ready_before_cmd(window=40)
+    # REQ: EXEC-OFF-01 - when active, engine may prefetch SDO before the write cmd
+    tb.sb.compare(0, "offload_prefetch", True, offload_prefetch)
+    dut.sdo_data_valid.value = 0
+    tb.set_offload_active(False)
+    tb.sb.assert_no_errors()
+
+
+# EXEC-OFF-02 (spi_engine_execution.rst): offload prefetch requires ALL SDO lanes
+# active, so ANY partial mask must suppress prefetch (engine waits for the write
+# instruction). Swept over the whole partial-mask class, not one mask, so an RTL
+# fix that special-cases a single mask does not pass while the class still fails.
+# Only meaningful at NUM_OF_SDIO>=2; single-lane builds skip (companion test below).
+@cocotb.test(skip=_NSD < 2)
+async def test_offload_prefetch_requires_all_lanes(dut):
+    """Every partial SDO lane mask must suppress offload prefetch (EXEC-OFF-02)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    rng = tb.rc.derive("off_submask_prefetch")
+
+    for mask in _partial_masks(nsd, min_active=1, rng=rng):
+        # Reset between masks so latched word_ready/prefetch state from the prior
+        # iteration cannot hold sdo_data_ready low and mask a fresh prefetch.
+        await apply_reset(dut, cycles_before=0, hold=3)
+        tb.after_reset()
+        # Clean baseline (see test_offload_prefetch_readiness): a non-transfer
+        # command clears any pending write-instruction / assembler state.
+        await tb.issue(ins.config_clk_div(0))
+        await tb.wait_idle()
+        await tb.issue(ins.config_sdo_lane_mask(mask))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, nsd + 4)  # let lane-mask processing settle
+        tb.set_offload_active(True)
+        dut.sdo_data_valid.value = 1
+        dut.sdo_data.value = 0x5A & ((1 << wl) - 1)
+        pf_sub = await tb.observe_sdo_ready_before_cmd(window=40)
+        # REQ: EXEC-OFF-02 - a partial mask must suppress prefetch (waits for cmd)
+        tb.sb.compare(0, f"offload_prefetch_mask_{mask:#04x}", False, pf_sub)
+        dut.sdo_data_valid.value = 0
+        tb.set_offload_active(False)
+
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test(skip=_NSD >= 2)
+async def test_offload_prefetch_single_lane_allowed(dut):
+    """At NUM_OF_SDIO=1 'all lanes' == the one lane, so prefetch is allowed.
+
+    Companion to test_offload_prefetch_requires_all_lanes: exercises the OFF-02
+    all-active degenerate case on single-lane builds (where the sub-mask path
+    cannot run) so the requirement still has boundary coverage there. Multi-lane
+    builds cover OFF-02 via the sub-mask test and skip this one.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    await tb.issue(ins.config_clk_div(0))
+    await tb.wait_idle()
+    tb.set_offload_active(True)
+    dut.sdo_data_valid.value = 1
+    dut.sdo_data.value = 0x5A & ((1 << wl) - 1)
+    pf = await tb.observe_sdo_ready_before_cmd(window=40)
+    # REQ: EXEC-OFF-02 - all-lanes (degenerate at nsd=1) allows offload prefetch
+    tb.sb.compare(0, "offload_all_lanes_1", True, pf)
+    dut.sdo_data_valid.value = 0
+    tb.set_offload_active(False)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_offload_waveform_matches_fifo(dut):
+    """Same command/SDO sequence yields identical bus waveform in both modes."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 4
+    rng = tb.rc.derive("off_wave")
+    data = [rng.randrange(1 << wl) for _ in range(n * tb.num_sdio)]
+
+    # FIFO mode (offload inactive).
+    tb.set_offload_active(False)
+    res_fifo = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+    fifo_words = list(tb.bus_mon.sdo_words)
+    tb.sb.compare_sequences(res_fifo.sdo_words, fifo_words, field="fifo_wave")
+
+    # Offload mode: same commands and data, s_offload_active=1.
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.chipselect(allcs, delay=1))
+    await tb.wait_idle()
+    tb.bus_mon.words.clear()
+    tb.set_offload_active(True)
+    res_off = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+    offload_words = list(tb.bus_mon.sdo_words)
+    tb.set_offload_active(False)
+    # REQ: EXEC-OFF-03 - bus waveform identical in offload vs FIFO mode
+    tb.sb.compare_sequences(res_off.sdo_words, offload_words, field="offload_wave")
+    tb.sb.compare_sequences(fifo_words, offload_words, field="fifo_vs_offload")
+    tb.sb.assert_no_errors()
+
+
+async def _offload_vs_fifo_sdo(tb, mask, phase, *, n=4):
+    """Drive one write transfer under ``mask`` in FIFO then offload mode; compare
+    the resulting SDO bus words. ``phase`` delays data arrival after the offload
+    mask re-pulse, sweeping which cycle of the lane-scan rebuild consumes the
+    prefetched word. Records mismatches in the scoreboard under a mask/phase-tagged
+    field. Factored out so the test can sweep both the mask and the timing phase."""
+    dut = tb.dut
+    wl = tb.params["DATA_WIDTH"]
+    nsd = tb.num_sdio
+    rng = tb.rc.derive(f"off_submask_corrupt_{mask:#04x}_{phase}")
+    data = [rng.randrange(1 << wl) for _ in range(n * nsd)]
+
+    # CAUTION: do NOT add a reset here. The corruption needs a warm assembler
+    # whose lane map is rebuilt while a prefetched word is in flight (the realistic
+    # "reconfigure the mask mid-offload" case); a reset gives a cold map that maps
+    # the early word correctly and hides the bug. Per-iteration isolation comes
+    # from the FIFO leg below re-establishing the mask and clearing the bus monitor.
+
+    # FIFO mode (offload inactive) under the mask: golden bus reference.
+    tb.bus_mon.words.clear()
+    tb.set_offload_active(False)
+    await tb.issue(ins.config_sdo_lane_mask(mask))
+    await tb.wait_idle()
+    res_fifo = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+    fifo_words = list(tb.bus_mon.sdo_words)
+    laid_out = list(res_fifo.sdo_words)  # canonical period-major, active-lane-minor
+
+    # Offload mode: same command/data/mask, but pre-stream SDO so valid data is in
+    # flight DURING the lane-mask scan, exercising prefetch against a stale lane map.
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.chipselect(allcs, delay=1))
+    await tb.wait_idle()
+    tb.bus_mon.words.clear()
+    tb.set_offload_active(True)
+    # Re-pulse the lane mask to (re)start the scan; do NOT wait_idle - we want data
+    # racing the scan window.
+    await tb.issue(ins.config_sdo_lane_mask(mask))
+    # Shift data arrival by `phase` cycles so the early consumption lands at a
+    # different point of the scan rebuild each iteration.
+    if phase:
+        await ClockCycles(dut.clk, phase)
+    # Extra padding words guard against underrun if prefetch pulls more than the
+    # transfer needs (surplus never reaches the bus).
+    padded = laid_out + [rng.randrange(1 << wl) for _ in range(2 * nsd)]
+    tb.start_sdo_stream(padded, min_gap=0, max_gap=0)
+    await tb.issue(ins.transfer(n - 1, write=True, read=False), sdo_data=data)
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 3)
+    offload_words = list(tb.bus_mon.sdo_words)
+    tb.abort_streams()
+    tb.set_offload_active(False)
+
+    # REQ: EXEC-OFF-03 - offload SDO bus data must match FIFO mode
+    tb.sb.compare_sequences(fifo_words, offload_words,
+                            field=f"offload_sdo_mask_{mask:#04x}_ph{phase}")
+
+
+# Number of timing phases swept per mask: the offset (in core clocks) between the
+# offload lane-mask re-pulse and data arrival. The corruption depends on which
+# cycle of the ~NUM_OF_SDIO-cycle lane-scan rebuild consumes the prefetched word,
+# so a single phase can miss it (e.g. phase 0 happens to be clean for some masks).
+# NUM_OF_SDIO+3 covers the whole rebuild window plus pipeline slack.
+_OFF_PHASES = _NSD + 3
+
+
+# EXEC-OFF-03 (spi_engine_execution.rst): the SDO bus data must be identical in
+# offload and FIFO mode for the same command/data/mask. Swept over the whole
+# observable partial-mask class (>=2 active lanes) AND over the timing phase, so
+# neither a mask-specific RTL patch nor an incidental timing alignment can pass
+# while the class still corrupts. Verilator's speed makes the full mask x phase
+# sweep cheap; the sweep stops at the first failing point.
+# Needs nsd>=3: only then does a partial mask leave >=2 active lanes, so a lane
+# mismap is observable on the bus; at nsd<=2 the mismap is unobservable, so skip.
+@cocotb.test(skip=_NSD < 3)
+async def test_offload_submask_no_stream_corruption(dut):
+    """Every observable partial mask x timing phase: offload SDO bus == FIFO (EXEC-OFF-03)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    rng = tb.rc.derive("off_submask_masks")
+    # >=2 active lanes: a single active lane is an identity map, so a slide is
+    # invisible - those are covered by the prefetch-readiness test above.
+    for mask in _partial_masks(tb.num_sdio, min_active=2, rng=rng):
+        # CAUTION: do NOT collapse this to one phase. The corruption is a timing
+        # race; some (mask, phase) points are clean (mask 0b011 is clean only at
+        # phase 0), so pinning a phase silently hides real failures.
+        for phase in range(_OFF_PHASES):
+            before = len(tb.sb.mismatches)
+            # REQ: EXEC-OFF-03 - offload SDO bus data must match FIFO mode
+            await _offload_vs_fifo_sdo(tb, mask, phase)
+            # Fast-fail: stop the sweep at the first (mask, phase) that corrupts.
+            # The failing iteration's per-word mismatches are already recorded, so
+            # assert_no_errors below reports the full detail of that case.
+            if len(tb.sb.mismatches) > before:
+                tb.sb.assert_no_errors()
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_reset.py
+++ b/testbenches/ip/spi_engine/execution/test_reset.py
@@ -1,0 +1,165 @@
+"""Reset behaviour (boundary-observable), plus EXEC-CC-07.
+
+Verifies the documented idle/reset values on every boundary output after reset
+(including resets injected mid-instruction), and that receive state is cleared so
+the first read after reset returns only freshly-sampled bits.
+
+Only boundary outputs are asserted (ctrl streams + spi bus); internal state is
+out of scope.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from framework.reset import apply_reset, check_reset_values
+
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_reset_values_after_release(dut):
+    """All documented reset values hold after resetn is released."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+
+    # cmd_ready high (ready to accept), cs=all-ones, sclk=cpol, sdo_t=1.
+    errs = tb.check_reset_values()          # REQ: EXEC-RST-02 - cmd_ready asserted
+    errs += tb.check_reset_values_extra()   # REQ: EXEC-RST-06 - three_wire + sdi_data_valid low
+    assert not errs, f"reset value mismatches: {errs}"
+
+    cpol = (tb.params["DEFAULT_SPI_CFG"] >> 1) & 1
+    all_cs = (1 << tb.params["NUM_OF_CS"]) - 1
+    # REQ: EXEC-RST-03 - cs reads all-ones (every CS inactive) after reset
+    tb.sb.compare(0, "reset.cs_all_ones", all_cs, int(dut.cs.value))
+    # REQ: EXEC-RST-04 - sclk idles at CPOL from DEFAULT_SPI_CFG[1]
+    tb.sb.compare(0, "reset.sclk_cpol", cpol, int(dut.sclk.value))
+    idle = tb.params.get("SDO_DEFAULT", 0)
+    # REQ: EXEC-RST-05 - every sdo lane idles at sdo_idle_state, sdo_t tristated
+    tb.sb.compare(0, "reset.sdo_idle",
+                  idle * ((1 << tb.num_sdio) - 1), int(dut.sdo.value))
+    # REQ: EXEC-BUS-04 - cs reset value is all-inactive
+    tb.sb.compare(0, "reset.bus_cs", all_cs, int(dut.cs.value))
+    # REQ: EXEC-PARAM-04 - DEFAULT_SPI_CFG observed at reset (three_wire, cpol)
+    tb.sb.compare(0, "reset.cfg_three_wire",
+                  (tb.params["DEFAULT_SPI_CFG"] >> 2) & 1,
+                  int(dut.three_wire.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_reset_module_idle(dut):
+    """After reset the module is idle and accepts no in-flight command."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    # REQ: EXEC-RST-01 - module idle and at defined idle values after reset
+    assert int(dut.cmd_ready.value) == 1, "engine not idle after reset"
+    assert int(dut.sync_valid.value) == 0, "sync_valid high after reset"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_reset_during_transfer(dut):
+    """Reset mid-transfer returns all outputs to their reset values and recovers."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("rst_xfer")
+
+    await tb.issue(ins.config_clk_div(3))  # slow it so we land mid-transfer
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    nper = 4
+    data = [rng.randrange(1 << wl) for _ in range(nper * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(nper - 1, write=True, read=False),
+                         sdo_data=data)
+    tb.start_sdo_stream(res.sdo_words)
+    for _ in range(30):
+        await RisingEdge(dut.clk)
+        if int(dut.transfer_active.value) == 1:
+            break
+    await ClockCycles(dut.clk, 5)
+    await apply_reset(dut, cycles_before=0, hold=3)
+    tb.after_reset()
+
+    # REQ: EXEC-CC-07 - reset asserted mid-transfer restores reset values
+    errs = check_reset_values(dut, tb.params, scoreboard=tb.sb)
+    assert not errs, f"post-reset values wrong: {errs}"
+
+    # A fresh transfer must work after recovery. The SDO data-assembler's lane
+    # table auto-rebuilds after reset (reset clears lane_scan_idx and the scan
+    # reruns over the reset-default all-lanes sdo_lane_mask), so no post-reset
+    # lane-mask reprogram is needed for multi-lane distribution to be correct.
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    nper2 = 2
+    d2 = [rng.randrange(1 << wl) for _ in range(nper2 * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(nper2 - 1, write=True, read=False),
+                         sdo_data=d2)
+    cocotb.start_soon(tb.stream_sdo(res.sdo_words))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 3)
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="post_rst")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_reset_during_sleep(dut):
+    """Reset during a sleep instruction; clean recovery to idle."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    await tb.issue(ins.config_clk_div(3))
+    await tb.wait_idle()
+
+    await tb.issue(ins.sleep(20))
+    await ClockCycles(dut.clk, 10)
+    await apply_reset(dut, cycles_before=0, hold=3)
+    # REQ: EXEC-CC-07 - reset mid-sleep also restores reset values (recovers to idle)
+    errs = check_reset_values(dut, tb.params, scoreboard=tb.sb)
+    assert not errs, f"post-reset values wrong: {errs}"
+    assert int(dut.cmd_ready.value) == 1, "engine not idle after reset"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_reset_clears_receive_state(dut):
+    """First read after reset returns only newly-sampled bits (no stale SDI)."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("rst_rx")
+
+    # Start a read transfer and reset partway through so some bits are shifted in.
+    await tb.issue(ins.config_clk_div(3))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    stale = [rng.randrange(1 << wl) for _ in range(4 * tb.num_sdio)]
+    await tb.issue(ins.transfer(3, write=False, read=True), sdi_data=stale)
+    tb.slave.start()
+    for _ in range(30):
+        await RisingEdge(dut.clk)
+        if int(dut.transfer_active.value) == 1:
+            break
+    await ClockCycles(dut.clk, 5)
+    # Stop the slave (and release sdi) before asserting reset so it is not mid
+    # drive when the transfer is torn down, then reset.
+    tb.slave.stop()
+    await apply_reset(dut, cycles_before=0, hold=3)
+    tb.after_reset()
+
+    # Clean read after reset must return exactly the fresh responses. The lane
+    # tables auto-rebuild after reset (see test_reset_during_transfer), so no
+    # post-reset lane-mask reprogram is required.
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    fresh = [rng.randrange(1 << wl) for _ in range(2 * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(1, write=False, read=True), sdi_data=fresh)
+    tb.slave.start()
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 10)
+    # REQ: EXEC-RST-07 - receive state cleared by reset; only fresh bits returned
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="fresh_sdi")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_sequences.py
+++ b/testbenches/ip/spi_engine/execution/test_sequences.py
@@ -1,0 +1,118 @@
+"""Cross-cutting corner cases: interleaved sequences & parameter space.
+
+Recombines validated features into ordered sequences: a full interleaved
+transaction (EXEC-CC-05), a randomised valid-instruction fuzz stream, and a
+data-width / lane / CS parameter-space smoke (EXEC-CC-09; the full multi-compile
+sweep lives in runner.py).
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_interleaved_transaction(dut):
+    """CS-assert -> config -> transfer -> sleep -> sync -> CS-deselect in order."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("interleave")
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    await tb.issue(ins.config_clk_div(1))
+    await tb.wait_idle()
+
+    nper = 3
+    data = [rng.randrange(1 << wl) for _ in range(nper * tb.num_sdio)]
+    res = await tb.issue(ins.transfer(nper - 1, write=True, read=False),
+                         sdo_data=data)
+    cocotb.start_soon(tb.stream_sdo(res.sdo_words))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 3)
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="seq_sdo")
+
+    await tb.issue(ins.sleep(3))
+    await tb.wait_idle()
+
+    sid = 0x7
+    await tb.issue(ins.sync(sid))
+    await tb.wait_idle()
+    tb.sb.compare(0, "seq.sync", sid, int(dut.sync.value))
+
+    allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+    await tb.issue(ins.chipselect(allcs, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 2)
+    # REQ: EXEC-CC-05 - interleaved sequence executes in order with correct idle
+    tb.sb.compare(0, "seq.deassert", allcs, int(dut.cs.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_random_instruction_stream(dut):
+    """Fuzz: a random but valid instruction sequence; data transfers checked."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("fuzz")
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    for _ in range(25):
+        choice = rng.random()
+        if choice < 0.5:
+            nper = rng.randint(1, 3)
+            data = [rng.randrange(1 << wl) for _ in range(nper * tb.num_sdio)]
+            tb.bus_mon.words.clear()
+            res = await tb.issue(ins.transfer(nper - 1, write=True,
+                                              read=False), sdo_data=data)
+            cocotb.start_soon(tb.stream_sdo(res.sdo_words))
+            await tb.wait_idle()
+            await ClockCycles(dut.clk, 2)
+            # REQ: EXEC-CC-09 - representative instruction/data mix exercised
+            tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words,
+                                    field="fuzz_sdo")
+        elif choice < 0.7:
+            await tb.issue(ins.config_clk_div(rng.randint(0, 3)))
+            await tb.wait_idle()
+        elif choice < 0.85:
+            await tb.issue(ins.sleep(rng.randint(0, 4)))
+            await tb.wait_idle()
+        else:
+            sid = rng.randint(0, 255)
+            await tb.issue(ins.sync(sid))
+            await tb.wait_idle()
+            tb.sb.compare(0, "fuzz_sync", sid, int(dut.sync.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_back_to_back_transfers(dut):
+    """Back-to-back transfers of varying length all produce correct data."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("b2b")
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    expected = []
+    tb.bus_mon.words.clear()
+    for _ in range(5):
+        nper = rng.randint(1, 4)
+        data = [rng.randrange(1 << wl) for _ in range(nper * tb.num_sdio)]
+        res = await tb.issue(ins.transfer(nper - 1, write=True, read=False),
+                             sdo_data=data)
+        expected += res.sdo_words
+        cocotb.start_soon(tb.stream_sdo(res.sdo_words))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 3)
+    # REQ: EXEC-CC-06 - back-to-back transfers keep order+data (no-backpressure baseline)
+    tb.sb.compare_sequences(expected, tb.bus_mon.sdo_words, field="b2b")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_transfer.py
+++ b/testbenches/ip/spi_engine/execution/test_transfer.py
@@ -1,0 +1,280 @@
+"""Transfer instruction: SDO/SDI datapaths, and EXEC-CC-02/03.
+
+Covers the Transfer instruction end-to-end at the module boundary: word count
+(n+1), MSB-first shifting on both directions, the four {r,w} combinations
+(including the clock-only 00 characterization lock), sdo_t polarity, sdo idle
+level, short (MSB-aligned) words, single/multi-word termination, and the
+closed-form transfer-duration timing (EXEC-XFER-08).
+
+Data is checked exactly; timing with a small ±cycle tolerance.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_write_only(dut):
+    """w=1 r=0: SDO words shifted out match the streamed data, sdo_t driven."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 4
+    data = [tb.rc.derive("wdata").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    res = await tb.issue(ins.transfer(n - 1, write=True, read=False),
+                         sdo_data=data)
+    tb.start_sdo_stream(res.sdo_words)
+    # REQ: EXEC-XFER-03 - during a write sdo_t is driven (0)
+    sdo_t = await tb.sample_sdo_t_during_transfer()
+    # REQ: EXEC-BUS-03 - sdo_t is 0 (driven) only during a write transfer
+    tb.sb.compare(0, "sdo_t.write", 0, sdo_t)
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+
+    # REQ: EXEC-XFER-01 - n+1 words generated for the transfer
+    # REQ: EXEC-XFER-02 - bits shifted MSB-first (monitor reconstructs from wire)
+    # REQ: EXEC-SDO-01 - each word MSB-first, one bit per SCLK bit-period
+    # REQ: EXEC-SDO-04 - exactly n+1 words consumed from the SDO stream
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_read_only(dut):
+    """w=0 r=1: SDI words captured match the slave; sdo tristated/idle."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 4
+    resp = [tb.rc.derive("rdata").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    res = await tb.issue(ins.transfer(n - 1, write=False, read=True),
+                         sdi_data=resp)
+    tb.slave.start()
+    # REQ: EXEC-XFER-06 - during a read (w=0) sdo_t is tristated (1)
+    sdo_t = await tb.sample_sdo_t_during_transfer()
+    tb.sb.compare(0, "sdo_t.read", 1, sdo_t)
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+
+    # REQ: EXEC-XFER-04 - sdi sampled and assembled word presented on SDI stream
+    # REQ: EXEC-SDI-01 - sdi sampled MSB-first into the lane slice
+    # REQ: EXEC-SDI-02 - sdi_data_valid asserts once a word is received, held to ready
+    # REQ: EXEC-SDI-03 - exactly n+1 SDI words produced
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="sdi")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_read_write_full_duplex(dut):
+    """w=1 r=1: both directions exercised simultaneously."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 3
+    nwords = n * tb.num_sdio
+    wdata = [tb.rc.derive("rw_w").randrange(1 << wl) for _ in range(nwords)]
+    rdata = [tb.rc.derive("rw_r").randrange(1 << wl) for _ in range(nwords)]
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    res = await tb.issue(ins.transfer(n - 1, write=True, read=True),
+                         sdo_data=wdata, sdi_data=rdata)
+    tb.slave.start()
+    await tb.stream_sdo(res.sdo_words)
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+
+    # (XFER-05 all-four-{r,w} is homed in test_clock_only_transfer; rw=11 here)
+    # REQ: EXEC-SDI-04 - each SDIO lane captured into its own DATA_WIDTH slice
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo")
+    tb.sb.compare_sequences(res.sdi_words, tb.sdi_values, field="sdi")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_clock_only_transfer(dut):
+    """rw=00: SCLK toggles with no stream traffic (RTL-CHARACTERIZED lock).
+
+    Neither reference driver emits a clock-only transfer (spec Appendix C), so
+    this is a regression lock, not a conformance check: it pins the current RTL
+    behaviour (SCLK runs, no SDO/SDI words move) ahead of any driver need.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    await tb.issue(ins.config_clk_div(1))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    tb.bus_mon.words.clear()
+    # No sdo_data streamed, no slave started: a dummy transfer.
+    await tb.issue(ins.transfer(2, write=False, read=False))
+    saw_sclk = await tb.measure_sclk_period()
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+    # REQ: EXEC-XFER-05 - clock-only/dummy (rw=00) toggles SCLK, no stream traffic
+    assert saw_sclk > 0, "SCLK did not toggle during a clock-only transfer"
+    assert len(tb.sdi_mon.received) == 0, "SDI words produced on a rw=00 transfer"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sdo_idle_outside_transfer(dut):
+    """Outside a write transfer every sdo lane presents sdo_idle_state."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+    await ClockCycles(dut.clk, 5)
+    idle = tb.params.get("SDO_DEFAULT", 0)
+    # REQ: EXEC-SDO-03 - sdo presents sdo_idle_state when no write is active
+    tb.sb.compare(0, "sdo_idle",
+                  idle * ((1 << tb.num_sdio) - 1), int(dut.sdo.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_single_and_multi_word(dut):
+    """n=0 (single), n>0 (multi) and a long (max) transfer all terminate to idle.
+
+    The long case caps its word count on wide DATA_WIDTH builds to keep runtime
+    reasonable under Verilator; 256 words at wl=8 is fast.
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    rng = tb.rc.derive("nwords")
+    long_n = 256 if wl <= 8 else 64
+
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    for nper in (1, 5, long_n):
+        data = [rng.randrange(1 << wl) for _ in range(nper * tb.num_sdio)]
+        tb.bus_mon.words.clear()
+        res = await tb.run_transfer(n=nper, write=True, read=False,
+                                    sdo_words=data)
+        # REQ: EXEC-CC-02 - single, multi and max-length transfers all terminate
+        tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words,
+                                field=f"n{nper}")
+        assert int(dut.cmd_ready.value) == 1, "engine not idle after transfer"
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_short_word_msb_aligned(dut):
+    """word_length < DATA_WIDTH: short words are MSB-aligned on the wire."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl_full = tb.params["DATA_WIDTH"]
+    new_wl = max(1, wl_full // 2)
+    await tb.issue(ins.config_word_length(new_wl))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    data = [tb.rc.derive("shortwl").randrange(1 << new_wl)
+            for _ in range(2 * tb.num_sdio)]
+    res = await tb.run_transfer(n=2, write=True, read=False, sdo_words=data)
+    # REQ: EXEC-SDO-02 - short word MSB-aligned (bit word_length-1 first)
+    # REQ: EXEC-CC-03 - min/short word length works, MSB-aligned
+    # REQ: EXEC-PARAM-03 - DATA_WIDTH sizes the word granularity
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="short")
+    tb.sb.assert_no_errors()
+
+
+# Startup latency between the CMD handshake and SCLK starting, on top of the
+# closed-form transfer time: offset = 3 + n_lanes (measured across lane counts,
+# constant over div). The n_lanes term is a transaction quantity — the SDO
+# assembler gathers one word per active lane before the first shift — so it lives
+# in the expected value; the fixed command/registration latency rides the ±tol.
+TRANSFER_STARTUP_FIXED = 3       # command handshake + output registration
+TRANSFER_DURATION_TOL = 2        # residual pipeline jitter (±)
+
+
+@cocotb.test()
+async def test_transfer_duration_timing(dut):
+    """Transfer execution time matches the closed-form formula + lane startup."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    # Active SDO lanes drive the assembler fill startup (see module note).
+    n_lanes = bin(tb.model.sdo_lane_mask & ((1 << tb.num_sdio) - 1)).count("1")
+
+    for div in (0, 1, 3):
+        await tb.issue(ins.config_clk_div(div))
+        await tb.wait_idle()
+        await tb.issue(ins.chipselect(0, delay=1))
+        await tb.wait_idle()
+
+        nper = 3
+        data = [tb.rc.derive(f"dur{div}").randrange(1 << wl)
+                for _ in range(nper * tb.num_sdio)]
+        res = await tb.issue(ins.transfer(nper - 1, write=True, read=False),
+                             sdo_data=data)
+        tb.start_sdo_stream(res.sdo_words)
+        start = tb.now_cycles()
+        await tb.wait_idle()
+        elapsed = tb.now_cycles() - start
+        # Closed-form transfer time plus the lane-scaled fill startup.
+        predicted = (tb.model.transfer_duration(nper)
+                     + TRANSFER_STARTUP_FIXED + n_lanes)
+        tb.log.info(f"div={div} lanes={n_lanes} transfer dur predicted~"
+                    f"{predicted} elapsed={elapsed}")
+        # REQ: EXEC-XFER-08 - transfer time = 2 + (n+1)*word_length*(div+1)*2
+        tb.sb.compare_within(div, "transfer_duration", predicted, elapsed,
+                             TRANSFER_DURATION_TOL, note=f"div={div}")
+        await ClockCycles(dut.clk, 3)
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_min_word_length(dut):
+    """word_length=1: single-bit words shift out correctly.
+
+    A non-zero clk_div keeps the SDO stream able to keep pace (at wl=1/div=0 the
+    period is just 2 core clocks, a stimulus-rate limit not a DUT behaviour).
+    """
+    tb = ExecutionTB(dut)
+    await tb.start()
+    await tb.issue(ins.config_clk_div(2))
+    await tb.wait_idle()
+    await tb.issue(ins.config_word_length(1))
+    await tb.wait_idle()
+    n = 4
+    data = [tb.rc.derive("minwl").randint(0, 1) for _ in range(n * tb.num_sdio)]
+    res = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data)
+    # REQ: EXEC-CC-03 - minimum word_length (wl=1 extreme) shifts out correctly
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="minwl")
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_transfer_stalls_on_backpressure(dut):
+    """A transfer does not advance past a word boundary until flow-ready."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+    n = 5
+    data = [tb.rc.derive("xfer_bp").randrange(1 << wl)
+            for _ in range(n * tb.num_sdio)]
+    # Random gaps in the SDO producer: engine must stall losslessly.
+    res = await tb.run_transfer(n=n, write=True, read=False, sdo_words=data,
+                                sdo_gap=(1, 3))
+    # REQ: EXEC-XFER-07 - transfer stalls until flow-control readiness, no loss
+    tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words, field="sdo")
+    tb.sb.assert_no_errors()

--- a/testbenches/ip/spi_engine/execution/test_waveform.py
+++ b/testbenches/ip/spi_engine/execution/test_waveform.py
@@ -1,0 +1,118 @@
+"""SPI waveform: SCLK period, CPOL idle, CPHA/CPOL edge relationship,
+and runtime-change-takes-effect-next-transfer.
+
+The passive SPI bus monitor reconstructs SDO words by sampling on the CPOL/CPHA-
+implied edge; a correct round-trip across all four modes therefore confirms the
+standard sampling/update-edge relationship (EXEC-SCLK-03) end-to-end. SCLK period
+is measured directly on the boundary sclk output across several prescaler values.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, ClockCycles
+
+from framework.spi import instructions as ins
+from tb_env import ExecutionTB
+
+
+@cocotb.test()
+async def test_sclk_period_across_div(dut):
+    """SCLK period = (div+1)*2 core clocks for several prescaler values."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+
+    for div in (0, 1, 3):
+        await tb.issue(ins.config_clk_div(div))
+        await tb.wait_idle()
+        await tb.issue(ins.chipselect(0, delay=1))
+        await tb.wait_idle()
+        data = [(0x5A + i) & ((1 << wl) - 1) for i in range(tb.num_sdio)]
+        res = await tb.issue(ins.transfer(0, write=True, read=False),
+                             sdo_data=data)
+        tb.start_sdo_stream(res.sdo_words)
+        period = await tb.measure_sclk_period()
+        await tb.wait_idle()
+        # REQ: EXEC-SCLK-01 - SCLK period is (div+1)*2 core clocks
+        # REQ: EXEC-PARAM-05 - DEFAULT_CLK_DIV sets the initial SCLK period
+        tb.sb.compare_within(div, "sclk_period", (div + 1) * 2, period, 1,
+                             note=f"div={div}")
+        await ClockCycles(dut.clk, 3)
+        allcs = (1 << tb.params["NUM_OF_CS"]) - 1
+        await tb.issue(ins.chipselect(allcs, delay=1))
+        await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_sclk_idle_level(dut):
+    """When not transferring, sclk idles at the CPOL level."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    for cpol in (0, 1):
+        await tb.issue(ins.config_spi_mode(cpol=cpol))
+        await tb.wait_idle()
+        await ClockCycles(dut.clk, 4)
+        # REQ: EXEC-SCLK-02 - sclk idles at CPOL when not transferring
+        tb.sb.compare(cpol, "sclk_idle", cpol, int(dut.sclk.value))
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_all_cpol_cpha_modes(dut):
+    """All four CPOL/CPHA modes: idle level and data round-trip correctly."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+
+    for cpol in (0, 1):
+        for cpha in (0, 1):
+            await tb.issue(ins.config_spi_mode(cpol=cpol, cpha=cpha))
+            await tb.wait_idle()
+            await ClockCycles(dut.clk, 3)
+            tb.sb.compare((cpol << 1) | cpha, "mode_idle_sclk", cpol,
+                          int(dut.sclk.value), note=f"cpol={cpol} cpha={cpha}")
+
+            await tb.issue(ins.chipselect(0, delay=1))
+            await tb.wait_idle()
+            data = [tb.rc.derive(f"mode_{cpol}{cpha}").randrange(1 << wl)
+                    for _ in range(tb.num_sdio)]
+            res = await tb.issue(ins.transfer(0, write=True, read=False),
+                                 sdo_data=data)
+            await tb.stream_sdo(res.sdo_words)
+            await tb.wait_idle()
+            await ClockCycles(dut.clk, 3)
+            # REQ: EXEC-SCLK-03 - CPOL/CPHA produce the standard edge relationship
+            # REQ: EXEC-SCLK-05 - sclk/sdo/sdo_t retain fixed mutual alignment
+            tb.sb.compare_sequences(res.sdo_words, tb.bus_mon.sdo_words,
+                                    field=f"mode{cpol}{cpha}")
+            tb.bus_mon.words.clear()
+            await tb.issue(ins.chipselect((1 << tb.params["NUM_OF_CS"]) - 1,
+                                          delay=1))
+            await tb.wait_idle()
+    tb.sb.assert_no_errors()
+
+
+@cocotb.test()
+async def test_config_change_takes_effect_next_transfer(dut):
+    """A prescaler change applies to the next transfer, not the current one."""
+    tb = ExecutionTB(dut)
+    await tb.start()
+    wl = tb.params["DATA_WIDTH"]
+
+    # Baseline transfer at div=0, then reconfigure to div=3 for the next one and
+    # confirm the new period is what the following transfer uses.
+    await tb.issue(ins.config_clk_div(0))
+    await tb.wait_idle()
+    await tb.issue(ins.chipselect(0, delay=1))
+    await tb.wait_idle()
+
+    await tb.issue(ins.config_clk_div(3))
+    await tb.wait_idle()
+    data = [(0x33 + i) & ((1 << wl) - 1) for i in range(tb.num_sdio)]
+    res = await tb.issue(ins.transfer(0, write=True, read=False), sdo_data=data)
+    tb.start_sdo_stream(res.sdo_words)
+    period = await tb.measure_sclk_period()
+    await tb.wait_idle()
+    # REQ: EXEC-SCLK-04 - runtime prescaler change takes effect on next transfer
+    tb.sb.compare_within(0, "sclk_next_xfer", (3 + 1) * 2, period, 1)
+    tb.sb.assert_no_errors()


### PR DESCRIPTION
## SPI Engine execution - IP-level testbench POC (cocotb + Verilator)

**Not for merge (yet)**. This PR shares an experimental IP/unit-testbench POC for early review, opinions, and suggestions.

**Start here:** testbenches/ip/spi_engine/execution/README.md - fast, hands-on instructions to build and run the TB.

### What this is

Driven by the need for IP-level testbenches, this POC verifies the SPI Engine execution module with a cocotb testbench that drives the command stream and checks every SPI-bus / SDI transaction against an independent Python golden model.

### Why cocotb + Verilator

- Golden model in Python - a high-level, RTL-independent reference (similar to VUnit), easing reporting, test-case handling, constrained-random + reproducible tests, CSV stimulus/golden comparison, protocol checkers, parallelism, etc.
- One TB, many simulators - the same test runs on Verilator, Icarus, xsim (maybe!! To be tested), ... each client/person can bring their own.
- Verilator line coverage - surfaces test gaps (Verilator is slower to compile but enables coverage reports).
- LLM-friendly - Python has far more training data than UVM/SV, and the methodology below plays to that.

### Requirements-driven, LLM-friendly methodology

- Maps the exact expected IP behaviour - loosely-documented in the HDL repo.
- Traceability: Requirement ↔ RTL ↔ Test case, so we can prove every requirement is tested.
- Greppable, atomic requirements let LLMs (and humans) navigate the repo quickly.
- Guidelines + framework included so this can be extended to other SPI Engine modules (only execution is covered today) and other IPs (e.g. AXI DMAC).

### Status & early results

- Incomplete by design - not all behaviours are mapped yet (e.g. SCLK ECHO) and some generic axes
aren't swept.
- Already flagged three potential RTL bugs - see bug_log.md.

Feedback and suggestions are more than welcome.