### PR TITLE
library/regmaps/adi_regmap_pkg: Added missing variable type

### DIFF
--- a/library/regmaps/adi_regmap_pkg.sv
+++ b/library/regmaps/adi_regmap_pkg.sv
@@ -61,7 +61,7 @@ package adi_regmap_pkg;
   function bit [31:0] SetField(reg_t register,
                                string field,
                                bit [31:0] value);
-    bit [31:0] ret = 'h0;
+    automatic bit [31:0] ret = 'h0;
     int lsb, msb;
 
     if (!register.fields.exists(field))
@@ -83,7 +83,7 @@ package adi_regmap_pkg;
   function bit [31:0] GetField(reg_t register,
                                string field,
                                bit [31:0] regvalue);
-    bit [31:0] ret = 'h0;
+    automatic bit [31:0] ret = 'h0;
     int lsb, msb;
 
     if (!register.fields.exists(field))
@@ -106,7 +106,7 @@ package adi_regmap_pkg;
                                   string field,
                                   bit [31:0] regvalue,
                                   bit [31:0] curregvalue);
-    bit [31:0] ret = curregvalue;
+    automatic bit [31:0] ret = curregvalue;
 
     if (!register.fields.exists(field))
       `FATAL(("Field %s in reg %s does not exists", field, register.name));


### PR DESCRIPTION
## PR Description

Vivado:
WARNING: [VRFC 10-3824] variable 'ret' must explicitly be declared as automatic or static
This PR adds missing automatic declaration to the variables.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] New test (change that adds new test program and/or testbench)
- [ ] Update (change that modifies existing functionality)
- [ ] Breaking change (has dependencies in other repositories/testbenches)
- [ ] Documentation (change that adds or modifies documentation)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [ ] I have ran all testbenches affected by this PR
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [x] I have not introduced new Warnings/Errors on compilation/elaboration/simulation
- [ ] I have set the verbosity level to none for the test program
