### PR TITLE
Extend XCVR automation to support JESD204C

### DIFF
--- a/scripts/adi_sim.tcl
+++ b/scripts/adi_sim.tcl
@@ -235,13 +235,21 @@ proc adi_xcvr_sim_init {} {
   set pll_type  $ad_project_params(PLL_TYPE)
   set board_name $ad_project_params(FPGA_BOARD)
 
-  set xcvr_config_paths [adi_xcvr_project [list \
+  set xcvr_params [list \
     LANE_RATE $lane_rate \
     REF_CLK   $ref_clk \
     PLL_TYPE  $pll_type \
-  ] $board_name]
+  ]
 
-  puts "INFO: XCVR config - LANE_RATE: $lane_rate, REF_CLK: $ref_clk, PLL_TYPE: $pll_type"
+  foreach opt_param {JESD_MODE XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
+    if {[info exists ad_project_params($opt_param)] && $ad_project_params($opt_param) ne ""} {
+      lappend xcvr_params $opt_param $ad_project_params($opt_param)
+    }
+  }
+
+  set xcvr_config_paths [adi_xcvr_project $xcvr_params $board_name]
+
+  puts "INFO: XCVR config - LANE_RATE: $lane_rate, REF_CLK: $ref_clk, PLL_TYPE: $pll_type, BOARD: $board_name"
   puts "xcvr_config_paths: $xcvr_config_paths"
   return $xcvr_config_paths
 }

--- a/scripts/adi_sim.tcl
+++ b/scripts/adi_sim.tcl
@@ -242,15 +242,14 @@ proc adi_xcvr_sim_init {} {
   ]
 
   foreach opt_param {JESD_MODE XCVR_RX_PLL_TYPE XCVR_RX_LANE_RATE XCVR_RX_REF_CLK} {
-    if {[info exists ad_project_params($opt_param)] && $ad_project_params($opt_param) ne ""} {
+    if {[info exists ad_project_params($opt_param)]} {
       lappend xcvr_params $opt_param $ad_project_params($opt_param)
     }
   }
 
   set xcvr_config_paths [adi_xcvr_project $xcvr_params $board_name]
-
-  puts "INFO: XCVR config - LANE_RATE: $lane_rate, REF_CLK: $ref_clk, PLL_TYPE: $pll_type, BOARD: $board_name"
   puts "xcvr_config_paths: $xcvr_config_paths"
+
   return $xcvr_config_paths
 }
 

--- a/testbenches/project/mxfe/cfgs/cfg1.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg1.tcl
@@ -2,7 +2,9 @@ global ad_project_params
 
 set ad_project_params(JESD_MODE) 8B10B
 
+set ad_project_params(LANE_RATE) 10
 set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(PLL_TYPE) QPLL0
 
 set ad_project_params(RX_LANE_RATE) 10
 set ad_project_params(TX_LANE_RATE) 10

--- a/testbenches/project/mxfe/cfgs/cfg2_64b66b_np8.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg2_64b66b_np8.tcl
@@ -1,11 +1,15 @@
 global ad_project_params
 
 set ad_project_params(JESD_MODE) 64B66B
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set ad_project_params(RX_LANE_RATE) 16.5
 set ad_project_params(RX_PLL_SEL) 2
 set ad_project_params(TX_LANE_RATE) 16.5
 set ad_project_params(TX_PLL_SEL) 2
-set ad_project_params(REF_CLK_RATE) 500
 
 set ad_project_params(RX_NUM_LINKS) 1
 set ad_project_params(RX_JESD_M) 2
@@ -24,9 +28,6 @@ set ad_project_params(TX_JESD_F) 1
 set ad_project_params(TX_JESD_K) 256
 
 set ad_project_params(TDD_SUPPORT) 0
-
-set ad_project_params(LANE_RATE) 16.5
-set ad_project_params(PLL_TYPE) QPLL1
 
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]

--- a/testbenches/project/mxfe/cfgs/cfg2_64b66b_np8.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg2_64b66b_np8.tcl
@@ -25,6 +25,9 @@ set ad_project_params(TX_JESD_K) 256
 
 set ad_project_params(TDD_SUPPORT) 0
 
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]
 set ad_project_params(FPGA_BOARD) $chosen_board

--- a/testbenches/project/mxfe/cfgs/cfg3_64b66b_np12.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg3_64b66b_np12.tcl
@@ -1,11 +1,15 @@
 global ad_project_params
 
 set ad_project_params(JESD_MODE) 64B66B
+
+set ad_project_params(REF_CLK_RATE) 250
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set ad_project_params(RX_LANE_RATE) 16.5
 set ad_project_params(RX_PLL_SEL) 2
 set ad_project_params(TX_LANE_RATE) 16.5
 set ad_project_params(TX_PLL_SEL) 2
-set ad_project_params(REF_CLK_RATE) 250
 
 set ad_project_params(RX_NUM_LINKS) 1
 set ad_project_params(RX_JESD_M) 4
@@ -24,9 +28,6 @@ set ad_project_params(TX_JESD_F) 3
 set ad_project_params(TX_JESD_K) 256
 
 set ad_project_params(TDD_SUPPORT) 0
-
-set ad_project_params(LANE_RATE) 16.5
-set ad_project_params(PLL_TYPE) QPLL1
 
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]

--- a/testbenches/project/mxfe/cfgs/cfg3_64b66b_np12.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg3_64b66b_np12.tcl
@@ -25,6 +25,9 @@ set ad_project_params(TX_JESD_K) 256
 
 set ad_project_params(TDD_SUPPORT) 0
 
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]
 set ad_project_params(FPGA_BOARD) $chosen_board

--- a/testbenches/project/mxfe/cfgs/cfg4_8b10b_np12.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg4_8b10b_np12.tcl
@@ -1,11 +1,15 @@
 global ad_project_params
 
 set ad_project_params(JESD_MODE) 8B10B
+
+set ad_project_params(REF_CLK_RATE) 500 ;# [R/T]X_RATE/20
+set ad_project_params(LANE_RATE) 10
+set ad_project_params(PLL_TYPE) QPLL0
+
 set ad_project_params(RX_LANE_RATE) 10
 set ad_project_params(RX_PLL_SEL) 2
 set ad_project_params(TX_LANE_RATE) 10
 set ad_project_params(TX_PLL_SEL) 2
-set ad_project_params(REF_CLK_RATE) 500 ;# [R/T]X_RATE/20
 
 set ad_project_params(RX_NUM_LINKS) 1
 set ad_project_params(RX_JESD_M) 8
@@ -24,9 +28,6 @@ set ad_project_params(TX_JESD_F) 6
 set ad_project_params(TX_JESD_K) 32
 
 set ad_project_params(TDD_SUPPORT) 0
-
-set ad_project_params(LANE_RATE) 10
-set ad_project_params(PLL_TYPE) QPLL0
 
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]

--- a/testbenches/project/mxfe/cfgs/cfg4_8b10b_np12.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg4_8b10b_np12.tcl
@@ -25,6 +25,9 @@ set ad_project_params(TX_JESD_K) 32
 
 set ad_project_params(TDD_SUPPORT) 0
 
+set ad_project_params(LANE_RATE) 10
+set ad_project_params(PLL_TYPE) QPLL0
+
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]
 set ad_project_params(FPGA_BOARD) $chosen_board

--- a/testbenches/project/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
@@ -25,6 +25,9 @@ set ad_project_params(TX_JESD_K) 128
 
 set ad_project_params(TDD_SUPPORT) 0
 
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]
 set ad_project_params(FPGA_BOARD) $chosen_board

--- a/testbenches/project/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg5_204c_txmode_10_rxmode_11.tcl
@@ -1,11 +1,15 @@
 global ad_project_params
 
 set ad_project_params(JESD_MODE) 64B66B
+
+set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 16.5
+set ad_project_params(PLL_TYPE) QPLL1
+
 set ad_project_params(RX_LANE_RATE) 16.5
 set ad_project_params(RX_PLL_SEL) 2
 set ad_project_params(TX_LANE_RATE) 16.5
 set ad_project_params(TX_PLL_SEL) 2
-set ad_project_params(REF_CLK_RATE) 500
 
 set ad_project_params(RX_NUM_LINKS) 1
 set ad_project_params(RX_JESD_M) 4
@@ -24,9 +28,6 @@ set ad_project_params(TX_JESD_F) 2
 set ad_project_params(TX_JESD_K) 128
 
 set ad_project_params(TDD_SUPPORT) 0
-
-set ad_project_params(LANE_RATE) 16.5
-set ad_project_params(PLL_TYPE) QPLL1
 
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]

--- a/testbenches/project/mxfe/cfgs/cfg6_m16_l8_tdd.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg6_m16_l8_tdd.tcl
@@ -3,6 +3,8 @@ global ad_project_params
 set ad_project_params(JESD_MODE) 8B10B
 
 set ad_project_params(REF_CLK_RATE) 500
+set ad_project_params(LANE_RATE) 10
+set ad_project_params(PLL_TYPE) QPLL0
 
 set ad_project_params(RX_LANE_RATE) 10
 set ad_project_params(TX_LANE_RATE) 10
@@ -31,9 +33,6 @@ set ad_project_params(TDD_SYNC_WIDTH) 32
 set ad_project_params(TDD_SYNC_INT) 1
 set ad_project_params(TDD_SYNC_EXT) 0
 set ad_project_params(TDD_SYNC_EXT_CDC) 0
-
-set ad_project_params(LANE_RATE) 10
-set ad_project_params(PLL_TYPE) QPLL0
 
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]

--- a/testbenches/project/mxfe/cfgs/cfg6_m16_l8_tdd.tcl
+++ b/testbenches/project/mxfe/cfgs/cfg6_m16_l8_tdd.tcl
@@ -32,6 +32,9 @@ set ad_project_params(TDD_SYNC_INT) 1
 set ad_project_params(TDD_SYNC_EXT) 0
 set ad_project_params(TDD_SYNC_EXT_CDC) 0
 
+set ad_project_params(LANE_RATE) 10
+set ad_project_params(PLL_TYPE) QPLL0
+
 set xilinx_boards {"vcu118"}
 set chosen_board [lindex $xilinx_boards [expr {int(rand() * [llength $xilinx_boards])}]]
 set ad_project_params(FPGA_BOARD) $chosen_board

--- a/testbenches/project/mxfe/system_project.tcl
+++ b/testbenches/project/mxfe/system_project.tcl
@@ -13,6 +13,8 @@ source "cfgs/${cfg_file}"
 # Set the project name
 set project_name [file rootname $cfg_file]
 
+set xcvr_config_required 1
+
 # Create the project
 adi_sim_project_xilinx $project_name
 


### PR DESCRIPTION
## PR Description

This PR extends XCVR automation support for JESD204C by adding support for optional jesd_mode and RX-specific XCVR parameters (lane_rate, ref_clk, and pll_type) for asymmetric TX/RX configurations.
It also integrates the automation flow into the MXFE (AD9081) testbench.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [x] Update (change that modifies existing functionality)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
